### PR TITLE
lib/krb5: allow predefined PAC_{LOGON_NAME,PRIVSVR_CHECKSUM,SERVER_CH…

### DIFF
--- a/lib/krb5/pac.c
+++ b/lib/krb5/pac.c
@@ -986,6 +986,40 @@ _krb5_pac_sign(krb5_context context,
 
     krb5_data_zero(&logon);
 
+    for (i = 0; i < p->pac->numbuffers; i++) {
+	if (p->pac->buffers[i].type == PAC_SERVER_CHECKSUM) {
+	    if (p->server_checksum == NULL) {
+		p->server_checksum = &p->pac->buffers[i];
+	    }
+	    if (p->server_checksum != &p->pac->buffers[i]) {
+		ret = EINVAL;
+		krb5_set_error_message(context, ret,
+				       N_("PAC have two server checksums", ""));
+		goto out;
+	    }
+	} else if (p->pac->buffers[i].type == PAC_PRIVSVR_CHECKSUM) {
+	    if (p->privsvr_checksum == NULL) {
+		p->privsvr_checksum = &p->pac->buffers[i];
+	    }
+	    if (p->privsvr_checksum != &p->pac->buffers[i]) {
+		ret = EINVAL;
+		krb5_set_error_message(context, ret,
+				       N_("PAC have two KDC checksums", ""));
+		goto out;
+	    }
+	} else if (p->pac->buffers[i].type == PAC_LOGON_NAME) {
+	    if (p->logon_name == NULL) {
+		p->logon_name = &p->pac->buffers[i];
+	    }
+	    if (p->logon_name != &p->pac->buffers[i]) {
+		ret = EINVAL;
+		krb5_set_error_message(context, ret,
+				       N_("PAC have two logon names", ""));
+		goto out;
+	    }
+	}
+    }
+
     if (p->logon_name == NULL)
 	num++;
     if (p->server_checksum == NULL)


### PR DESCRIPTION
…ECKSUM} elements in _krb5_pac_sign()

A caller may want to specify an explicit order of PAC elements,
e.g. the PAC_UPN_DNS_INFO element should be placed after the PAC_LOGON_NAME
element.

Signed-off-by: Stefan Metzmacher <metze@samba.org>