### PR TITLE
kadm5: fix race in Makefile with kadm5_err.h

### DIFF
--- a/lib/kadm5/Makefile.am
+++ b/lib/kadm5/Makefile.am
@@ -155,6 +155,7 @@ iprop-commands.c iprop-commands.h: iprop-commands.in
 	$(SLC) $(srcdir)/iprop-commands.in
 
 $(libkadm5srv_la_OBJECTS): kadm5_err.h
+$(libkadm5clnt_la_OBJECTS): kadm5_err.h
 $(iprop_log_OBJECTS): iprop-commands.h
 
 client_glue.lo server_glue.lo: $(srcdir)/common_glue.c


### PR DESCRIPTION
When running `make` with `-j4`, occasionally kadm5 fails due to a missing header file `kadm5_err.h`. Fix the race condition.

Thanks @jcajka for the original patch.

This is a cherry-pick of commit 6affa4cceceaa1369dd895f8acdd7a883ee65674 which was merged to master in https://github.com/heimdal/heimdal/pull/108 . This pull request is for the 1.6 branch.