### PR TITLE
Update krb5-config to include sqlite3 lib

### DIFF
--- a/tools/krb5-config.in
+++ b/tools/krb5-config.in
@@ -200,7 +200,7 @@ if test "$do_libs" = "yes"; then
 	lib_flags="$lib_flags -lkrb5"
     fi
     deplibs="$deplibs @LIB_pkinit@ -lcom_err"
-    deplibs="$deplibs @LIB_hcrypto_appl@ -lasn1 -lwind -lheimbase -lroken"
+    deplibs="$deplibs @LIB_hcrypto_appl@ @LIB_sqlite3@ -lasn1 -lwind -lheimbase -lroken"
     deplibs="$deplibs @LIB_crypt@ @PTHREAD_LIBADD@ @LIB_dlopen@"
     deplibs="$deplibs @LIB_door_create@ @LIBS@"
     if test X"$do_lib_deps" = X"yes"; then


### PR DESCRIPTION
libkrb5 can use sqlite3 as provided internally, and if libheimsqlite
is built and libkrb5 needs it, krb5-config --libs should include it.
