### PR TITLE
Set default principal for password change to credential client

### DIFF
--- a/lib/krb5/changepw.c
+++ b/lib/krb5/changepw.c
@@ -718,7 +718,7 @@ krb5_change_password (krb5_context	context,
  * @param context a Keberos context
  * @param creds The initial kadmin/passwd for the principal or an admin principal
  * @param newpw The new password to set
- * @param targprinc if unset, the default principal is used.
+ * @param targprinc if unset, the client principal from creds is used
  * @param result_code Result code, KRB5_KPASSWD_SUCCESS is when password is changed.
  * @param result_code_string binary message from the server, contains
  * at least the result_code.
@@ -748,7 +748,7 @@ krb5_set_password(krb5_context context,
     krb5_data_zero(result_string);
 
     if (targprinc == NULL) {
-	ret = krb5_get_default_principal(context, &principal);
+	ret = krb5_copy_principal(context, creds->client, &principal);
 	if (ret)
 	    return ret;
     } else


### PR DESCRIPTION
The default client principal for `krb5_set_password`, if the principal argument were `NULL`, was `krb5_get_default_principal`.  But `krb5_set_password` requires credentials for the password change service be passed in, and those credentials are already associated with a client principal that's much more likely to be the correct choice for a default.  Use that principal instead of `krb5_get_default_principal`.