### PR TITLE
Update URL for Kerberos FAQ

### DIFF
--- a/lib/krb5/kerberos.8
+++ b/lib/krb5/kerberos.8
@@ -73,7 +73,7 @@ without giving your password.
 .Pp
 For more information on how Kerberos works, and other general Kerberos
 questions see the Kerberos FAQ at
-.Pa http://www.nrl.navy.mil/CCS/people/kenh/kerberos-faq.html .
+.Pa http://www.cmf.nrl.navy.mil/krb/kerberos-faq.html .
 .Pp
 For setup instructions see the Heimdal Texinfo manual.
 .Sh SEE ALSO


### PR DESCRIPTION
The old URL ends up at http://www.cmf.nrl.navy.mil/ccs/ which is not very helpful.
