### PR TITLE
Use C99 designated initializers in a couple places

### DIFF
--- a/lib/hcrypto/rand-fortuna.c
+++ b/lib/hcrypto/rand-fortuna.c
@@ -622,6 +622,16 @@ fortuna_status(void)
     return result ? 1 : 0;
 }
 
+#if defined(__GUNC__) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901)
+const RAND_METHOD hc_rand_fortuna_method = {
+    .seed = fortuna_seed,
+    .bytes = fortuna_bytes,
+    .cleanup = fortuna_cleanup,
+    .add = fortuna_add,
+    .pseudorand = fortuna_pseudorand,
+    .status = fortuna_status
+};
+#else
 const RAND_METHOD hc_rand_fortuna_method = {
     fortuna_seed,
     fortuna_bytes,
@@ -630,6 +640,7 @@ const RAND_METHOD hc_rand_fortuna_method = {
     fortuna_pseudorand,
     fortuna_status
 };
+#endif
 
 const RAND_METHOD *
 RAND_fortuna_method(void)

--- a/lib/hcrypto/rand-timer.c
+++ b/lib/hcrypto/rand-timer.c
@@ -183,6 +183,16 @@ timer_status(void)
 #endif
 }
 
+#if defined(__GUNC__) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901)
+const RAND_METHOD hc_rand_timer_method = {
+    .seed = timer_seed,
+    .bytes = timer_bytes,
+    .cleanup = timer_cleanup,
+    .add = timer_add,
+    .pseudorand = timer_pseudorand,
+    .status = timer_status
+};
+#else
 const RAND_METHOD hc_rand_timer_method = {
     timer_seed,
     timer_bytes,
@@ -191,6 +201,7 @@ const RAND_METHOD hc_rand_timer_method = {
     timer_pseudorand,
     timer_status
 };
+#endif
 
 const RAND_METHOD *
 RAND_timer_method(void)


### PR DESCRIPTION
I had considered preparing a broader change to use designated initializers everywhere, or everywhere in hcrypto, but it's unclear that the benefit of designated initializers is worth the global churn, so I figured I would make a pull request with the targeted changes and see what response it got.
