### PR TITLE
Fix signature of hdb_generate_key_set_password()

### DIFF
--- a/lib/hdb/keys.c
+++ b/lib/hdb/keys.c
@@ -772,11 +772,12 @@ hdb_generate_key_set(krb5_context context, krb5_principal principal,
 
 
 krb5_error_code
-hdb_generate_key_set_password(krb5_context context,
-			      krb5_principal principal,
-			      const char *password,
-			      krb5_key_salt_tuple *ks_tuple, int n_ks_tuple,
-			      Key **keys, size_t *num_keys)
+hdb_generate_key_set_password_with_ks_tuple(krb5_context context,
+					    krb5_principal principal,
+					    const char *password,
+					    krb5_key_salt_tuple *ks_tuple,
+					    int n_ks_tuple,
+					    Key **keys, size_t *num_keys)
 {
     krb5_error_code ret;
     size_t i;
@@ -808,4 +809,17 @@ hdb_generate_key_set_password(krb5_context context,
 	return ret;
     }
     return ret;
+}
+
+
+krb5_error_code
+hdb_generate_key_set_password(krb5_context context,
+			      krb5_principal principal,
+			      const char *password,
+			      Key **keys, size_t *num_keys)
+{
+
+    return hdb_generate_key_set_password_with_ks_tuple(context, principal,
+						       password, NULL, 0,
+						       keys, num_keys);
 }

--- a/lib/hdb/test_hdbkeys.c
+++ b/lib/hdb/test_hdbkeys.c
@@ -94,7 +94,7 @@ main(int argc, char **argv)
     *keyset.set_time = time(NULL);
 
     ret = hdb_generate_key_set_password(context, principal, password_str,
-					NULL, 0, &keyset.keys.val, &len);
+					&keyset.keys.val, &len);
     if (ret)
 	krb5_err(context, 1, ret, "hdb_generate_key_set_password");
     keyset.keys.len = len;

--- a/lib/hdb/version-script.map
+++ b/lib/hdb/version-script.map
@@ -44,6 +44,7 @@ HEIMDAL_HDB_1.0 {
 		hdb_free_master_key;
 		hdb_generate_key_set;
 		hdb_generate_key_set_password;
+		hdb_generate_key_set_password_with_ks_tuple;
 		hdb_get_dbinfo;
 		hdb_init_db;
 		hdb_key2principal;

--- a/lib/kadm5/set_keys.c
+++ b/lib/kadm5/set_keys.c
@@ -50,11 +50,11 @@ _kadm5_set_keys(kadm5_server_context *context,
     size_t num_keys;
     kadm5_ret_t ret;
 
-    ret = hdb_generate_key_set_password(context->context,
-					ent->principal,
-					password,
-					ks_tuple, n_ks_tuple,
-					&keys, &num_keys);
+    ret = hdb_generate_key_set_password_with_ks_tuple(context->context,
+						      ent->principal,
+						      password,
+						      ks_tuple, n_ks_tuple,
+						      &keys, &num_keys);
     if (ret)
 	return ret;
 


### PR DESCRIPTION
The change to the signature of hdb_generate_key_set_password() in
Heimdal 7.1 broke API/ABI compatibility with previous releases.  We
fix this by renaming it hdb_generate_key_set_password_with_ks_tuple()
and creating a new hdb_generate_key_set_password() which calls our
new function with zeroes for the added arguments.

Issue #246      https://github.com/heimdal/heimdal/issues/246