### PR TITLE
Solaris 8 x86 uses ->d_fd not ->dd_fd or dirfd()

### DIFF
--- a/cf/roken-frag.m4
+++ b/cf/roken-frag.m4
@@ -435,6 +435,10 @@ AC_HAVE_STRUCT_FIELD(DIR, dd_fd, [#include <sys/types.h>
 #include <dirent.h>
 #endif])
 
+AC_HAVE_STRUCT_FIELD(DIR, d_fd, [#include <sys/types.h>
+#ifdef HAVE_DIRENT_H
+#include <dirent.h>
+#endif])
 
 AC_BROKEN2(inet_aton,
 [#ifdef HAVE_SYS_TYPES_H

--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -801,9 +801,11 @@ int rk_flock(int fd, int operation);
 #ifndef HAVE_DIRFD
 #ifdef HAVE_DIR_DD_FD
 #define dirfd(x) ((x)->dd_fd)
+#elif defined(HAVE_DIR_D_FD)
+#define dirfd(x) ((x)->d_fd)
 #else
 #ifndef _WIN32 /* Windows code never calls dirfd */
-#error Missing dirfd() and ->dd_fd
+#error Missing dirfd() and ->dd_fd and ->d_fd
 #endif
 #endif
 #endif


### PR DESCRIPTION
Here's a stack overflow article for reference:
http://stackoverflow.com/questions/28022507/solaris-10-alternative-to-dirfd

On Solaris 8 x86 there is no dirfd() or ->dd_fd, so we need to check for ->d_fd also.
