### PR TITLE
test_fx: enable weak crypto

### DIFF
--- a/lib/krb5/test_fx.c
+++ b/lib/krb5/test_fx.c
@@ -120,6 +120,10 @@ test_cf2(krb5_context context)
     unsigned int i;
     unsigned int errors = 0;
 
+    ret = krb5_allow_weak_crypto(context, 1);
+    if (ret)
+        krb5_err(context, 1, ret, "krb5_allow_weak_crypto");
+
     for (i = 0; i < sizeof(cf2)/sizeof(cf2[0]); i++) {
 	pw.data = cf2[i].p1;
 	pw.length = strlen(cf2[i].p1);


### PR DESCRIPTION
Now that `test_fx` checks 1DES keys, we need to call enable_weak_crypto on the context.

Without this fix, "`make check`" was failing with the following error:

```
=============================================
   Heimdal 1.6rc2: lib/krb5/test-suite.log
=============================================

# TOTAL: 24
# PASS:  23
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: test_fx
=============

lt-test_fx: krb5_crypto_init: Encryption type des-cbc-crc not supported
```
