### PR TITLE
Properly define the NO_AFS AM_CONDITIONAL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,9 +240,9 @@ AC_ARG_ENABLE([afs-support],
 if test "$enable_afs_support" = no; then
 	AC_DEFINE(NO_AFS, 1, [Define if you don't wan't support for AFS.])
 	NO_AFS="1"
-	AM_CONDITIONAL(NO_AFS, 1)
 fi
 AC_SUBST(NO_AFS)dnl
+AM_CONDITIONAL(NO_AFS, test "$enable_afs_support" = no)
 
 rk_DB
 


### PR DESCRIPTION
My fix in d8080162eab578337de08637faed39106efdc557 turns off AFS all the time. @nicowilliams fix in 6d1571a3c4e4f126e6527b00e2ee7cf5b22b7b11 leaves AFS on always.

This is the proper way to define the AM_CONDITIONAL. I tested this with and without the --disable-afs-support flag, and it now behaves correctly.