### PR TITLE
Implement krb5_get_init_creds_opt_set_change_password_prompt()

### DIFF
--- a/lib/krb5/init_creds.c
+++ b/lib/krb5/init_creds.c
@@ -195,6 +195,12 @@ krb5_get_init_creds_opt_set_default_flags(krb5_context context,
 #endif
 }
 
+KRB5_LIB_FUNCTION void KRB5_LIB_CALL
+krb5_get_init_creds_opt_set_change_password_prompt(krb5_get_init_creds_opt *opt,
+		int change_password_prompt) {
+	opt->flags |= KRB5_GET_INIT_CREDS_OPT_CHANGE_PASSWORD_PROMPT;
+	opt->change_password_prompt = change_password_prompt;
+}
 
 KRB5_LIB_FUNCTION void KRB5_LIB_CALL
 krb5_get_init_creds_opt_set_tkt_life(krb5_get_init_creds_opt *opt,

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -539,6 +539,8 @@ change_password (krb5_context context,
 	krb5_get_init_creds_opt_set_preauth_list (options,
 						  old_options->preauth_list,
 						  old_options->preauth_list_length);
+    if (old_options && old_options->flags & KRB5_GET_INIT_CREDS_OPT_CHANGE_PASSWORD_PROMPT)
+        krb5_get_init_creds_opt_set_change_password_prompt(options, old_options->change_password_prompt);
 
     krb5_data_zero (&result_code_string);
     krb5_data_zero (&result_string);
@@ -2678,6 +2680,10 @@ krb5_get_init_creds_password(krb5_context context,
 	/* don't try to change password where then where none */
 	if (prompter == NULL)
 	    goto out;
+
+	if ((options->flags & KRB5_GET_INIT_CREDS_OPT_CHANGE_PASSWORD_PROMPT) == KRB5_GET_INIT_CREDS_OPT_CHANGE_PASSWORD_PROMPT && !options->change_password_prompt) {
+		goto out;
+	}
 
 	ret = change_password (context,
 			       client,

--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -746,6 +746,7 @@ struct _krb5_get_init_creds_opt {
     int forwardable;
     int proxiable;
     int anonymous;
+    int change_password_prompt;
     krb5_enctype *etype_list;
     int etype_list_length;
     krb5_addresses *address_list;
@@ -769,6 +770,7 @@ typedef struct _krb5_get_init_creds_opt krb5_get_init_creds_opt;
 #define KRB5_GET_INIT_CREDS_OPT_SALT		0x0080 /* no supported */
 #define KRB5_GET_INIT_CREDS_OPT_ANONYMOUS	0x0100
 #define KRB5_GET_INIT_CREDS_OPT_DISABLE_TRANSITED_CHECK	0x0200
+#define KRB5_GET_INIT_CREDS_OPT_CHANGE_PASSWORD_PROMPT	0x0400
 
 /* krb5_init_creds_step flags argument */
 #define KRB5_INIT_CREDS_STEP_FLAG_CONTINUE	0x0001

--- a/lib/krb5/krb5_get_init_creds.3
+++ b/lib/krb5/krb5_get_init_creds.3
@@ -97,6 +97,11 @@ Kerberos 5 Library (libkrb5, -lkrb5)
 .Fa "int anonymous"
 .Fc
 .Ft void
+.Fo krb5_get_init_creds_opt_set_change_password_prompt
+.Fa "krb5_get_init_creds_opt *opt"
+.Fa "int change_password_prompt"
+.Fc
+.Ft void
 .Fo krb5_get_init_creds_opt_set_default_flags
 .Fa "krb5_context context"
 .Fa "const char *appname"

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -350,6 +350,7 @@ EXPORTS
 	krb5_get_init_creds_opt_set_address_list
 	krb5_get_init_creds_opt_set_addressless
 	krb5_get_init_creds_opt_set_anonymous
+	krb5_get_init_creds_opt_set_change_password_prompt
 	krb5_get_init_creds_opt_set_canonicalize
 	krb5_get_init_creds_opt_set_default_flags
 	krb5_get_init_creds_opt_set_etype_list

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -346,6 +346,7 @@ HEIMDAL_KRB5_2.0 {
 		krb5_get_init_creds_opt_set_address_list;
 		krb5_get_init_creds_opt_set_addressless;
 		krb5_get_init_creds_opt_set_anonymous;
+		krb5_get_init_creds_opt_set_change_password_prompt;
 		krb5_get_init_creds_opt_set_canonicalize;
 		krb5_get_init_creds_opt_set_default_flags;
 		krb5_get_init_creds_opt_set_etype_list;


### PR DESCRIPTION
To be compliant with MIT kerberos.
This function enables/disables prompting for a new password if the password of a user is expired.
