### PR TITLE
Fix memory leak in _gss_ntlm_release_cred.

### DIFF
--- a/lib/gssapi/ntlm/release_cred.c
+++ b/lib/gssapi/ntlm/release_cred.c
@@ -58,6 +58,9 @@ OM_uint32 GSSAPI_CALLCONV _gss_ntlm_release_cred
 	free(cred->key.data);
     }
 
+    memset(cred, 0, sizeof(*cred));
+    free(cred);
+
     return GSS_S_COMPLETE;
 }
 


### PR DESCRIPTION
ntlm_cred is always allocated with calloc, so we need to free the cred
object too, similarly to what _gsskrb5_release_cred does.