### PR TITLE
kdc: de_http stricter parsing

### DIFF
--- a/kdc/connect.c
+++ b/kdc/connect.c
@@ -515,15 +515,21 @@ static int
 de_http(char *buf)
 {
     unsigned char *p, *q;
-    for(p = q = (unsigned char *)buf; *p; p++, q++) {
-	if(*p == '%' && isxdigit(p[1]) && isxdigit(p[2])) {
-	    unsigned int x;
-	    if(sscanf((char *)p + 1, "%2x", &x) != 1)
+    unsigned int x;
+
+    for (p = q = (unsigned char *)buf; *p; p++, q++) {
+	if (*p == '%') {
+	    if (!(isxdigit(p[1]) && isxdigit(p[2])))
 		return -1;
+
+	    if (sscanf((char *)p + 1, "%2x", &x) != 1)
+		return -1;
+
 	    *q = x;
 	    p += 2;
-	} else
+	} else {
 	    *q = *p;
+	}
     }
     *q = '\0';
     return 0;


### PR DESCRIPTION
In de_http() treat any sequence of '%' not followed by two hex digits
as invalid.

Change-Id: I812665c1a2806f8daba06d267bbee57287aa2314