### PR TITLE
Fix build when OpenSSL does not support EGD

### DIFF
--- a/lib/hcrypto/rand-egd.c
+++ b/lib/hcrypto/rand-egd.c
@@ -33,6 +33,8 @@
 
 #include <config.h>
 
+#ifndef OPENSSL_NO_EGD
+
 #include <sys/types.h>
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h>
@@ -258,3 +260,5 @@ RAND_egd_bytes(const char *filename, int size)
 
     return 1;
 }
+
+#endif

--- a/lib/krb5/crypto-rand.c
+++ b/lib/krb5/crypto-rand.c
@@ -71,6 +71,7 @@ seed_something(void)
 	krb5_context context;
 	const char *p;
 
+#ifndef OPENSSL_NO_EGD
 	/* Try using egd */
 	if (!krb5_init_context(&context)) {
 	    p = krb5_config_get_string(context, NULL, "libdefaults",
@@ -79,6 +80,8 @@ seed_something(void)
 		RAND_egd_bytes(p, ENTROPY_NEEDED);
 	    krb5_free_context(context);
 	}
+#endif
+
 #else
 	/* TODO: Once a Windows CryptoAPI RAND method is defined, we
 	   can use that and failover to another method. */


### PR DESCRIPTION
- EGD is disabled by default in OpenSSL 1.1.0
- EGD was removed from LibreSSL
- No current platform requires EGD
