### PR TITLE
Use actual libdir/includedir in heimdal-gssapi.pc.

### DIFF
--- a/tools/heimdal-gssapi.pc.in
+++ b/tools/heimdal-gssapi.pc.in
@@ -1,8 +1,8 @@
 # $Id$
 prefix=@prefix@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+libdir=@libdir@
+includedir=@includedir@
 
 Name: @PACKAGE@
 Description: Heimdal is an implementation of Kerberos 5, freely available under a three clause BSD style license.


### PR DESCRIPTION
This fixes the library path on e.g. systems like Debian which specify a custom --includedir and --libdir to configure.
