### PR TITLE
krb5_c_random_make_octets incorrectly implemented

### DIFF
--- a/lib/krb5/mit_glue.c
+++ b/lib/krb5/mit_glue.c
@@ -378,7 +378,8 @@ krb5_c_prf(krb5_context context,
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_c_random_make_octets(krb5_context context, krb5_data * data)
 {
-    return krb5_generate_random_keyblock(context, data->length, data->data);
+    krb5_generate_random_block(context, data->length, data->data);
+    return 0;
 }
 
 /**

--- a/lib/krb5/mit_glue.c
+++ b/lib/krb5/mit_glue.c
@@ -378,7 +378,7 @@ krb5_c_prf(krb5_context context,
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_c_random_make_octets(krb5_context context, krb5_data * data)
 {
-    krb5_generate_random_block(context, data->length, data->data);
+    krb5_generate_random_block(data->data, data->length);
     return 0;
 }
 


### PR DESCRIPTION
The function, found in `lib/krb5/mit_glue.c`, is currently using `krb5_generate_random_keyblock()`. This compiles because warning-level is not high enough, but does not work. At runtime the `krb5_generate_random_keyblock()` interprets the second argument as the `krb5_enctype` (rather than a _length_ of anything) and tries to verify it.

When the length does not match any known enctype, as usually happens, the function fails and returns an error. If the length happened to correspond to an enctype, the function would likely crash due to misinterpreting its third argument as a valid `krb5_keyblock`.

The change uses `krb5_generate_random_block()` instead. This function does not return anything -- upon detecting failure it will cause the entire application to exist instead...