### PR TITLE
Avoid another potential check-iprop race.

### DIFF
--- a/tests/kdc/check-iprop.in
+++ b/tests/kdc/check-iprop.in
@@ -283,6 +283,7 @@ ${kadmin} -l get host/bar@${R} > /dev/null 2>/dev/null && exit 1
 echo "Re-add host"
 ${kadmin} -l add --random-key --use-defaults host/foo@${R} || exit 1
 ${kadmin} -l add --random-key --use-defaults host/bar@${R} || exit 1
+slave_check_exists  host/bar@${R}
 
 echo "kill slave and remove log and database"
 > iprop-stats


### PR DESCRIPTION
Though a race was never observed, the re-sync, slave DB deletion,
master changes and restart did not take into account late changes
in the master before slave down.