### PR TITLE
Avoid breaking symbol names for all previously present functions.

### DIFF
--- a/lib/hx509/version-script.map
+++ b/lib/hx509/version-script.map
@@ -1,6 +1,6 @@
 # $Id$
 
-HEIMDAL_X509_1.3 {
+HEIMDAL_X509_1.2 {
 	global:
 		_hx509_cert_assign_key;
 		_hx509_cert_private_key;
@@ -46,7 +46,6 @@ HEIMDAL_X509_1.3 {
 		hx509_ca_tbs_set_notBefore;
 		hx509_ca_tbs_set_proxy;
 		hx509_ca_tbs_set_serialnumber;
-		hx509_ca_tbs_set_signature_algorithm;
 		hx509_ca_tbs_set_spki;
 		hx509_ca_tbs_set_subject;
 		hx509_ca_tbs_set_template;
@@ -248,5 +247,10 @@ HEIMDAL_X509_1.3 {
 		C_GetFunctionList;
 	local:
 		*;
+};
+
+HEIMDAL_X509_1.3 {
+	global:
+		hx509_ca_tbs_set_signature_algorithm;
 };
 


### PR DESCRIPTION
Commit 88a8724 changed the symbol name of all functions that were previously present in the library, because it updated the version number.

This should not be necessary, it should only add the new symbol for the new version and leave the previous symbols untouched.
