### PR TITLE
lib/gssapi/mech/gss_compare_name.c: fix memcmp() call

### DIFF
--- a/lib/gssapi/mech/gss_compare_name.c
+++ b/lib/gssapi/mech/gss_compare_name.c
@@ -47,7 +47,7 @@ gss_compare_name(OM_uint32 *minor_status,
 		if (!gss_oid_equal(&name1->gn_type, &name2->gn_type)) {
 			*name_equal = 0;
 		} else if (name1->gn_value.length != name2->gn_value.length ||
-		    memcmp(name1->gn_value.value, name1->gn_value.value,
+		    memcmp(name1->gn_value.value, name2->gn_value.value,
 			name1->gn_value.length)) {
 			*name_equal = 0;
 		}


### PR DESCRIPTION
Make memcmp() compare the name1 and name2 value instead of comparing
name1 with itself.

The memcmp() is only executed if the left-hand side of the || is false
i.e. when both length are equal so the length argument is correct (no out-of-bounds reads).

I'm confused about the `$FreeBSD: ...$` tag, is this originally from FreeBSD SVN? Should I send this change on their mailing list?