### PR TITLE
kdc: unused pid element is (pid_t)-1 not zero

### DIFF
--- a/kdc/connect.c
+++ b/kdc/connect.c
@@ -1122,9 +1122,11 @@ start_kdc(krb5_context context,
     if (max_kdcs < 1)
 	max_kdcs = 1;
 
-    pids = calloc(max_kdcs, sizeof(*pids));
+    pids = malloc(max_kdcs * sizeof(*pids));
     if (!pids)
 	krb5_err(context, 1, errno, "malloc");
+    for (i = 0; i < max_kdcs; i++)
+	pids[i] = (pid_t)-1;
 
     /*
      * We open a socketpair of which we hand one end to each of our kids.
@@ -1196,12 +1198,12 @@ start_kdc(krb5_context context,
                 sleep(10);
                 break;
             default:
-                for (i=0; i < max_kdcs; i++) {
-                    if (pids[i] == 0) {
-                        pids[i] = pid;
-                        break;
-                    }
-                }
+		for (i = 0; i < max_kdcs; i++) {
+		    if (pids[i] == (pid_t)-1) {
+			pids[i] = pid;
+			break;
+		    }
+		}
                 kdc_log(context, config, 0, "KDC worker process started: %d",
                         pid);
                 num_kdcs++;


### PR DESCRIPTION
When the termination of a child process is observed by reap_kid() it
clears the pids[] element by assigning it the invalid pid value
(pid_t)-1. However, start_kdc() assumes that the unused pid[[] element
value is 0.  As a result, each pid[] element's associated child process
can only be restarted once since start_kdc() will not be able to locate
an unused element.

This change alters start_kdc() to initialize all elements of pids[] to
(pid_t)-1 and use that as the marker for unused elements.  By doing so
start_kdc() can properly record child process pids and indefinitely
restart child processes as necessary.

Change-Id: Ia93c9284ab21289994eca7fc9cf1278be7c00683