### PR TITLE
remove reference to pop3, telnet and rsh Makefiles

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -647,16 +647,9 @@ AC_CONFIG_FILES(Makefile 		\
 	appl/kx/Makefile		\
 	appl/login/Makefile		\
 	appl/otp/Makefile		\
-	appl/popper/Makefile		\
 	appl/push/Makefile		\
-	appl/rsh/Makefile		\
-	appl/rcp/Makefile		\
 	appl/su/Makefile		\
 	appl/xnlock/Makefile		\
-	appl/telnet/Makefile		\
-	appl/telnet/libtelnet/Makefile	\
-	appl/telnet/telnet/Makefile	\
-	appl/telnet/telnetd/Makefile	\
 	appl/test/Makefile		\
 	appl/kf/Makefile		\
 	appl/dceutils/Makefile		\


### PR DESCRIPTION
The pop3, telnet and rsh/rcp support was removed from the tree in e55b0d0ca5038a8101276a593ffbb6be4c27c8d0. Delete the corresponding Makefiles so autoconf doesn't try to look for them.

This is needed to run `./autogen.sh` on Fedora 20 (GNU Autoconf 2.69)
