### PR TITLE
Fix compilation error in dlfcn.h

### DIFF
--- a/lib/roken/dlfcn.hin
+++ b/lib/roken/dlfcn.hin
@@ -51,7 +51,7 @@ typedef int (__stdcall *DLSYM_RET_TYPE)();
 #endif
 
 #ifdef __cplusplus
-extern "C" 
+extern "C" {
 #endif
 
 /* Implementation based on


### PR DESCRIPTION
When dlfcn.h is included from a C++ file causes a compilation error due to missing '{'.