### PR TITLE
Fix build when OpenSSL has no EGD support

### DIFF
--- a/cf/crypto.m4
+++ b/cf/crypto.m4
@@ -118,6 +118,7 @@ if test "$crypto_lib" = "unknown" -a "$with_openssl" != "no"; then
 			break;
 		fi
 	done
+	AC_CHECK_LIB(crypto, RAND_egd, AC_DEFINE(HAVE_RAND_EGD, 1, [Define if the libcrypto has RAND_egd]))
 	CFLAGS="$save_CFLAGS"
 	LIBS="$save_LIBS"
 fi

--- a/include/NTMakefile
+++ b/include/NTMakefile
@@ -79,7 +79,6 @@ while(<>) {
     if ("$(DIR_hdbdir)") { print "#define HDB_DB_DIR \"".'$(DIR_hdbdir)'."\"\n"; }
     if ("$(HAVE_MSLSA_CACHE)") { print "#define HAVE_MSLSA_CACHE 1\n"; }
     if ("$(NO_LOCALNAME)") { print "#define NO_LOCALNAME 1\n"; }
-    if ("$(NO_RAND_EGD_METHOD)") { print "#define NO_RAND_EGD_METHOD 1\n"; }
 
   } elsif (m/\@VERSION_OPTDEFS\@/) {
 

--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -1363,9 +1363,6 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 /* Define if you don't want to use mmap. */
 #define NO_MMAP 1
 
-/* Define if EGD rand method is not defined */
-#define NO_RAND_EGD_METHOD 1
-
 /* Define if the Unix rand method is not defined */
 #define NO_RAND_UNIX_METHOD 1
 

--- a/lib/hcrypto/rand-fortuna.c
+++ b/lib/hcrypto/rand-fortuna.c
@@ -486,7 +486,7 @@ fortuna_reseed(void)
 	entropy_p = 1;
     }
 #endif
-#if !defined(NO_RAND_EGD_METHOD) && defined(HAVE_RAND_EGD)
+#if defined(HAVE_RAND_EGD)
     /*
      * Only to get egd entropy if /dev/random or arc4rand failed since
      * it can be horribly slow to generate new bits.

--- a/lib/hcrypto/rand-fortuna.c
+++ b/lib/hcrypto/rand-fortuna.c
@@ -486,7 +486,7 @@ fortuna_reseed(void)
 	entropy_p = 1;
     }
 #endif
-#ifndef NO_RAND_EGD_METHOD
+#if !defined(NO_RAND_EGD_METHOD) && defined(HAVE_RAND_EGD)
     /*
      * Only to get egd entropy if /dev/random or arc4rand failed since
      * it can be horribly slow to generate new bits.

--- a/lib/hcrypto/test_rand.c
+++ b/lib/hcrypto/test_rand.c
@@ -125,7 +125,7 @@ main(int argc, char **argv)
 	else if (strcasecmp(rand_method, "unix") == 0)
 	    RAND_set_rand_method(RAND_unix_method());
 #endif
-#if !defined(NO_RAND_EGD_METHOD) && defined(HAVE_RAND_EGD)
+#if defined(HAVE_RAND_EGD)
 	else if (strcasecmp(rand_method, "egd") == 0)
 	    RAND_set_rand_method(RAND_egd_method());
 #endif

--- a/lib/hcrypto/test_rand.c
+++ b/lib/hcrypto/test_rand.c
@@ -125,7 +125,7 @@ main(int argc, char **argv)
 	else if (strcasecmp(rand_method, "unix") == 0)
 	    RAND_set_rand_method(RAND_unix_method());
 #endif
-#ifndef NO_RAND_EGD_METHOD
+#if !defined(NO_RAND_EGD_METHOD) && defined(HAVE_RAND_EGD)
 	else if (strcasecmp(rand_method, "egd") == 0)
 	    RAND_set_rand_method(RAND_egd_method());
 #endif

--- a/lib/krb5/crypto-rand.c
+++ b/lib/krb5/crypto-rand.c
@@ -67,7 +67,7 @@ seed_something(void)
     /* Calling RAND_status() will try to use /dev/urandom if it exists so
        we do not have to deal with it. */
     if (RAND_status() != 1) {
-#ifndef NO_RAND_EGD_METHOD
+#if !defined(NO_RAND_EGD_METHOD) && defined(HAVE_RAND_EGD)
 	krb5_context context;
 	const char *p;
 

--- a/lib/krb5/crypto-rand.c
+++ b/lib/krb5/crypto-rand.c
@@ -67,7 +67,7 @@ seed_something(void)
     /* Calling RAND_status() will try to use /dev/urandom if it exists so
        we do not have to deal with it. */
     if (RAND_status() != 1) {
-#if !defined(NO_RAND_EGD_METHOD) && defined(HAVE_RAND_EGD)
+#if defined(HAVE_RAND_EGD)
 	krb5_context context;
 	const char *p;
 

--- a/windows/NTMakefile.config
+++ b/windows/NTMakefile.config
@@ -95,9 +95,6 @@ WEAK_CRYPTO=1
 # Disable use of GSS LOCALNAME support
 NO_LOCALNAME=1
 
-# No entropy-gathering daemon on Windows
-NO_RAND_EGD_METHOD=1
-
 # Windows CRT mkdir does not have the mode parameter
 MKDIR_DOES_NOT_HAVE_MODE=1
 


### PR DESCRIPTION
Hi,

Current 1.5.3 heimdal does not build with LibreSSL as it does not have EGD support. This fixing and upstreaming is part of the work done to enable all ports to work with LibreSSL on FreeBSD, see https://wiki.freebsd.org/LibreSSL and the PR to fix this is https://bugs.freebsd.org/198527
I believe it is safe to remove EGD altogether as this is a relic from the past, nothing recent requires EGD (not even Windows as can be seen in the master branch).
Latest versions requiring EGD
IRIX 6.5.19 Feb 2003
Solaris 2.6 Jul 1997
AIX 5.2 Oct 2002
Tru64 5.1B Sep 2002
HP-UX 11i v2 Sep 2003

This patch detects EGD support in the OpenSSL (or LibreSSL) libcrypto and adds ifdef's where relevant. Looks a bit kludgy now that this has been made conditional in the reverse way for Windows.

Hope you will add this to your next release!

Thanks, Bernard Spil