### PR TITLE
Related to vas segfault from re-defining krb5_krbhst_data

### DIFF
--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -805,16 +805,6 @@ typedef struct krb5_verify_opt {
 
 #define KPASSWD_PORT 464
 
-/* types for the new krbhst interface */
-struct krb5_krbhst_data;
-typedef struct krb5_krbhst_data *krb5_krbhst_handle;
-
-#define KRB5_KRBHST_KDC		1
-#define KRB5_KRBHST_ADMIN	2
-#define KRB5_KRBHST_CHANGEPW	3
-#define KRB5_KRBHST_KRB524	4
-#define KRB5_KRBHST_KCA		5
-
 typedef struct krb5_krbhst_info {
     enum { KRB5_KRBHST_UDP,
 	   KRB5_KRBHST_TCP,
@@ -825,6 +815,37 @@ typedef struct krb5_krbhst_info {
     struct krb5_krbhst_info *next;
     char hostname[1]; /* has to come last */
 } krb5_krbhst_info;
+
+/* types for the new krbhst interface */
+struct krb5_krbhst_data {
+    char *realm;
+    unsigned int flags;
+    int def_port;
+    int port;           /* hardwired port number if != 0 */
+#define KD_CONFIG        1
+#define KD_SRV_UDP       2
+#define KD_SRV_TCP       4
+#define KD_SRV_HTTP      8
+#define KD_FALLBACK     16
+#define KD_CONFIG_EXISTS    32
+#define KD_LARGE_MSG        64
+#define KD_PLUGIN          128
+#define KD_HOSTNAMES           256
+    krb5_error_code (*get_next)(krb5_context, struct krb5_krbhst_data *,
+                krb5_krbhst_info**);
+
+    char *hostname;
+    unsigned int fallback_count;
+
+    struct krb5_krbhst_info *hosts, **index, **end;
+};
+typedef struct krb5_krbhst_data *krb5_krbhst_handle;
+
+#define KRB5_KRBHST_KDC		1
+#define KRB5_KRBHST_ADMIN	2
+#define KRB5_KRBHST_CHANGEPW	3
+#define KRB5_KRBHST_KRB524	4
+#define KRB5_KRBHST_KCA		5
 
 /* flags for krb5_krbhst_init_flags (and krb5_send_to_kdc_flags) */
 enum {

--- a/lib/krb5/krbhst.c
+++ b/lib/krb5/krbhst.c
@@ -161,30 +161,6 @@ srv_find_realm(krb5_context context, krb5_krbhst_info ***res, int *count,
     return 0;
 }
 
-
-struct krb5_krbhst_data {
-    char *realm;
-    unsigned int flags;
-    int def_port;
-    int port;			/* hardwired port number if != 0 */
-#define KD_CONFIG		 1
-#define KD_SRV_UDP		 2
-#define KD_SRV_TCP		 4
-#define KD_SRV_HTTP		 8
-#define KD_FALLBACK		16
-#define KD_CONFIG_EXISTS	32
-#define KD_LARGE_MSG		64
-#define KD_PLUGIN	       128
-#define KD_HOSTNAMES	       256
-    krb5_error_code (*get_next)(krb5_context, struct krb5_krbhst_data *,
-				krb5_krbhst_info**);
-
-    char *hostname;
-    unsigned int fallback_count;
-
-    struct krb5_krbhst_info *hosts, **index, **end;
-};
-
 static krb5_boolean
 krbhst_empty(const struct krb5_krbhst_data *kd)
 {


### PR DESCRIPTION
At some point a VAS dev re-defined krb5_krbhst_data because we only get a stub from the header file. When I updated our heimdal version, the VAS re-definition was different from the heimdal definition, which ended up corrupting some values in the structure when passed to VAS source.

I moved the definition of krb5_krbhst_data into krb5.h to solve that problem, but figured I'd push this upstream since it just makes since to be there instead of in the source file.