### PR TITLE
ipv6 loopbacks fix

### DIFF
--- a/lib/krb5/addr_families.c
+++ b/lib/krb5/addr_families.c
@@ -1161,6 +1161,7 @@ krb5_parse_address(krb5_context context,
 {
     int i, n;
     struct addrinfo *ai, *a;
+    struct addrinfo hint;
     int error;
     int save_errno;
 
@@ -1180,7 +1181,10 @@ krb5_parse_address(krb5_context context,
 	}
     }
 
-    error = getaddrinfo (string, NULL, NULL, &ai);
+    /* if not parsed as numeric address, do a name lookup */
+    memset(&hint, 0, sizeof(hint));
+    hint.ai_family = AF_UNSPEC;
+    error = getaddrinfo (string, NULL, &hint, &ai);
     if (error) {
 	krb5_error_code ret2;
 	save_errno = errno;


### PR DESCRIPTION
I'm not sure if this is still needed? @net9rok had added this to the Fedora packages in July 2012, and I want to send this upstream to see if we still need it or if I should drop it from the Fedora/EPEL packages.

"Fix IPv6 and multiple interfaces bug in krb5_parse_address." See discussion at https://bugzilla.redhat.com/808147