### PR TITLE
Always provide a usable PATH_MAX

### DIFF
--- a/lib/roken/roken-common.h
+++ b/lib/roken/roken-common.h
@@ -151,7 +151,11 @@
 #endif	/* !_WIN32 */
 
 #ifndef PATH_MAX
+#ifdef MAX_PATH
 #define PATH_MAX MAX_PATH
+#else
+#define PATH_MAX 4096
+#endif
 #endif
 
 #ifndef RETSIGTYPE


### PR DESCRIPTION
If a program does not include limits.h (or includes it after roken.h),
it can end up with PATH_MAX defined to be MAX_PATH, but MAX_PATH
undefined.  This causes consumers of PATH_MAX to become unhappy.

Work around this case by only using MAX_PATH if it is available, and
a constant otherwise.
