### PR TITLE
kadmin: handle systemd setpgid failure

### DIFF
--- a/kadmin/kadm_conn.c
+++ b/kadmin/kadm_conn.c
@@ -189,7 +189,8 @@ wait_for_connection(krb5_context contextp,
 
     pgrp = getpid();
 
-    if(setpgid(0, pgrp) < 0)
+    /* systemd may cause setpgid to fail with EPERM */
+    if(setpgid(0, pgrp) < 0 && errno != EPERM)
 	err(1, "setpgid");
 
     signal(SIGTERM, terminate);


### PR DESCRIPTION
When running as a service under systemd, kadmin cannot successfully use `setpgid()`.  The call fails with `EPERM`. Do not treat this as a fatal error; instead, allow kadmind to continue starting up.
