### PR TITLE
Do not detect x32 as 64-bit platform.

### DIFF
--- a/lib/hcrypto/libtommath/tommath.h
+++ b/lib/hcrypto/libtommath/tommath.h
@@ -46,7 +46,7 @@ extern "C" {
 
 
 /* detect 64-bit mode if possible */
-#if defined(__x86_64__)
+#if defined(__x86_64__) && !defined(__ILP32__)
    #if !(defined(MP_64BIT) && defined(MP_16BIT) && defined(MP_8BIT))
       #define MP_64BIT
    #endif


### PR DESCRIPTION
Fixes test failures due to ISO C Undefined Behaviour in MP_MASK macro.

Thorsten is also forwarding this to upstream libtommath.