### PR TITLE
Enable threads on FreeBSD 10 and 11

### DIFF
--- a/cf/pthreads.m4
+++ b/cf/pthreads.m4
@@ -30,7 +30,9 @@ case "$host" in
 	dnl heim_threads.h knows this
 	PTHREAD_LIBADD="-lpthread"
 	;;
-*-*-freebsd[[56789]]*)
+*-*-freebsd[[1234]])
+    ;;
+*-*-freebsd*)
 	native_pthread_support=yes
 	PTHREAD_LIBADD="-pthread"
 	;;


### PR DESCRIPTION
`freebsd[56789]*)` will not match `freebsd10` and `freebsd11`
