### PR TITLE
Fix roken-h-process.pl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ EXTRA_DIST = \
 	autogen.sh \
 	krb5.conf \
 	cf/make-proto.pl \
+	cf/roken-h-process.pl \
 	cf/install-catman.sh \
 	cf/ChangeLog \
 	cf/c-function.m4 \

--- a/cf/roken-h-process.pl
+++ b/cf/roken-h-process.pl
@@ -145,15 +145,15 @@ sub parse_if
     if (m/^\s*$/) {
 	print "end $_\n" if ($debug);
 	return 1;
+    } elsif (m/^\(([^&]+)\&\&(.*)\)\s*\|\|\s*\(([^&]+)\&\&(.*)\)$/) {
+	print "($1 and $2) or ($3 and $4)\n" if ($debug);
+	return ((parse_if($1) and parse_if($2)) or (parse_if($3) and parse_if($4)));
     } elsif (m/^([^&]+)\&\&(.*)$/) {
-	print "$1 and $2\n" if ($debug);
-	return parse_if($1) and parse_if($2);
-    } elsif (m/^\(([^&]+)\&\&(.*)$/) {
 	print "$1 and $2\n" if ($debug);
 	return parse_if($1) and parse_if($2);
     } elsif (m/^([^\|]+)\|\|(.*)$/) {
 	print "$1 or $2\n" if ($debug);
-	return parse_if($1) or parse_if($2);
+	return (parse_if($1) or parse_if($2));
     } elsif (m/^\s*(\!)?\s*defined\((\w+)\)/) {
 	($neg, $var) = ($1, $2);
 	print "def: ${neg}-defined(${var})\n" if ($debug);


### PR DESCRIPTION
I'm trying to cross-build Heimdal. I hit upon some problems that I know have been reported to you before but, for one reason or another, haven't been fully resolved.

First off, roken-h-process.pl is still missing from EXTRA_DIST so it wasn't in the tarball.

Second, I stumbled across the problem outlined [here](http://comments.gmane.org/gmane.comp.encryption.kerberos.heimdal.general/6196) back in 2011. Although you did add @jpadhye's fix for roken-h-process.pl, you added it in the wrong place so it was ineffective. As it turns out, the fix itself was wrong anyway. This is why he felt the need to modify roken.h.in even though you rightly pointed out that it was correct.

I don't know what possessed you to try and reimplement the C preprocessor in Perl but I won't dwell on it. ;) The HAVE_STRERROR_R line was just too complex for it to handle with the existing set of regular expressions. It was evaluating the left-most clause as false, followed by &&, subsequently ignoring the rest. I fixed this by adding a longer regular expression that looks for (A && B) || (C && D).

That wasn't all. I noticed that the existing "or" clause wasn't being handled properly because of precedence rules in Perl. This resulted in the wrong outcome for the mkstemp function. The following two lines are not equivalent. You want the latter, not the former.

``` perl
return parse_if($1) or parse_if($2);
return (parse_if($1) or parse_if($2));
```

I am still having trouble with compile_et but I will file another issue about that.
