### PR TITLE
Include heimbase.h in hx509.h; required for heim_err_t.

### DIFF
--- a/lib/hx509/hx509.h
+++ b/lib/hx509/hx509.h
@@ -39,6 +39,7 @@
 #include <rfc2459_asn1.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <heimbase.h>
 
 typedef struct hx509_cert_attribute_data *hx509_cert_attribute;
 typedef struct hx509_cert_data *hx509_cert;


### PR DESCRIPTION
This fixes Samba's configure against newer snapshots of Heimdal.
