### PR TITLE
Add ability to specifiy PKCS#11 slot number when using hx509

### DIFF
--- a/lib/hx509/crypto.c
+++ b/lib/hx509/crypto.c
@@ -3015,6 +3015,8 @@ match_keys_ec(hx509_cert c, hx509_private_key private_key)
 int
 _hx509_match_keys(hx509_cert c, hx509_private_key key)
 {
+    if (!key->ops)
+	return 0;
     if (der_heim_oid_cmp(key->ops->key_oid, ASN1_OID_ID_PKCS1_RSAENCRYPTION) == 0)
 	return match_keys_rsa(c, key);
     if (der_heim_oid_cmp(key->ops->key_oid, ASN1_OID_ID_ECPUBLICKEY) == 0)

--- a/lib/hx509/ks_p11.c
+++ b/lib/hx509/ks_p11.c
@@ -65,6 +65,7 @@ struct p11_module {
     CK_FUNCTION_LIST_PTR funcs;
     CK_ULONG num_slots;
     unsigned int ref;
+    unsigned int selected_slot;
     struct p11_slot *slot;
 };
 
@@ -833,6 +834,7 @@ p11_init(hx509_context context,
     }
 
     p->ref = 1;
+    p->selected_slot = 0;
 
     str = strchr(list, ',');
     if (str)
@@ -842,10 +844,8 @@ p11_init(hx509_context context,
 	strnext = strchr(str, ',');
 	if (strnext)
 	    *strnext++ = '\0';
-#if 0
 	if (strncasecmp(str, "slot=", 5) == 0)
 	    p->selected_slot = atoi(str + 5);
-#endif
 	str = strnext;
     }
 
@@ -930,6 +930,8 @@ p11_init(hx509_context context,
 	}
 
 	for (i = 0; i < p->num_slots; i++) {
+	    if ((p->selected_slot != 0) && (slot_ids[i] != (p->selected_slot - 1)))
+		continue;
 	    ret = p11_init_slot(context, p, lock, slot_ids[i], i, &p->slot[i]);
 	    if (!ret) {
 	        if (p->slot[i].flags & P11_TOKEN_PRESENT)


### PR DESCRIPTION
Example usage: kinit -C PKCS11:/usr/lib/opensc-pkcs11.so,slot=3 foo@BAR.TLD

This is required for certain tokens, such as the OpenPGP cards, that default to an incorrect slot.  Slot numbering is consistent with the pkcs11 PAM module.