### PR TITLE
texinfo 5.1 fixes

### DIFF
--- a/doc/hx509.texi
+++ b/doc/hx509.texi
@@ -39,14 +39,12 @@
 @def@copyrightstart{}
 @def@copyrightend{}
 @end iftex
-@ifinfo
 @macro copynext
 @end macro
 @macro copyrightstart
 @end macro
 @macro copyrightend
 @end macro
-@end ifinfo
 
 @page
 @copyrightstart

--- a/doc/whatis.texi
+++ b/doc/whatis.texi
@@ -43,9 +43,11 @@ services can authenticate each other.
 
 @ifhtml
 @macro sub{arg}
+
 @html
 <sub>\arg\</sub>
 @end html
+
 @end macro
 @end ifhtml
 


### PR DESCRIPTION
I'm working with Alexander Boström (@abokth) to package Heimdal for Fedora and EPEL. One problem we've run across is that the some texinfo files do not work properly with Fedora 19's texinfo 5.1. texinfo-4.13a in Fedora 18 works fine, but texinfo 5.1 fails.

We're using four texinfo patches that are not yet on heimdal-1-5-branch. Two are already upstream on master (1846c7a35d1091d3b6140c56befd7fee0a91dcbb and 0e0351776a48a69ec704085e554a0653d8179452). This pull request includes the remaining two patches that are not yet upstream.

The first patch in this pull request is one that Debian is using in their Heimdal package. (The original patch author, Daniel Schepler, included the same "@iftex" change that is already in master as mentioned above, so I removed that portion.) The Debian patch also includes additional copyright macros for the non "tex" conditional case, and it also adds missing entries into the table of contents.

The second patch is some of my own hacks to fix up the remaining issues on texinfo 5.1. For hx509.texi, we need the copyright macros for both html and info. The patch removes the `ifhtml` conditionals that previously came from the above Debian patch. For whatis.texi, texinfo 5.1 inserts the `sub{}` macro inline with no newlines, so there are errors about `@html` not being at the end of a line, etc. The patch adds additional newlines to satisfy makeinfo.

Once this pull request is merged, I'll cherry-pick the four patches onto heimdal-1-5-branch.
