### PR TITLE
version-script-client.map needs to be in dist

### DIFF
--- a/lib/kadm5/Makefile.am
+++ b/lib/kadm5/Makefile.am
@@ -208,4 +208,5 @@ EXTRA_DIST = \
 	check-cracklib.pl \
 	flush.c \
 	sample_passwd_check.c \
-	version-script.map
+	version-script.map \
+	version-script-client.map


### PR DESCRIPTION
version-script-client.map needs to be in lib/kadm5's EXTRA_DIST,
otherwise make distcheck fails
