### PR TITLE
krb5tgs: let TGS_REQ with NULL caddr returns an addessless ticket

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -815,8 +815,6 @@ tgs_make_reply(krb5_context context,
     rep.ticket.tkt_vno = 5;
 
     ek.caddr = et.caddr;
-    if(et.caddr == NULL)
-	et.caddr = tgt->caddr;
 
     {
 	time_t life;


### PR DESCRIPTION
When processing a request, current tgs_make_reply uses the requested
set of addrs of the request to establish the set of addresses to
associate with the ticket in reply.

However, when the request input set of addrs is NULL, it reverts to
using the TGT set of addresses instead. As a result, it is not
possible to acquire an addressless TGS (or forwarded TGT) using a
TGT that is addressed.

This patch remove the fallback ensuring that a TGS_REQ with a set
of addrs set to NULL enables to acquire an addressless ticket.
