### PR TITLE
Add include/includedir directives for krb5.conf

### DIFF
--- a/doc/setup.texi
+++ b/doc/setup.texi
@@ -52,7 +52,14 @@ separated from the equal sign with some whitespace). Subsections have a
 other bindings are treated as variable assignments. The value of a
 variable extends to the end of the line.
 
+Configuration files can also include other files, or all files in a
+directory.  Use absolute paths in include directives.  When including a
+directoty, only files whose names consist of alphanumeric, hyphen, or
+underscore characters are allowed, though they may end in '.conf'.
+
 @example
+include /some/config/file
+includedir /some/config/directory
 [section1]
         a-subsection = @{
                 var = value1

--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -54,6 +54,7 @@ The grammar looks like:
 file:
 	/* empty */
 	sections
+        includes
 
 sections:
 	section sections
@@ -76,9 +77,21 @@ binding:
 name:
 	STRING
 
+includes:
+	'include' path
+	'includedir' path
+
+path: STRING
+
 .Ed
 .Li STRINGs
 consists of one or more non-whitespace characters.
+.Pp
+Files and directories may be included by absolute path.  Including a
+directory causes all files in the directory to be included as if each
+file had been included separately, but only files whose names consist of
+alphanumeric, hyphen, and underscore are included, though they may also
+end in '.conf'.
 .Pp
 STRINGs that are specified later in this man-page uses the following
 notation.

--- a/tests/gss/include-krb5.conf
+++ b/tests/gss/include-krb5.conf
@@ -1,0 +1,17 @@
+[libdefaults]
+	default_realm = TEST.H5L.SE
+	no-addresses = TRUE
+	dns_canonicalize_hostname = false
+	dns_lookup_realm = false
+	name_canon_rules = as-is:realm=TEST.H5L.SE
+	name_canon_rules = qualify:domain=test.h5l.se
+
+[domain_realms]
+	.test.h5l.se = TEST.H5L.SE
+
+[kdc]
+	enable-digest = true
+	digests_allowed = ntlm-v2,ntlm-v1-session,ntlm-v1
+
+[kadmin]
+	save-password = true

--- a/tests/gss/krb5.conf.in
+++ b/tests/gss/krb5.conf.in
@@ -1,26 +1,14 @@
-# $Id$
+include @srcdir@/include-krb5.conf
 
 [libdefaults]
-	default_realm = TEST.H5L.SE
-	no-addresses = TRUE
 	default_keytab_name = @objdir@/server.keytab
-	dns_canonicalize_hostname = false
-	dns_lookup_realm = false
-	name_canon_rules = as-is:realm=TEST.H5L.SE
-	name_canon_rules = qualify:domain=test.h5l.se
 
 [realms]
 	TEST.H5L.SE = {
 		kdc = localhost:@port@
 	}
 
-[domain_realms]
-	.test.h5l.se = TEST.H5L.SE
-
 [kdc]
-	enable-digest = true
-	digests_allowed = ntlm-v2,ntlm-v1-session,ntlm-v1
-
 	database = {
 		dbname = @objdir@/current-db
 		realm = TEST.H5L.SE
@@ -34,6 +22,3 @@
 [logging]
 	kdc = 0-/FILE:@objdir@/messages.log
 	default = 0-/FILE:@objdir@/messages.log
-
-[kadmin]
-	save-password = true


### PR DESCRIPTION
Includes docs and one test.  includedir is not tested in-tree, but I tested it manually.