### PR TITLE
hcrypto/rand-unix.c: Ignore write(2) result harder

### DIFF
--- a/lib/hcrypto/rand-unix.c
+++ b/lib/hcrypto/rand-unix.c
@@ -82,7 +82,8 @@ unix_seed(const void *indata, int size)
     if (fd < 0)
 	return;
 
-    write(fd, indata, size);
+    if (write(fd, indata, size) != size)
+	; /* don't care */
     close(fd);
 
 }


### PR DESCRIPTION
unix_seed(), called by the add-seed-data op unix_add(), attempts to
write seed data to the random data device.  If this fails, the failure
is ignored, as it must be, since there is no way to inform the caller.

This change modifies the way in which the return value from write(2)
is ignored, to avoid compiler warnings when building on Ubuntu 12.10,
with gcc 4.7.2 and eglibc 2.15-0ubuntu20.1.
