### PR TITLE
Fix bias in ordering SRV RR results by weight.

### DIFF
--- a/lib/roken/resolve.c
+++ b/lib/roken/resolve.c
@@ -674,7 +674,7 @@ rk_dns_srv_order(struct rk_dns_reply *r)
 	/* ss is now the first record of this priority and ee is the
            first of the next */
 	while(ss < ee) {
-	    rnd = rk_random() % (sum + 1);
+	    rnd = rk_random() % sum + 1;
 	    for(count = 0, tt = ss; ; tt++) {
 		if(*tt == NULL)
 		    continue;


### PR DESCRIPTION
In lib/roken/resolve.c, we find rk_dns_srv_order() which re-orders
the results of an SRV RR lookup by the algorithm in RFC2782.  We
fix a bias in the random weight sorting by changing the order of
operations when selecting rnd.  rnd should be a non-zero random
number less than the sum of the weights at a particular priority,
but zero was included as a legitimate output thus biasing the
selection process.  rk_random() % sum is still biased as a 32
bit int modulo a number which doesn't divide 2^32 does not have
a uniform distribution, but the bias should be small enough to
live with for our purposes here.
