### PR TITLE
telnet: don't ignore HAVE_OPENPTY on linux

### DIFF
--- a/appl/telnet/telnetd/sys_term.c
+++ b/appl/telnet/telnetd/sys_term.c
@@ -365,7 +365,7 @@ static char *ptsname(int fd)
 
 int getpty(int *ptynum)
 {
-#if defined(HAVE_OPENPTY) || defined(__linux) || defined(__osf__) /* XXX */
+#if defined(HAVE_OPENPTY) || defined(__osf__) /* XXX */
     {
 	int master;
 	int slave;


### PR DESCRIPTION
`openpty()` is not available on all Linux distributions. Trust autoconf's determination for `HAVE_OPENPTY` instead of unconditionally using `openpty()` on all Linux.

This is similar to the change to roken in 9ae257d7d444667c9cb368bb95f744ae00240b59, but this is for telnet.

This is a 1.6-only change, since telnet has been removed from master in e55b0d0ca5038a8101276a593ffbb6be4c27c8d0.
