### PR TITLE
--disable-afs-support doesn't really disable afs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,6 +240,7 @@ AC_ARG_ENABLE([afs-support],
 if test "$enable_afs_support" = no; then
 	AC_DEFINE(NO_AFS, 1, [Define if you don't wan't support for AFS.])
 	NO_AFS="1"
+	AM_CONDITIONAL(HAVE_AFS, 0)
 fi
 AC_SUBST(NO_AFS)dnl
 

--- a/kuser/Makefile.am
+++ b/kuser/Makefile.am
@@ -2,6 +2,10 @@
 
 include $(top_srcdir)/Makefile.am.common
 
+if HAVE_AFS
+afs_lib = $(LIB_kafs)
+endif
+
 AM_CPPFLAGS += -I$(srcdir)/../lib/krb5 \
 	$(INCLUDE_libintl) \
 	-DHEIMDAL_LOCALEDIR='"$(localedir)"'
@@ -21,7 +25,7 @@ libexec_PROGRAMS = kdigest kimpersonate
 noinst_PROGRAMS = kverify kdecode_ticket generate-requests
 
 kinit_LDADD = \
-	$(LIB_kafs) \
+	$(afs_lib) \
 	$(top_builddir)/lib/krb5/libkrb5.la \
 	$(top_builddir)/lib/ntlm/libheimntlm.la \
 	$(LIB_hcrypto) \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -20,6 +20,9 @@ endif
 if MAINTAINER_MODE
 dir_sqlite = sqlite
 endif
+if HAVE_AFS
+dir_afs = kafs
+endif
 
 SUBDIRS = \
 	roken \
@@ -36,7 +39,7 @@ SUBDIRS = \
 	hx509 \
 	krb5 \
 	ntlm \
-	kafs \
+	$(dir_afs) \
 	gssapi \
 	hdb \
 	kadm5 \


### PR DESCRIPTION
The --disable-afs-support configure flag doesn't really disable afs. It still gets built, and kinit still links to it, although it doesn't use it.