### PR TITLE
Limit the libraries pulled in when dynamic linking.

### DIFF
--- a/tools/heimdal-gssapi.pc.in
+++ b/tools/heimdal-gssapi.pc.in
@@ -8,6 +8,7 @@ Name: @PACKAGE@
 Description: Heimdal is an implementation of Kerberos 5, freely available under a three clause BSD style license.
 Version: @VERSION@
 URL: http://www.pdc.kth.se/heimdal/
-Requires: heimdal-krb5
-Libs: -L${libdir} -lgssapi -lheimntlm @LIB_crypt@
+Requires.private: heimdal-krb5
+Libs: -L${libdir} -lgssapi
+Libs.private: -lheimntlm @LIB_crypt@
 Cflags: -I${includedir}

--- a/tools/heimdal-kadm-client.pc.in
+++ b/tools/heimdal-kadm-client.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: heimdal-kadm-client
 Description: Kadmin client library.
 Version: @VERSION@
-Requires: heimdal-gssapi
+Requires.private: heimdal-gssapi
 Libs: -L${libdir} -lkadm5clnt
 Cflags: -I${includedir}

--- a/tools/heimdal-kadm-server.pc.in
+++ b/tools/heimdal-kadm-server.pc.in
@@ -6,6 +6,7 @@ includedir=@includedir@
 Name: heimdal-kadm-server
 Description: Kadmin server library.
 Version: @VERSION@
-Requires: heimdal-gssapi
-Libs: -L${libdir} -lkadm5srv @LIB_dbopen@
+Requires.private: heimdal-gssapi
+Libs: -L${libdir} -lkadm5srv
+Libs.private: @LIB_dbopen@
 Cflags: -I${includedir}

--- a/tools/heimdal-krb5.pc.in
+++ b/tools/heimdal-krb5.pc.in
@@ -7,5 +7,6 @@ vendor=Heimdal
 Name: heimdal-krb5
 Description: Heimdal implementation of the Kerberos network authentication.
 Version: @VERSION@
-Libs: -L${libdir} -lkrb5 @LIB_pkinit@ -lcom_err @LIB_hcrypto_appl@ -lasn1 -lwind -lheimbase -lroken @LIB_crypt@ @PTHREAD_LIBADD@ @LIB_dlopen@ @LIB_door_create@ @LIBS@
+Libs: -L${libdir} -lkrb5
+Libs.private: @LIB_pkinit@ -lcom_err @LIB_hcrypto_appl@ -lasn1 -lwind -lheimbase -lroken @LIB_crypt@ @PTHREAD_LIBADD@ @LIB_dlopen@ @LIB_door_create@ @LIBS@
 Cflags: -I${includedir}

--- a/tools/kadm-client.pc.in
+++ b/tools/kadm-client.pc.in
@@ -7,4 +7,4 @@ vendor=Heimdal
 Name: kadm-client
 Description: Kadmin client library.
 Version: @VERSION@
-Depends: heimdal-kadm-client
+Requires: heimdal-kadm-client

--- a/tools/kadm-server.pc.in
+++ b/tools/kadm-server.pc.in
@@ -7,4 +7,4 @@ vendor=Heimdal
 Name: kadm-server
 Description: Kadmin server library.
 Version: @VERSION@
-Depends: heimdal-kadm-server
+Requires: heimdal-kadm-server

--- a/tools/kafs.pc.in
+++ b/tools/kafs.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: kafs
 Description: Libraries for application that uses kafs.
 Version: @VERSION@
-Requires: heimdal-krb5
+Requires.private: heimdal-krb5
 Libs: -lkafs


### PR DESCRIPTION
See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=745543 for a longer explanation. To quote Russ:

The convention for pkgconfig files is to list the libraries required for dynamic linking to get the public ABI in Libs and the other libraries requied for static linking in Libs.private.  This prevents over-linking binaries on systems with good shared library dependency resolution, such as Linux.
