### PR TITLE
Fix check-iprop race

### DIFF
--- a/tests/kdc/check-iprop.in
+++ b/tests/kdc/check-iprop.in
@@ -221,19 +221,28 @@ ${EGREP} 'up-to-date with version' iprop-slave-status >/dev/null || { echo "slav
 
 # ----------------- checking: pushing lives changes
 
+slave_get() { KRB5_CONFIG="${objdir}/krb5-slave.conf" ${kadmin} -l get "$@"; }
+slave_check_exists() {
+    # Creation with a random key is not atomic, there are at present
+    # 3 log entries to create a random key principal, the entry is
+    # "invalid" for the first two of these.  We wait for the entry to
+    # exist and not be invalid
+    #
+    attrs=`slave_get -o attributes "$@" 2>/dev/null` || return 1
+    echo $attrs | egrep 'Attributes:' | egrep -v invalid >/dev/null || return 1
+    get_iprop_ver 0
+}
+
 echo "Add host"
 ${kadmin} -l add --random-key --use-defaults host/foo@${R} || exit 1
-wait_for_slave
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
-${kadmin} -l get host/foo@${R} > /dev/null || exit 1
+wait_for "Slave sees new host" slave_check_exists "host/foo@${R}"
 
 echo "Rollover host keys"
 ${kadmin} -l cpw -r --keepold host/foo@${R} || exit 1
 ${kadmin} -l cpw -r --keepold host/foo@${R} || exit 1
 ${kadmin} -l cpw -r --keepold host/foo@${R} || exit 1
 wait_for_slave 3
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
-${kadmin} -l get host/foo@${R} | \
+slave_get host/foo@${R} | \
     ${EGREP} Keytypes: | cut -d: -f2 | tr ' ' '
 ' | sed 's/^.*[[]\(.*\)[]].*$/\1/' | grep '[0-9]' | sort -nu | tr -d '
 ' | ${EGREP} 1234 > /dev/null || exit 1


### PR DESCRIPTION
Creation of a random key HDB entry takes 3 updates, not one.  Instead of
hard-coding this magic count, wait for the appearance of the expected
entry with no "invalid" flag among its attributes.