### PR TITLE
lib/krb5: krb5_config_parse_file_multi use after free

### DIFF
--- a/lib/krb5/config_file.c
+++ b/lib/krb5/config_file.c
@@ -658,9 +658,9 @@ krb5_config_parse_file_multi (krb5_context context,
         if (!S_ISREG(st.st_mode)) {
             (void) fclose(f.f);
             context->config_include_depth--;
-            free(newfname);
 	    krb5_set_error_message(context, EISDIR, "not a regular file %s: %s",
 				   fname, strerror(EISDIR));
+	    free(newfname);
 	    return EISDIR;
         }
 


### PR DESCRIPTION
If the file is not a regular file, the 'fname' buffer will be freed
before it is passed to the krb5_set_error_message() routine.  That
this is true is not obvious from code inspection but 'newfname'
and 'fname' refer to the same memory.

Change-Id: I7780eae9ceaf01b245df488a2f7d7f406770864f