### PR TITLE
ignore lib/base/base64.c in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,7 @@ asn1_*.[cx]
 /lib/asn1/der-private.h
 /lib/asn1/lex.c
 /lib/auth/Makefile.in
+/lib/base/base64.c
 /lib/com_err/compile_et
 /lib/com_err/lex.c
 /lib/com_err/parse.c


### PR DESCRIPTION
`lib/base/base64.c` is an auto-generated file. Add it to the list in `.gitignore`
