### PR TITLE
Add travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+script: ./autogen.sh && ./configure && make && make check
+compiler:
+  - clang
+  - gcc
+install:
+  - sudo apt-get update
+  - sudo apt-get install -qq bison comerr-dev flex libcap-ng-dev libdb-dev libedit-dev libhesiod-dev libjson-perl libldap2-dev libncurses5-dev libperl4-corelibs-perl libsqlite3-dev libx11-dev libxau-dev libxt-dev pkg-config python ss-dev texinfo x11proto-core-dev unzip netbase


### PR DESCRIPTION
This configuration makes travis (http://travis-ci.org) configure, build and test every mainline commit and pull request for Heimdal.

Travis-CI integrates well with GitHub, and displays notes indicating when "make check" in a pull request is failing.

Apart from this configuration file, you will also need to enable Travis builds for Heimdal on https://travis-ci.org/profile/heimdal.
