### PR TITLE
default life/renewlife time to KDC policy

### DIFF
--- a/kcm/config.c
+++ b/kcm/config.c
@@ -270,7 +270,7 @@ ccache_init_system(void)
 	renew_life = kcm_system_config_get_string("renew_life");
 
     if (renew_life == NULL)
-	renew_life = "1 month";
+	renew_life = "2147483647s";
 
     if (renew_life != NULL) {
 	ccache->renew_life = parse_time(renew_life, "s");

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -553,7 +553,7 @@ get_new_tickets(krb5_context context,
 						addrs_flag ? FALSE : TRUE);
 
     if (renew_life == NULL && renewable_flag)
-	renewstr = "1 month";
+	renewstr = "2147483647s";
     if (renew_life)
 	renewstr = renew_life;
     if (renewstr) {

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -249,9 +249,12 @@ init_cred (krb5_context context,
 	tmp = KRB5_TKT_LIFETIME_DEFAULT;
     cred->times.endtime = now + tmp;
 
-    if ((options->flags & KRB5_GET_INIT_CREDS_OPT_RENEW_LIFE) &&
-	options->renew_life > 0) {
-	cred->times.renew_till = now + options->renew_life;
+    if (options->flags & KRB5_GET_INIT_CREDS_OPT_RENEW_LIFE) {
+	if (options->renew_life > 0)
+	    tmp = options->renew_life;
+	else
+	    tmp = KRB5_TKT_RENEW_LIFETIME_DEFAULT;
+	cred->times.renew_till = now + tmp;
     }
 
     return 0;

--- a/lib/krb5/krb5_locl.h
+++ b/lib/krb5/krb5_locl.h
@@ -322,7 +322,11 @@ typedef struct krb5_context_data {
 #endif
 
 #ifndef KRB5_TKT_LIFETIME_DEFAULT
-# define KRB5_TKT_LIFETIME_DEFAULT	(10 * 60 * 60)	/* 10 hours */
+# define KRB5_TKT_LIFETIME_DEFAULT	2147483647	/* seconds */
+#endif
+
+#ifndef KRB5_TKT_RENEW_LIFETIME_DEFAULT
+# define KRB5_TKT_RENEW_LIFETIME_DEFAULT 2147483647	/* seconds */
 #endif
 
 #ifdef PKINIT


### PR DESCRIPTION
Instead of imposing a default 10 hour ticket lifetime and 1 month renew
lifetime when requesting tickets, increase the default lifetime and
renew lifetime to 2147483647 seconds.  This ensures that in the absence
of any other configuration or command line parameters that the KDC will
determine the ticket lifetime and renew lifetime.

Change-Id: I52b6eeac1ee830a9bf4d0130e8f4ec7b70bc8694