### PR TITLE
Properly terminate ifdef conditional in krb5-types.h

### DIFF
--- a/include/krb5-types.cross
+++ b/include/krb5-types.cross
@@ -60,6 +60,7 @@ typedef ssize_t krb5_ssize_t;
 #if __has_extension(__warn_unused_result__) || KRB5TYPES_REQUIRE_GNUC(3,3,0)
 #define HEIMDAL_WARN_UNUSED_RESULT_ATTRIBUTE __attribute__((__warn_unused_result__))
 #endif
+#endif
 
 typedef int krb5_socket_t;
 


### PR DESCRIPTION
This pull request adds a missing "endif" for krb5-types.h
