### PR TITLE
PK-INIT improvements

### DIFF
--- a/lib/hx509/hx509_err.et
+++ b/lib/hx509/hx509_err.et
@@ -100,4 +100,10 @@ error_code OPEN_SESSION,  "Failed to open session to slot"
 error_code LOGIN,  "Failed to login to slot"
 error_code LOAD,  "Failed to load PKCS module"
 
+# pkinit related errors
+error_code PIN_INCORRECT, "Incorrect User PIN"
+error_code PIN_LOCKED, "User PIN locked"
+error_code PIN_NOT_INITIALIZED, "User PIN not initialized"
+error_code PIN_EXPIRED, "User PIN expired"
+
 end

--- a/lib/hx509/ks_p11.c
+++ b/lib/hx509/ks_p11.c
@@ -931,10 +931,10 @@ p11_init(hx509_context context,
 
 	for (i = 0; i < p->num_slots; i++) {
 	    ret = p11_init_slot(context, p, lock, slot_ids[i], i, &p->slot[i]);
-	    if (ret)
-		break;
-	    if (p->slot[i].flags & P11_TOKEN_PRESENT)
-		num_tokens++;
+	    if (!ret) {
+	        if (p->slot[i].flags & P11_TOKEN_PRESENT)
+	            num_tokens++;
+	    }
 	}
 	free(slot_ids);
 	if (ret)

--- a/lib/hx509/ks_p11.c
+++ b/lib/hx509/ks_p11.c
@@ -343,7 +343,7 @@ p11_init_slot(hx509_context context,
     if (ret) {
 	hx509_set_error_string(context, 0, HX509_PKCS11_NO_TOKEN,
 			       "Failed to init PKCS11 slot %d "
-			       "with error 0x08x",
+			       "with error 0x%08x",
 			       num, ret);
 	return HX509_PKCS11_NO_TOKEN;
     }

--- a/lib/hx509/ks_p11.c
+++ b/lib/hx509/ks_p11.c
@@ -467,7 +467,7 @@ p11_get_session(hx509_context context,
 	        case CKR_PIN_INCORRECT:
 	            return HX509_PKCS11_PIN_INCORRECT;
 	        case CKR_USER_PIN_NOT_INITIALIZED:
-	            return HX509_PKCS11_USER_PIN_NOT_INITIALIZED;
+	            return HX509_PKCS11_PIN_NOT_INITIALIZED;
 	        default:
 	            return HX509_PKCS11_LOGIN;
 	    }

--- a/lib/hx509/ks_p11.c
+++ b/lib/hx509/ks_p11.c
@@ -459,7 +459,18 @@ p11_get_session(hx509_context context,
 				       "Failed to login on slot id %d "
 				       "with error: 0x%08x",
 				       (int)slot->id, ret);
-	    return HX509_PKCS11_LOGIN;
+	    switch(ret) {
+	        case CKR_PIN_LOCKED:
+	            return HX509_PKCS11_PIN_LOCKED;
+	        case CKR_PIN_EXPIRED:
+	            return HX509_PKCS11_PIN_EXPIRED;
+	        case CKR_PIN_INCORRECT:
+	            return HX509_PKCS11_PIN_INCORRECT;
+	        case CKR_USER_PIN_NOT_INITIALIZED:
+	            return HX509_PKCS11_USER_PIN_NOT_INITIALIZED;
+	        default:
+	            return HX509_PKCS11_LOGIN;
+	    }
 	} else
 	    slot->flags |= P11_LOGIN_DONE;
 


### PR DESCRIPTION
This PR add:

* more support related to common PIN errors (PIN blocked, incorrect, ...)
* the corresponding messages allowing a more friendly debugging.
* fix a small typo
* allow more than one token to be present (if the first is not usable, the second one can be).

Credit: thanks to Romain Sahut for his help.
