### PR TITLE
Lukeh/cfb8

### DIFF
--- a/lib/hcrypto/evp-cc.c
+++ b/lib/hcrypto/evp-cc.c
@@ -711,6 +711,56 @@ EVP_cc_sha256(void)
 }
 
 /**
+ * The CommonCrypto sha384 provider
+ *
+ * @ingroup hcrypto_evp
+ */
+
+const EVP_MD *
+EVP_cc_sha384(void)
+{
+#ifdef HAVE_COMMONCRYPTO_COMMONDIGEST_H
+    static const struct hc_evp_md sha384 = {
+	CC_SHA384_DIGEST_LENGTH,
+	CC_SHA384_BLOCK_BYTES,
+	sizeof(CC_SHA512_CTX),
+	(hc_evp_md_init)CC_SHA384_Init,
+	(hc_evp_md_update)CC_SHA384_Update,
+	(hc_evp_md_final)CC_SHA384_Final,
+	(hc_evp_md_cleanup)NULL
+    };
+    return &sha384;
+#else
+    return NULL;
+#endif
+}
+
+/**
+ * The CommonCrypto sha512 provider
+ *
+ * @ingroup hcrypto_evp
+ */
+
+const EVP_MD *
+EVP_cc_sha512(void)
+{
+#ifdef HAVE_COMMONCRYPTO_COMMONDIGEST_H
+    static const struct hc_evp_md sha512 = {
+	CC_SHA512_DIGEST_LENGTH,
+	CC_SHA512_BLOCK_BYTES,
+	sizeof(CC_SHA512_CTX),
+	(hc_evp_md_init)CC_SHA512_Init,
+	(hc_evp_md_update)CC_SHA512_Update,
+	(hc_evp_md_final)CC_SHA512_Final,
+	(hc_evp_md_cleanup)NULL
+    };
+    return &sha512;
+#else
+    return NULL;
+#endif
+}
+
+/**
  * The Camellia-128 cipher type - CommonCrypto
  *
  * @return the Camellia-128 EVP_CIPHER pointer.

--- a/lib/hcrypto/evp-cc.h
+++ b/lib/hcrypto/evp-cc.h
@@ -42,6 +42,8 @@
 #define EVP_cc_md5 hc_EVP_cc_md5
 #define EVP_cc_sha1 hc_EVP_cc_sha1
 #define EVP_cc_sha256 hc_EVP_cc_sha256
+#define EVP_cc_sha384 hc_EVP_cc_sha384
+#define EVP_cc_sha512 hc_EVP_cc_sha512
 #define EVP_cc_des_cbc hc_EVP_cc_des_cbc
 #define EVP_cc_des_ede3_cbc hc_EVP_cc_des_ede3_cbc
 #define EVP_cc_aes_128_cbc hc_EVP_cc_aes_128_cbc
@@ -70,6 +72,8 @@ const EVP_MD * EVP_cc_md4(void);
 const EVP_MD * EVP_cc_md5(void);
 const EVP_MD * EVP_cc_sha1(void);
 const EVP_MD * EVP_cc_sha256(void);
+const EVP_MD * EVP_cc_sha384(void);
+const EVP_MD * EVP_cc_sha512(void);
 
 const EVP_CIPHER * EVP_cc_rc2_cbc(void);
 const EVP_CIPHER * EVP_cc_rc2_40_cbc(void);


### PR DESCRIPTION
The builtin hcrypto CFB8 implementation was completely broken, as were the test vectors.

Also, OS X (since 10.7) has an inbuilt CFB8 implementation in CommonCrypto we can use.

AES CFB8 is only used for Windows interop (NetLogon).