### PR TITLE
Heimdal kdc preauth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - make
 
 script:
-    - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then make check; fi
+    - if [ x${COVERITY_SCAN_BRANCH} != x1 ]; then make check; fi
 
 compiler: clang
 

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1755,13 +1755,14 @@ _kdc_as_rep(kdc_request_t r,
 	    pa = _kdc_find_padata(req, &i, pat[n].type);
 	    if (pa) {
 		ret = pat[n].validate(r, pa);
-		if (ret == 0) {
-		    kdc_log(context, config, 0,
-			    "%s pre-authentication succeeded -- %s",
-			    pat[n].name, r->client_name);
-		    found_pa = 1;
-		    r->et.flags.pre_authent = 1;
+		if (ret != 0) {
+		    goto out;
 		}
+		kdc_log(context, config, 0,
+			"%s pre-authentication succeeded -- %s",
+			pat[n].name, r->client_name);
+		found_pa = 1;
+		r->et.flags.pre_authent = 1;
 	    }
 	}
     }

--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -268,6 +268,7 @@ fi
 
 
 echo foo > ${objdir}/foopassword
+echo notfoo > ${objdir}/notfoopassword
 
 echo Starting kdc ; > messages.log
 env MallocStackLogging=1 MallocStackLoggingNoCompact=1 MallocErrorAbort=1 MallocLogFile=${objdir}/malloc-log \
@@ -289,6 +290,12 @@ trap "kill -9 ${kdcpid} ${kpasswddpid}; echo signal killing kdc kpasswdd; exit 1
 
 ec=0
 
+echo "Getting client initial tickets with wrong password"; > messages.log
+${kinit} --password-file=${objdir}/notfoopassword \
+        foo@${R} 2>kinit-log.tmp && \
+	{ ec=1 ; eval "${testfailed}"; }
+grep 'Password incorrect' kinit-log.tmp > /dev/null || \
+	{ ec=1 ; eval "${testfailed}"; }
 echo "Getting client initial tickets"; > messages.log
 ${kinit} --password-file=${objdir}/foopassword foo@$R || \
 	{ ec=1 ; eval "${testfailed}"; }


### PR DESCRIPTION
While researching a very strange (at first) test failure in Samba when trying to rebase lorikeet-heimdal up to the modern world, I noticed that Heimdal no longer returned KRB5KDC_ERR_PREAUTH_FAILED errors. 

This gave the client library KRB5_GET_IN_TKT_LOOP internally when it got KRB5KDC_ERR_PREAUTH_REQUIRED twice in a row. 

This adds a potential fix, which should be carefully examined by someone who understands the intended behaviour in the presence of multiple possible PA requests on the AS-REQ.