### PR TITLE
krb5_kt_next_entry() needs to operate on a zero'd krb5_keytab_entry.

### DIFF
--- a/lib/krb5/keytab.c
+++ b/lib/krb5/keytab.c
@@ -823,6 +823,7 @@ krb5_kt_next_entry(krb5_context context,
 			       id->prefix);
 	return HEIM_ERR_OPNOTSUPP;
     }
+    memset(entry, 0x0, sizeof(*entry));
     return (*id->next_entry)(context, id, entry, cursor);
 }
 


### PR DESCRIPTION
Addresses PR#277