### PR TITLE
Fix QAS Bug 21711: Kerberos BAD_INTEGRITY error with 2008 R2 RODC

### DIFF
--- a/lib/krb5/principal.c
+++ b/lib/krb5/principal.c
@@ -211,6 +211,10 @@ krb5_parse_name_flags(krb5_context context,
     int enterprise = flags & KRB5_PRINCIPAL_PARSE_ENTERPRISE;
     int ignore_realm = flags & KRB5_PRINCIPAL_PARSE_IGNORE_REALM;
     int no_def_realm = flags & KRB5_PRINCIPAL_PARSE_NO_DEF_REALM;
+    int srv_and_inst = 0;
+
+    if( !strncasecmp( name, KRB5_TGS_NAME, 6 ) )
+        srv_and_inst = 1;
 
     *principal = NULL;
 
@@ -348,6 +352,9 @@ krb5_parse_name_flags(krb5_context context,
     }
     if (enterprise)
 	(*principal)->name.name_type = KRB5_NT_ENTERPRISE_PRINCIPAL;
+    else
+    if( srv_and_inst )
+    (*principal)->name.name_type = KRB5_NT_SRV_INST;
     else
 	(*principal)->name.name_type = KRB5_NT_PRINCIPAL;
     (*principal)->name.name_string.val = comp;

--- a/lib/krb5/principal.c
+++ b/lib/krb5/principal.c
@@ -213,7 +213,7 @@ krb5_parse_name_flags(krb5_context context,
     int no_def_realm = flags & KRB5_PRINCIPAL_PARSE_NO_DEF_REALM;
     int srv_and_inst = 0;
 
-    if( !strncasecmp( name, KRB5_TGS_NAME, 6 ) )
+    if (!strncasecmp(name, KRB5_TGS_NAME, 6))
         srv_and_inst = 1;
 
     *principal = NULL;
@@ -352,9 +352,8 @@ krb5_parse_name_flags(krb5_context context,
     }
     if (enterprise)
 	(*principal)->name.name_type = KRB5_NT_ENTERPRISE_PRINCIPAL;
-    else
-    if( srv_and_inst )
-    (*principal)->name.name_type = KRB5_NT_SRV_INST;
+    else if (srv_and_inst)
+        (*principal)->name.name_type = KRB5_NT_SRV_INST;
     else
 	(*principal)->name.name_type = KRB5_NT_PRINCIPAL;
     (*principal)->name.name_string.val = comp;


### PR DESCRIPTION
BAD_INTEGRITY error when trying to kinit:

ERROR: VAS_ERR_KRB5: Failed to obtain credentials. Client: SLED10-32$@F.QAS,
Service: SLED10-32$@F.QAS, Server: ad2-f.f.qas
   Caused by:
   KRB5KRB_AP_ERR_BAD_INTEGRITY (-1765328353): Decrypt integrity check failed

MS changed code for RODCs in 2008R2.  MS does state that ALL krgtgt/REALM tickets SHOULD be sent using principal name type of KRB5_NT_SRV_INST, instead of KRB5_NT_PRINCIPAL.

From Microsoft:

"I believe we discovered the problem.  There isn’t a bug in Windows. 
There’s been a code change to address another issue which puts in additional
checks for Kerberos tickets.  The problem is with the Unix clients when the
client request a TGT.  The Unix clients are using Name-type Principal
[KRB_NT_PRINCIPAL  (1)] instead of using Name-type Service and Instance
[KRB_NT_SRV_INST  (2)]...."  

Further correspondence suggests that other tickets should be formatted to use:

"TGT’s should always be KRB5_NT_SRV_INST.  As far as principal type, it
depends on the name type being used.  If it’s in the form of http/ or
mssqlsvc/, etc then it would use KRB5_NT_SRV_INST.  If it is host/ then it
would be KRB_NT_SRV_HST.  If it’s in the form of a UPN then it would be
KRB_NT_ENTERPRISE_PRINCIPAL."