### PR TITLE
roken: don't ignore HAVE_OPENPTY on linux

### DIFF
--- a/lib/roken/rkpty.c
+++ b/lib/roken/rkpty.c
@@ -99,7 +99,7 @@ open_pty(void)
     printf("implement open_pty\n");
     exit(77);
 #endif
-#if defined(HAVE_OPENPTY) || defined(__linux) || defined(__osf__) /* XXX */
+#if defined(HAVE_OPENPTY) || defined(__osf__) /* XXX */
     if(openpty(&master, &slave, line, 0, 0) == 0)
 	return;
 #endif /* HAVE_OPENPTY .... */


### PR DESCRIPTION
`openpty()` is not available on all Linux distributions. Trust autoconf's determination for `HAVE_OPENPTY` instead of unconditionally using `openpty()` on all Linux.
