### PR TITLE
solaris 8 sparc defines _LP64 to empty, causing build failure

### DIFF
--- a/lib/hcrypto/evp-pkcs11.c
+++ b/lib/hcrypto/evp-pkcs11.c
@@ -60,7 +60,7 @@
 #include <ref/pkcs11.h>
 
 #if __sun && !defined(PKCS11_MODULE_PATH)
-# if _LP64
+# ifdef _LP64
 # define PKCS11_MODULE_PATH "/usr/lib/64/libpkcs11.so"
 # else
 # define PKCS11_MODULE_PATH "/usr/lib/libpkcs11.so"


### PR DESCRIPTION
When building with -m64 on solaris 8 sparc, the build fails with:
evp-pkcs11.c:63:11: error: #if with no expression

On solaris 8, _LP64 is defined as nothing, so we need to check if it's defined, not if it is defined as 1.

gcc 4.6.1
