### PR TITLE
roken: fix rename recursion due to macro

### DIFF
--- a/lib/roken/rename.c
+++ b/lib/roken/rename.c
@@ -31,6 +31,7 @@
 
 #include <config.h>
 #include "roken.h"
+#undef rk_rename
 
 /* rename() for platforms where the native implementation doesn't
  * unlink newname. */


### PR DESCRIPTION
rk_rename() function must not be redefined to rename() in rename.c, otherwise
the function becomes an infinite recursion.
