### PR TITLE
The evp-w32.h header should not be included on all platforms

### DIFF
--- a/lib/hcrypto/evp.c
+++ b/lib/hcrypto/evp.c
@@ -44,7 +44,9 @@
 #include <evp.h>
 #include <evp-hcrypto.h>
 #include <evp-cc.h>
+#if _WIN32
 #include <evp-w32.h>
+#endif
 #include <evp-pkcs11.h>
 #include <evp-openssl.h>
 

--- a/lib/hcrypto/test_bulk.c
+++ b/lib/hcrypto/test_bulk.c
@@ -39,7 +39,9 @@
 #include <evp.h>
 #include <evp-hcrypto.h>
 #include <evp-cc.h>
+#if _WIN32
 #include <evp-w32.h>
+#endif
 #include <evp-pkcs11.h>
 #include <hex.h>
 #include <err.h>

--- a/lib/hcrypto/test_cipher.c
+++ b/lib/hcrypto/test_cipher.c
@@ -41,7 +41,9 @@
 #include <evp.h>
 #include <evp-hcrypto.h>
 #include <evp-cc.h>
+#if _WIN32
 #include <evp-w32.h>
+#endif
 #include <evp-pkcs11.h>
 #include <evp-openssl.h>
 #include <hex.h>


### PR DESCRIPTION
This caused undefined symbol errors on multiple platforms. I can't remember which. Seems like it was x86 solaris and ia64 hpux.
gcc 4.6.1