### PR TITLE
Remove duplicate symbols from libroken version-script.map

### DIFF
--- a/lib/hx509/version-script.map
+++ b/lib/hx509/version-script.map
@@ -23,7 +23,6 @@ HEIMDAL_X509_1.2 {
 		_hx509_request_print;
 		_hx509_request_set_email;
 		_hx509_request_to_pkcs10;
-		_hx509_request_to_pkcs10;
 		_hx509_unmap_file_os;
 		_hx509_write_file;
 		hx509_bitstring_print;

--- a/lib/roken/version-script.map
+++ b/lib/roken/version-script.map
@@ -128,19 +128,14 @@ HEIMDAL_ROKEN_1.0 {
 		rk_strptime;
 		rk_strsep_copy;
 		rk_strsvis;
-		rk_strsvis;
 		rk_strsvisx;
 		rk_strtoll;
 		rk_strtoull;
 		rk_strunvis;
-		rk_strunvis;
 		rk_strunvisx;
 		rk_strupr;
 		rk_strvis;
-		rk_strvis;
 		rk_strvisx;
-		rk_strvisx;
-		rk_svis;
 		rk_svis;
 		rk_timegm;
 		rk_timevaladd;
@@ -154,7 +149,6 @@ HEIMDAL_ROKEN_1.0 {
 		rk_unvis;
 		rk_vasnprintf;
 		rk_vasprintf;
-		rk_vis;
 		rk_vis;
 		rk_vsnprintf;
 		rk_vstrcollect;


### PR DESCRIPTION
Commit efed5633 (r24759) prefixed some symbols with rk_, but introduced 6 duplicate symbols in the version script (because the rk_-prefixed versions of the symbols were already present).