### PR TITLE
fortuna: handle gettimeofday() failure

### DIFF
--- a/lib/hcrypto/rand-fortuna.c
+++ b/lib/hcrypto/rand-fortuna.c
@@ -177,6 +177,7 @@ init_state(FState * st)
     for (i = 0; i < NUM_POOLS; i++)
 	md_init(&st->pool[i]);
     st->pid = getpid();
+    /* Skip st->ciph until there is entropy for a key, in reseed(). */
 }
 
 /*
@@ -391,10 +392,10 @@ extract_data(FState * st, unsigned count, unsigned char *dst)
     unsigned	block_nr = 0;
     pid_t	pid = getpid();
 
-    /* Should we reseed? */
-    if (st->pool0_bytes >= POOL0_FILL || st->reseed_count == 0)
-	if (enough_time_passed(st))
-	    reseed(st);
+    /* Do the initial seeding, and check if we should reseed. */
+    if (st->reseed_count == 0 ||
+	(st->pool0_bytes > POOL0_FILL && enough_time_passed(st)))
+	reseed(st);
 
     /* Do some randomization on first call */
     if (!st->tricks_done)


### PR DESCRIPTION
gettimeofday() is allowed to fail; in particular it is likely to
do so in a standalone or kernel environment, where the routine may
be a stub that always fails.

In such cases, without this check, we will not reseed() in the
st->reseed_count == 0 case in extract_data() (i.e., the first time
we need to produce output).  This results in attempting to perform
an encryption operation with st->ciph uninitialized, in particular
with 'rounds' set to zero.  This causes the loop termination check
("--r == 0") in rijndaelEncrypt() to fail, which eventually leads
to an attempt to access unmapped memory as array indices grow too
large.

When we cannot usefully tell if enough time has passed, we must
be conservative and assume that enough time has passed, allowing
the reseed to continue.
