### PR TITLE
interpolate sqlite3 lib in krb5-config

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -34,6 +34,7 @@ subst = sed	-e "s!@PACKAGE\@!$(PACKAGE)!g" \
 		-e "s!@LIB_dbopen\@!$(LIB_dbopen)!g" \
 		-e "s!@INCLUDE_hcrypto\@!$(INCLUDE_hcrypto)!g" \
 		-e "s!@LIB_hcrypto_appl\@!$(LIB_hcrypto_appl)!g" \
+		-e "s!@LIB_sqlite3\@!$(LIB_sqlite3)!g" \
 		-e "s!@LIB_dlopen\@!$(LIB_dlopen)!g" \
 		-e "s!@LIB_door_create\@!$(LIB_door_create)!g" \
 		-e "s!@LIB_pkinit\@!$(LIB_pkinit)!g" \


### PR DESCRIPTION
Commit 7e6b558d2a261228806c0998f3be83985bb1bf3e updated krb5-config to include sqlite. However, the value was not actually being interpolated if a user ran eg `./configure --with-sqlite3=/foo`.

This pull request adds `@LIB_sqlite3@` to the list of values that get interpolated during the krb5-config build.
