### PR TITLE
Close memory leak in external_passwd_quality

### DIFF
--- a/lib/kadm5/password_quality.c
+++ b/lib/kadm5/password_quality.c
@@ -199,6 +199,7 @@ external_passwd_quality (krb5_context context,
 	fclose(out);
 	fclose(error);
 	wait_for_process(child);
+	free(p);
 	return 1;
     }
     reply[strcspn(reply, "\n")] = '\0';


### PR DESCRIPTION
If the external password quality program returned a failure message, the unparsed form of the principal name was never freed.  Free it.