### PR TITLE
Proposal for dropping capabilities in kpasswdd

### DIFF
--- a/kdc/main.c
+++ b/kdc/main.c
@@ -38,10 +38,6 @@
 #include <util.h>
 #endif
 
-#ifdef HAVE_CAPNG
-#include <cap-ng.h>
-#endif
-
 sig_atomic_t exit_flag = 0;
 
 #ifdef SUPPORT_DETACH
@@ -53,58 +49,6 @@ sigterm(int sig)
 {
     exit_flag = sig;
 }
-
-/*
- * Allow dropping root bit, since heimdal reopens the database all the
- * time the database needs to be owned by the user you are switched
- * too. A better solution is to split the kdc in to more processes and
- * run the network facing part with very low privilege.
- */
-
-static void
-switch_environment(void)
-{
-#ifdef HAVE_GETEUID
-    if ((runas_string || chroot_string) && geteuid() != 0)
-	errx(1, "no running as root, can't switch user/chroot");
-
-    if (chroot_string) {
-	if (chroot(chroot_string))
-	    err(1, "chroot(%s) failed", chroot_string);
-	if (chdir("/"))
-	    err(1, "chdir(/) after chroot failed");
-    }
-
-    if (runas_string) {
-	struct passwd *pw;
-
-	pw = getpwnam(runas_string);
-	if (pw == NULL)
-	    errx(1, "unknown user %s", runas_string);
-
-	if (initgroups(pw->pw_name, pw->pw_gid) < 0)
-	    err(1, "initgroups failed");
-
-#ifndef HAVE_CAPNG
-	if (setgid(pw->pw_gid) < 0)
-	    err(1, "setgid(%s) failed", runas_string);
-
-	if (setuid(pw->pw_uid) < 0)
-	    err(1, "setuid(%s)", runas_string);
-#else
-	capng_clear (CAPNG_EFFECTIVE | CAPNG_PERMITTED);
-	if (capng_updatev (CAPNG_ADD, CAPNG_EFFECTIVE | CAPNG_PERMITTED,
-	                   CAP_NET_BIND_SERVICE, CAP_SETPCAP, -1) < 0)
-	    err(1, "capng_updateev");
-
-	if (capng_change_id(pw->pw_uid, pw->pw_gid,
-	                    CAPNG_CLEAR_BOUNDING) < 0)
-	    err(1, "capng_change_id(%s)", runas_string);
-#endif
-    }
-#endif
-}
-
 
 int
 main(int argc, char **argv)
@@ -166,7 +110,7 @@ main(int argc, char **argv)
 #endif
     pidfile(NULL);
 
-    switch_environment();
+    heim_switch_environment((const char *) runas_string, (const char *) chroot_string);
 
     loop(context, config);
     krb5_free_context(context);

--- a/kpasswd/kpasswdd.c
+++ b/kpasswd/kpasswdd.c
@@ -755,6 +755,9 @@ static int help_flag;
 static char *port_str;
 static char *config_file;
 
+static char *runas_string;
+static char *chroot_string;
+
 struct getargs args[] = {
 #ifdef HAVE_DLOPEN
     { "check-library", 0, arg_string, &check_library,
@@ -771,6 +774,12 @@ struct getargs args[] = {
     { "config-file", 'c', arg_string, &config_file, NULL, NULL },
     { "realm", 'r', arg_string, &realm_str, "default realm", "realm" },
     { "port",  'p', arg_string, &port_str, "port", NULL },
+    { "runas-user",	0,	arg_string, &runas_string,
+	"run as this user when connected to network", NULL
+    },
+    { "chroot",	0,	arg_string, &chroot_string,
+	"chroot directory to run in", NULL
+    },
     { "version", 0, arg_flag, &version_flag, NULL, NULL },
     { "help", 0, arg_flag, &help_flag, NULL, NULL }
 };
@@ -888,6 +897,8 @@ main (int argc, char **argv)
 #endif
 
     pidfile(NULL);
+
+    heim_switch_environment((const char *) runas_string, (const char *) chroot_string);
 
     return doit (keytab, port);
 }

--- a/lib/base/heimbase.h
+++ b/lib/base/heimbase.h
@@ -49,6 +49,11 @@
 #define true 1
 #endif
 #endif
+#ifdef HAVE_CAPNG
+#include <cap-ng.h>
+#endif
+
+
 
 #define HEIM_BASE_API_VERSION 20130210
 
@@ -379,6 +384,12 @@ heim_object_t heim_json_create_with_bytes(const void *, size_t, size_t,
 					  heim_error_t *);
 heim_string_t heim_json_copy_serialize(heim_object_t, heim_json_flags_t,
 				       heim_error_t *);
+
+/*
+ * Switch env
+ * Drop privileges
+ */
+void heim_switch_environment(const char *, const char *);
 
 
 /*

--- a/lib/base/version-script.map
+++ b/lib/base/version-script.map
@@ -88,6 +88,7 @@ HEIMDAL_BASE_1.0 {
 		heim_string_get_type_id;
 		heim_string_get_utf8;
 		heim_string_ref_create;
+                heim_switch_environment;
 	local:
 		*;
 };


### PR DESCRIPTION
KDC daemon already support dropping capabilities (using capng if available).

This patch only moves function `kdc/main/switch_environment()` to `lib/base/heimbase/heim_switch_environment()`.

This way, KDC and KPASSWDD daemons share the same routine to manage their privileges.
It also allows KPASSWDD to be run as a non-root user while using standard port (which is quite important for us).

I don't know if `heimbase` is the best place to put this _common_ code but I didn't have any better idea at the moment.
