### PR TITLE
On hpux, pthread_cond_t is undefined when pthread is disabled

### DIFF
--- a/lib/ipc/common.c
+++ b/lib/ipc/common.c
@@ -94,7 +94,9 @@ _heim_ipc_create_cred(uid_t uid, gid_t gid, pid_t pid, pid_t session, heim_icred
 #ifndef HAVE_GCD
 struct heim_isemaphore {
     HEIMDAL_MUTEX mutex;
+#ifdef ENABLE_PTHREAD_SUPPORT
     pthread_cond_t cond;
+#endif
     long counter;
 };
 #endif


### PR DESCRIPTION
Since pthread_cond_t is undefined, if I disable pthread with --disable-pthread-support, it should try to create this struct. It isn't used anyway, since the only place it's used is inside a #if ENABLE_PTHREAD_SUPPORT block.

I think this was on hpux pa 11.11 with gcc 4.7.1.
