### PR TITLE
Exported symbol prim breaks things

### DIFF
--- a/lib/asn1/template.c
+++ b/lib/asn1/template.c
@@ -46,7 +46,7 @@
 #define DPO(data,offset) ((void *)(((unsigned char *)data)  + offset))
 
 
-struct asn1_type_func prim[] = {
+static struct asn1_type_func prim[] = {
 #define el(name, type) {				\
 	(asn1_type_encode)der_put_##name,		\
 	(asn1_type_decode)der_get_##name,		\


### PR DESCRIPTION
libasn1 from heimdal exports a symbol named `prim`, which can easily conflict with other symbols of that name in completely unrelated pieces of code. Encountered this in [Gentoo bug 357235](https://bugs.gentoo.org/357235) where it broke pdftex.

This patch makes `prim` static, which prevents it getting exported. Unless there is a reason `prim` should be part of the public interface, that's the easiest fix I can imagine. In the long run, however, it might be advisable to turn the [version-script.map](https://github.com/heimdal/heimdal/blob/master/lib/asn1/version-script.map) from "export everything" to an explicit whitelist of exported symbols. As that's the only sane way you could attach version numbers to those symbols, I guess it would make sense in any case, even if you would still want to export every symbol. The current list is easy to obtain: 
    objdump -T /usr/lib/libasn1.so \
    | grep -E '.(text|data)._HEIMDAL_ASN1_1.0 ' | sed 's:._ ::'
