### PR TITLE
build failure with Fedora regarding hdb_ldap_create and hdb_ldapi_create

### DIFF
--- a/lib/hdb/hdb-ldap.c
+++ b/lib/hdb/hdb-ldap.c
@@ -44,9 +44,6 @@
 static krb5_error_code LDAP__connect(krb5_context context, HDB *);
 static krb5_error_code LDAP_close(krb5_context context, HDB *);
 
-static krb5_error_code hdb_ldap_create(krb5_context context, HDB **, const char *);
-static krb5_error_code hdb_ldapi_create(krb5_context context, HDB **, const char *);
-
 static krb5_error_code
 LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
 		   int flags, hdb_entry_ex * ent);


### PR DESCRIPTION
I'm seeing a build failure for 1.6 in the packages for Fedora 20, as a result of the recent commit that went in as e03d7af8d7e9ca7fc9dddc71f110ad1fa85f62f6.

```
hdb-ldap.c:47:24: error: static declaration of 'hdb_ldap_create' follows non-static declaration
 static krb5_error_code hdb_ldap_create(krb5_context context, HDB **, const char *);
                        ^
In file included from ./hdb.h:294:0,
                 from hdb_locl.h:67,
                 from hdb-ldap.c:35:
./hdb-protos.h:367:1: note: previous declaration of 'hdb_ldap_create' was here
 hdb_ldap_create (
 ^
hdb-ldap.c:48:24: error: static declaration of 'hdb_ldapi_create' follows non-static declaration
 static krb5_error_code hdb_ldapi_create(krb5_context context, HDB **, const char *);
                        ^
In file included from ./hdb.h:294:0,
                 from hdb_locl.h:67,
                 from hdb-ldap.c:35:
./hdb-protos.h:373:1: note: previous declaration of 'hdb_ldapi_create' was here
 hdb_ldapi_create (
 ^
```

I'm using GCC 4.8.2-7.fc20.
