### PR TITLE
kadm5: fix race in Makefile with kadm5_err.h

### DIFF
--- a/lib/kadm5/Makefile.am
+++ b/lib/kadm5/Makefile.am
@@ -155,6 +155,7 @@ iprop-commands.c iprop-commands.h: iprop-commands.in
 	$(SLC) $(srcdir)/iprop-commands.in
 
 $(libkadm5srv_la_OBJECTS): kadm5_err.h
+$(libkadm5clnt_la_OBJECTS): kadm5_err.h
 $(iprop_log_OBJECTS): iprop-commands.h
 
 client_glue.lo server_glue.lo: $(srcdir)/common_glue.c


### PR DESCRIPTION
When running make with -j4, occasionally kadm5 fails due to a missing header file kadm5_err.h. Fix the race condition.

Originally reported at https://bugzilla.redhat.com/1115164

Thanks @jcajka for the patch.
