### PR TITLE
Increase timeout when waiting for iprop-slave.

### DIFF
--- a/tests/kdc/wait-kdc.sh
+++ b/tests/kdc/wait-kdc.sh
@@ -36,7 +36,7 @@ log=${2:-messages.log}
 waitfor="${3:-${name} started}"
 
 t=0
-waitsec=35
+waitsec=65
 
 echo "Waiting for ${name} to start, looking logfile ${log}"
 


### PR DESCRIPTION
This is required when running on slower platforms. In Debian, we're hitting the timeout building on mips.