### PR TITLE
autoconf: test for Perl and Perl's JSON module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,24 @@ AM_CONDITIONAL(ENABLE_SHARED, test "$enable_shared" = "yes")
 rk_VERSIONSCRIPT
 
 dnl
+dnl Verify that Perl and Perl's JSON are available
+dnl
+
+AC_ARG_VAR([PERL], [Path to perl])
+AC_PATH_PROG([PERL], [perl])
+AS_IF([test x"$PERL" = x],
+  [AC_MSG_ERROR([cannot build Heimdal without perl])])
+
+AC_MSG_CHECKING([for Perl module JSON])
+$PERL -e "use JSON; exit"
+AS_IF([test $? -eq 0],
+  [PERL_JSON=yes; AC_MSG_RESULT(yes)],
+  [AC_MSG_RESULT(no)])
+AS_IF([test x"$PERL_JSON" = x],
+  [AC_MSG_ERROR([cannot build Heimdal without JSON Perl module])])
+
+
+dnl
 dnl Helper bits for cross compiling
 dnl
 


### PR DESCRIPTION
It can be very hard to diagnose when `make-protos.pl` fails, because the build will go all the way through until it complains about missing headers (`der-protos.h` for example).

Add some checks to configure to verify that Perl and Perl's JSON module are available.

(See also the heimdal-discuss mailing list thread about this from November 2013, "building heimdal from git tar ball, missing der-protos.h")
