### PR TITLE
Various fixes in kfb5.conf man page:

### DIFF
--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -144,7 +144,7 @@ Default realm to use, this is also known as your
 The default is the result of
 .Fn krb5_get_host_realm "local hostname" .
 .It Li allow_weak_crypto = Va boolean
-is weaks crypto algorithms allowed to be used, among others, DES is
+are weak crypto algorithms allowed to be used, among others, DES is
 considered weak.
 .It Li clockskew = Va time
 Maximum time differential (in seconds) allowed when comparing
@@ -168,9 +168,9 @@ the default credentials cache name.
 If you want to change the type only use
 .Li default_cc_type .
 The string can contain variables that are expanded on runtime.
-Only support variable now is
+The Only supported variable currently is
 .Li %{uid}
-that expands to the current user id.
+which expands to the current user id.
 .It Li default_etypes = Va etypes ...
 A list of default encryption types to use. (Default: all enctypes if
 allow_weak_crypto = TRUE, else all enctypes except single DES enctypes.)
@@ -243,10 +243,10 @@ It's the field ticketflags that is stored in reverse bit order for
 older than Heimdal 0.7.
 Setting this flag to
 .Dv TRUE
-make it store the MIT way, this is default for Heimdal 0.7.
+makes it store the MIT way, this is default for Heimdal 0.7.
 .It Li check-rd-req-server
-If set to "ignore", the framework will ignore any the server input to
-.Xr krb5_rd_req 3,
+If set to "ignore", the framework will ignore any of the server input to
+.Xr krb5_rd_req 3 ,
 this is very useful when the GSS-API server input the
 wrong server name into the gss_accept_sec_context call.
 .It Li k5login_directory = Va directory
@@ -288,7 +288,7 @@ K5login files are text files, with each line containing just a principal
 name; principals apearing in a user's k5login file are permitted access
 to the user's account. Note: this rule performs no ownership nor
 permissions checks on k5login files; proper ownership and
-permissions/ACLs are expected due to the system k5login location being a
+permissions/ACLs are expected due to the k5login location being a
 system location.
 .It Li kuserok = Va USER-K5LOGIN
 If set and evaluated then
@@ -389,7 +389,7 @@ with explicit
 .Va order
 then all other rules in the order in which they appear.  If any two
 rules have the same explicit
-.Va order
+.Va order ,
 their order of appearance in krb5.conf breaks the tie.  Explicitly
 specifying order can be useful where tools read and write the
 configuration file without preserving parameter order.


### PR DESCRIPTION
Fix grammar at multiple places
Also, fix mdoc syntax at one place. There should be a space between the
section and the comma in the .Xr macro.