### PR TITLE
krb5_check_transited() ret variable is unused

### DIFF
--- a/lib/krb5/transited.c
+++ b/lib/krb5/transited.c
@@ -447,7 +447,7 @@ hier_init(struct hier_iter *state, const char *local_realm, const char *server_r
 {
     size_t llen;
     size_t slen;
-    size_t len;
+    size_t len = 0;
     const char *lr;
     const char *sr;
 
@@ -604,13 +604,12 @@ krb5_check_transited(krb5_context context,
 		     unsigned int num_realms,
 		     int *bad_realm)
 {
-    krb5_error_code ret = 0;
     char **capath = NULL;
     size_t num_capath = 0;
     size_t i = 0;
     size_t j = 0;
 
-    ret = _krb5_find_capath(context, client_realm, client_realm, server_realm,
+    _krb5_find_capath(context, client_realm, client_realm, server_realm,
                             TRUE, &capath, &num_capath);
 
     for (i = 0; i < num_realms; i++) {


### PR DESCRIPTION
On aix 5.3 and solaris 10 x64

transited.c: In function 'krb5_check_transited':
transited.c:607:21: error: variable 'ret' set but not used [-Werror=unused-but-set-variable]
cc1: all warnings being treated as errors

gcc 4.6.2 on both systems.

Also,

transited.c: In function '_krb5_find_capath':
transited.c:487:16: error: 'len' may be used uninitialized in this function [-Werror=uninitialized]
transited.c:450:12: note: 'len' was declared here

Same systems and gcc

Fixing commit 1501740952a815fbe10ab8345bb38cfb0ded9504