### PR TITLE
Be friendly to krb5_generate_random_block consumers

### DIFF
--- a/include/NTMakefile
+++ b/include/NTMakefile
@@ -80,6 +80,7 @@ while(<>) {
     if ("$(DIR_hdbdir)") { print "#define HDB_DB_DIR \"".'$(DIR_hdbdir)'."\"\n"; }
     if ("$(HAVE_MSLSA_CACHE)") { print "#define HAVE_MSLSA_CACHE 1\n"; }
     if ("$(NO_LOCALNAME)") { print "#define NO_LOCALNAME 1\n"; }
+    if ("$(NO_RAND_EGD_METHOD)") { print "#define NO_RAND_EGD_METHOD 1\n"; }
 
   } elsif (m/\@VERSION_OPTDEFS\@/) {
 

--- a/lib/krb5/crypto-rand.c
+++ b/lib/krb5/crypto-rand.c
@@ -40,6 +40,7 @@ static HEIMDAL_MUTEX crypto_mutex = HEIMDAL_MUTEX_INITIALIZER;
 static int
 seed_something(void)
 {
+#ifndef NO_RANDFILE
     char buf[1024], seedfile[256];
 
     /* If there is a seed file, load it. But such a file cannot be trusted,
@@ -58,11 +59,12 @@ seed_something(void)
 	    seedfile[0] = '\0';
     } else
 	seedfile[0] = '\0';
+#endif
 
     /* Calling RAND_status() will try to use /dev/urandom if it exists so
        we do not have to deal with it. */
     if (RAND_status() != 1) {
-#ifndef _WIN32
+#ifndef NO_RAND_EGD_METHOD
 	krb5_context context;
 	const char *p;
 
@@ -81,9 +83,11 @@ seed_something(void)
     }
 
     if (RAND_status() == 1)	{
+#ifndef NO_RANDFILE
 	/* Update the seed file */
 	if (seedfile[0])
 	    RAND_write_file(seedfile);
+#endif
 
 	return 0;
     } else

--- a/windows/NTMakefile.config
+++ b/windows/NTMakefile.config
@@ -87,6 +87,9 @@ WEAK_CRYPTO=1
 # Disable use of GSS LOCALNAME support
 NO_LOCALNAME=1
 
+# No entropy-gathering daemon on Windows
+NO_RAND_EGD_METHOD=1
+
 # Disable build of installers
 !ifndef NO_INSTALLERS
 BUILD_INSTALLERS=1


### PR DESCRIPTION
Allow them to disable the EGD/profile access and the use of a
random seed file.

These facilities are not tenable when running in the kernel.
