### PR TITLE
Redefinition errors on ppc64 linux

### DIFF
--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -1230,6 +1230,7 @@ int ROKEN_LIB_FUNCTION rk_socket(int, int, int);
 #endif
 
 /* Microsoft VC 2010 POSIX definitions */
+#if _WIN32_
 #ifndef EAFNOSUPPORT
 #define EAFNOSUPPORT            102
 #endif
@@ -1253,6 +1254,7 @@ int ROKEN_LIB_FUNCTION rk_socket(int, int, int);
 #endif
 #ifndef EWOULDBLOCK
 #define EWOULDBLOCK             140
+#endif
 #endif
 
 


### PR DESCRIPTION
These defines cause redefinition warnings on most platforms/compilers. On ppc64 linux with gcc 4.7 it caused an error.