### PR TITLE
Revert "KVNOs are krb5uint32 in RFC4120, make it so"

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1572,6 +1572,8 @@ tgs_build_reply(krb5_context context,
 	hdb_entry_ex *uu;
 	krb5_principal p;
 	Key *uukey;
+	krb5uint32 second_kvno = 0;
+	krb5uint32 *kvno_ptr = NULL;
 
 	if(b->additional_tickets == NULL ||
 	   b->additional_tickets->len == 0){
@@ -1588,8 +1590,12 @@ tgs_build_reply(krb5_context context,
 	    goto out;
 	}
 	_krb5_principalname2krb5_principal(context, &p, t->sname, t->realm);
+	if(t->enc_part.kvno){
+	    second_kvno = *t->enc_part.kvno;
+	    kvno_ptr = &second_kvno;
+	}
 	ret = _kdc_db_fetch(context, config, p,
-			    HDB_F_GET_KRBTGT, t->enc_part.kvno,
+			    HDB_F_GET_KRBTGT, kvno_ptr,
 			    NULL, &uu);
 	krb5_free_principal(context, p);
 	if(ret){


### PR DESCRIPTION
This reverts commit 1124c4872dfb81bec9c4b527b8927ca35e39a599.

A reason for deviation from RFC4120 is backward compatibility.
With Windows RODC's, it is likely to have a kvno for the tgt which
has bit 31 set. Encoding such a kvno as unsigned would lead to a
5-byte number, whereas Windows, which treats kvno as int32, expects
up to 4 bytes. MIT Kerberos does the same for the exact same reason.

The encoding has already been reverted in commit
060474df1626bcc597ef6e786cc58d9b2daac8db. After reverting the encoding,
there's no reason to use krb5uint32 in the context of kvno, so this
commit reverts the rest, plus removes one more use of krb5uint32 in
the context of kvno.

Signed-off-by: Uri Simchoni <uri@samba.org>