### PR TITLE
lib/krb5/pac.c: fix NULL check typo

### DIFF
--- a/lib/krb5/pac.c
+++ b/lib/krb5/pac.c
@@ -771,7 +771,7 @@ build_logon_name(krb5_context context,
 
 	s2_len = (ucs2_len + 1) * 2;
 	s2 = malloc(s2_len);
-	if (ucs2 == NULL) {
+	if (s2 == NULL) {
 	    free(ucs2);
 	    return krb5_enomem(context);
 	}


### PR DESCRIPTION
ucs2 was already NULL checked earlier, this is never reached (and is doing a free(NULL), which man free(3) says it's a no-op) so no worries there.

You actually want to NULL-check s2 who has just received a malloc() result.
