### PR TITLE
Add heimdal-krb5.pc file, with krb5.pc depending on it.

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -8,6 +8,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 
 pkgconfig_DATA = \
 	heimdal-gssapi.pc \
+	heimdal-krb5.pc \
 	kafs.pc \
 	kadm-client.pc \
 	kadm-server.pc \

--- a/tools/heimdal-krb5.pc.in
+++ b/tools/heimdal-krb5.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+vendor=Heimdal
+
+Name: heimdal-krb5
+Description: Heimdal implementation of the kerberos network authentication.
+Version: @VERSION@
+Libs: -L${libdir} -lkrb5 @LIB_pkinit@ -lcom_err @LIB_hcrypto_appl@ -lasn1 -lwind -lheimbase -lroken @LIB_crypt@ @PTHREAD_LIBADD@ @LIB_dlopen@ @LIB_door_create@ @LIBS@
+Cflags: -I${includedir}

--- a/tools/krb5.pc.in
+++ b/tools/krb5.pc.in
@@ -7,5 +7,4 @@ vendor=Heimdal
 Name: krb5
 Description: Heimdal implementation of the kerberos network authentication.
 Version: @VERSION@
-Libs: -L${libdir} -lkrb5 @LIB_pkinit@ -lcom_err @LIB_hcrypto_appl@ -lasn1 -lwind -lheimbase -lroken @LIB_crypt@ @PTHREAD_LIBADD@ @LIB_dlopen@ @LIB_door_create@ @LIBS@
-Cflags: -I${includedir}
+Requires: heimdal-krb5


### PR DESCRIPTION
This makes it easier to install Heimdal and MIT kerberos on the same system by just providing the heimdal-krb5.pc file; the krb5.pc file is provided by both.

This is similar to what's done with heimdal-gssapi.pc/krb5-gssapi.pc.
