### PR TITLE
[WIP] HAVE_DB3 and HAVE_DB1 conflict when both defined

### DIFF
--- a/cf/db.m4
+++ b/cf/db.m4
@@ -59,7 +59,7 @@ AS_IF([test "x$with_berkeley_db" != xno],
 
 dnl db_create is used by db3 and db4 and db5
 
-  AC_FIND_FUNC_NO_LIBS(db_create, [$dbheader] db5 db4 db3 db, [
+  AC_FIND_FUNC_NO_LIBS(db_create, [$dbheader] db-5 db5 db4 db3 db, [
   #include <stdio.h>
   #ifdef HAVE_DBHEADER
   #include <$dbheader/db.h>

--- a/lib/hdb/db.c
+++ b/lib/hdb/db.c
@@ -33,7 +33,7 @@
 
 #include "hdb_locl.h"
 
-#if HAVE_DB1
+#if defined(HAVE_DB1) && !defined(HAVE_DB3)
 
 #if defined(HAVE_DB_185_H)
 #include <db_185.h>
@@ -376,4 +376,4 @@ hdb_db_create(krb5_context context, HDB **db,
     return 0;
 }
 
-#endif /* HAVE_DB1 */
+#endif /* defined(HAVE_DB1) && !defined(HAVE_DB3) */

--- a/lib/otp/Makefile.am
+++ b/lib/otp/Makefile.am
@@ -19,13 +19,13 @@ lib_LTLIBRARIES = libotp.la
 libotp_la_LDFLAGS = -version-info 1:5:1
 libotp_la_LIBADD  = $(LIB_hcrypto) $(LIB_roken)
 
-if HAVE_DB1
-ndbm_wrap = ndbm_wrap.c ndbm_wrap.h
-libotp_la_LIBADD += $(DB1LIB)
-else
 if HAVE_DB3
 ndbm_wrap = ndbm_wrap.c ndbm_wrap.h
 libotp_la_LIBADD += $(DB3LIB)
+else
+if HAVE_DB1
+ndbm_wrap = ndbm_wrap.c ndbm_wrap.h
+libotp_la_LIBADD += $(DB1LIB)
 else
 ndbm_wrap =
 libotp_la_LIBADD += $(NDBMLIB)


### PR DESCRIPTION
On my FreeBSD system I have the folowing Berkeley DB
packages installed:

db41-4.1.25_4                  The Berkeley DB package, revision 4.1
db42-4.2.52_5                  The Berkeley DB package, revision 4.2
db48-4.8.30.0_2                Berkeley DB package, revision 4.8
db5-5.3.28_4                   Oracle Berkeley DB, revision 5.3

The last one has uses /usr/local/lib/libdb-5.so naming
scheme, unlike the previous version.

DB1-compatible interface also gets detected, so HAVE_DB1
and HAVE_DB3 also get defined, leading to conflicting symbols.
