### PR TITLE
Merge fixes from Dell into heimdal master

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,6 +240,7 @@ AC_ARG_ENABLE([afs-support],
 if test "$enable_afs_support" = no; then
 	AC_DEFINE(NO_AFS, 1, [Define if you don't wan't support for AFS.])
 	NO_AFS="1"
+	AM_CONDITIONAL(HAVE_AFS, 0)
 fi
 AC_SUBST(NO_AFS)dnl
 

--- a/kuser/Makefile.am
+++ b/kuser/Makefile.am
@@ -2,6 +2,10 @@
 
 include $(top_srcdir)/Makefile.am.common
 
+if HAVE_AFS
+afs_lib = $(LIB_kafs)
+endif
+
 AM_CPPFLAGS += -I$(srcdir)/../lib/krb5 \
 	$(INCLUDE_libintl) \
 	-DHEIMDAL_LOCALEDIR='"$(localedir)"'
@@ -21,7 +25,7 @@ libexec_PROGRAMS = kdigest kimpersonate
 noinst_PROGRAMS = kverify kdecode_ticket generate-requests
 
 kinit_LDADD = \
-	$(LIB_kafs) \
+	$(afs_lib) \
 	$(top_builddir)/lib/krb5/libkrb5.la \
 	$(top_builddir)/lib/ntlm/libheimntlm.la \
 	$(LIB_hcrypto) \

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -890,7 +890,7 @@ static time_t
 renew_func(void *ptr)
 {
     krb5_error_code ret;
-    struct renew_ctx *ctx = ptr;
+    struct renew_ctx *ctx = (struct renew_ctx *) ptr;
     time_t renew_expire;
     static time_t exp_delay = 1;
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -20,6 +20,9 @@ endif
 if MAINTAINER_MODE
 dir_sqlite = sqlite
 endif
+if HAVE_AFS
+dir_afs = kafs
+endif
 
 SUBDIRS = \
 	roken \
@@ -36,7 +39,7 @@ SUBDIRS = \
 	hx509 \
 	krb5 \
 	ntlm \
-	kafs \
+	$(dir_afs) \
 	gssapi \
 	hdb \
 	kadm5 \

--- a/lib/base/bsearch.c
+++ b/lib/base/bsearch.c
@@ -82,15 +82,6 @@
  * _bsearch_file() is the interface for block-wise searching files.
  */
 
-struct bsearch_file_handle {
-    int fd;          /* file descriptor */
-    char *cache;     /* cache bytes */
-    char *page;      /* one double-size page worth of bytes */
-    size_t file_sz;  /* file size */
-    size_t cache_sz; /* cache size */
-    size_t page_sz;  /* page size */
-};
-
 /* Find a new-line */
 static const char *
 find_line(const char *buf, size_t i, size_t right)

--- a/lib/base/heimbase.h
+++ b/lib/base/heimbase.h
@@ -407,7 +407,14 @@ heim_description(heim_object_t ptr);
  *
  * Note: these are private until integrated into the heimbase object system.
  */
-typedef struct bsearch_file_handle *bsearch_file_handle;
+typedef struct _bsearch_file_handle {
+    int fd;          /* file descriptor */
+    char *cache;     /* cache bytes */
+    char *page;      /* one double-size page worth of bytes */
+    size_t file_sz;  /* file size */
+    size_t cache_sz; /* cache size */
+    size_t page_sz;  /* page size */
+} *bsearch_file_handle;
 int _bsearch_text(const char *buf, size_t buf_sz, const char *key,
 		   char **value, size_t *location, size_t *loops);
 int _bsearch_file_open(const char *fname, size_t max_sz, size_t page_sz,

--- a/lib/gssapi/mech/gss_display_status.c
+++ b/lib/gssapi/mech/gss_display_status.c
@@ -179,7 +179,7 @@ gss_display_status(OM_uint32 *minor_status,
 	switch (status_type) {
 	case GSS_C_GSS_CODE: {
 	    	char *buf = NULL;
-		int e;
+		int e = 0;
 
 		if (GSS_SUPPLEMENTARY_INFO(status_value))
 		    e = asprintf(&buf, "%s", supplementary_error(
@@ -201,7 +201,7 @@ gss_display_status(OM_uint32 *minor_status,
 		OM_uint32 maj_junk, min_junk;
 		gss_buffer_desc oid;
 		char *buf = NULL;
-		int e;
+		int e = 0;
 
 		maj_junk = gss_oid_to_str(&min_junk, mech_type, &oid);
 		if (maj_junk != GSS_S_COMPLETE) {

--- a/lib/hcrypto/Makefile.am
+++ b/lib/hcrypto/Makefile.am
@@ -335,7 +335,6 @@ EXTRA_DIST = \
 	DESperate.txt \
 	passwd_dialog.rc \
 	libhcrypto-exports.def \
-	dllmain.c \
 	ec.h \
 	ecdh.h \
 	ecdsa.h \

--- a/lib/hcrypto/evp-openssl.c
+++ b/lib/hcrypto/evp-openssl.c
@@ -38,8 +38,6 @@
 #include <assert.h>
 #include <evp.h>
 
-#ifdef HAVE_HCRYPTO_W_OPENSSL
-
 /*
  * This is the OpenSSL 1.x backend for hcrypto.  It has been tested with
  * OpenSSL 1.0.1f and OpenSSL 1.1.0-pre3-dev.
@@ -50,6 +48,8 @@
  */
 
 #include <evp-openssl.h>
+
+#ifdef HAVE_HCRYPTO_W_OPENSSL
 
 /*
  * This being an OpenSSL backend for hcrypto... we need to be able to

--- a/lib/hcrypto/evp.c
+++ b/lib/hcrypto/evp.c
@@ -44,7 +44,9 @@
 #include <evp.h>
 #include <evp-hcrypto.h>
 #include <evp-cc.h>
+#if _WIN32_
 #include <evp-w32.h>
+#endif
 #include <evp-pkcs11.h>
 #include <evp-openssl.h>
 

--- a/lib/hcrypto/test_bulk.c
+++ b/lib/hcrypto/test_bulk.c
@@ -39,7 +39,9 @@
 #include <evp.h>
 #include <evp-hcrypto.h>
 #include <evp-cc.h>
+#if _WIN32_
 #include <evp-w32.h>
+#endif
 #include <evp-pkcs11.h>
 #include <hex.h>
 #include <err.h>

--- a/lib/hcrypto/test_cipher.c
+++ b/lib/hcrypto/test_cipher.c
@@ -41,7 +41,9 @@
 #include <evp.h>
 #include <evp-hcrypto.h>
 #include <evp-cc.h>
+#if _WIN32_
 #include <evp-w32.h>
+#endif
 #include <evp-pkcs11.h>
 #include <evp-openssl.h>
 #include <hex.h>

--- a/lib/hcrypto/validate.c
+++ b/lib/hcrypto/validate.c
@@ -247,8 +247,8 @@ test_cipher(struct tests *t)
     if (memcmp(d, t->indata, t->datasize) != 0)
 	errx(1, "%s: decrypt not the same", t->name);
 
-    if (t->outiv)
-	/* XXXX check  */;
+    if (t->outiv) { }
+	/* XXXX check  */
 
     EVP_CIPHER_CTX_cleanup(&ectx);
     EVP_CIPHER_CTX_cleanup(&dctx);

--- a/lib/roken/getifaddrs.c
+++ b/lib/roken/getifaddrs.c
@@ -1071,7 +1071,7 @@ getlifaddrs2(struct ifaddrs **ifap,
 	size_t salen;
 
 	ifr = (struct lifreq *)p;
-	sa  = &ifr->lifr_addr;
+	sa  = (struct sockaddr_storage *)&ifr->lifr_addr;
 
 	sz = ifreq_sz;
 	salen = sizeof(struct sockaddr_storage);
@@ -1159,6 +1159,7 @@ getlifaddrs2(struct ifaddrs **ifap,
  * Either may be NULL. The new list head (usually base) will be
  * returned.
  */
+#if defined(HAVE_IPV6) && defined(SIOCGLIFCONF) && defined(SIOCGLIFFLAGS)
 static struct ifaddrs *
 append_ifaddrs(struct ifaddrs *base, struct ifaddrs *supp) {
     if (!base)
@@ -1174,6 +1175,7 @@ append_ifaddrs(struct ifaddrs *base, struct ifaddrs *supp) {
 
     return base;
 }
+#endif
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
 rk_getifaddrs(struct ifaddrs **ifap)

--- a/lib/roken/getxxyyy.c
+++ b/lib/roken/getxxyyy.c
@@ -53,7 +53,7 @@ rk_getpwnam_r(const char *name, struct passwd *pwd, char *buffer,
 	      size_t bufsize, struct passwd **result)
 {
      struct passwd *p;
-     size_t slen, n = 0;
+     size_t slen;
      
      *result = NULL;
 

--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -1230,6 +1230,7 @@ int ROKEN_LIB_FUNCTION rk_socket(int, int, int);
 #endif
 
 /* Microsoft VC 2010 POSIX definitions */
+#if _WIN32_
 #ifndef EAFNOSUPPORT
 #define EAFNOSUPPORT            102
 #endif
@@ -1254,7 +1255,7 @@ int ROKEN_LIB_FUNCTION rk_socket(int, int, int);
 #ifndef EWOULDBLOCK
 #define EWOULDBLOCK             140
 #endif
-
+#endif
 
 #ifdef SOCKET_WRAPPER_REPLACE
 #include <socket_wrapper.h>

--- a/lib/roken/strtoll.c
+++ b/lib/roken/strtoll.c
@@ -46,6 +46,18 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#ifndef LLONG_MAX
+
+/* HPUX defines this LONG_LONG_MAX, not LLONG_MAX */
+#ifdef LONG_LONG_MAX
+# define LLONG_MAX LONG_LONG_MAX
+#else
+#error NO LONG LONG MAX VALUE AVAILABLE - FIX THIS FOR YOUR PLATFORM SPECIFIC DEFINE!!
+#endif
+
+# define LLONG_MIN (-LLONG_MAX - 1LL)
+#endif
+
 /*
  * Convert a string to a long long integer.
  *

--- a/lib/roken/strtoull.c
+++ b/lib/roken/strtoull.c
@@ -46,6 +46,17 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#ifndef ULLONG_MAX
+
+/* HPUX defines this here */
+#ifdef ULONG_LONG_MAX
+# define ULLONG_MAX ULONG_LONG_MAX
+#else
+#error NO ULONG LONG MAX VALUE AVAILABLE - FIX THIS FOR YOUR PLATFORM SPECIFIC DEFINE!!
+#endif
+
+#endif
+
 /*
  * Convert a string to an unsigned long long integer.
  *


### PR DESCRIPTION
A small sample of fixes in Dell's heimdal branch. More will follow after extensive code review.
- The --disable-afs-support doesn't really disable afs. It still gets built, and kinit still links to it, although it doesn't use it.
- Plus various fixes for compiler errors on various platforms (mostly hpux, aix, solaris, and mac).