### PR TITLE
Try to avoid parse_{time,units,flags} symbol conflicts

### DIFF
--- a/lib/roken/parse_time.c
+++ b/lib/roken/parse_time.c
@@ -73,3 +73,32 @@ print_time_table (FILE *f)
 {
     print_units_table (time_units, f);
 }
+
+#undef parse_time
+#undef unparse_time
+#undef unparse_time_approx
+#undef print_time_table
+
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+parse_time(const char *s, const char *def_unit)
+{
+    return rk_parse_units(s, time_units, def_unit);
+}
+
+ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
+unparse_time(int t, char *s, size_t len)
+{
+    return rk_unparse_units(t, time_units, s, len);
+}
+
+ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
+unparse_time_approx(int t, char *s, size_t len)
+{
+    return rk_unparse_units_approx(t, time_units, s, len);
+}
+
+ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+print_time_table(FILE *f)
+{
+    rk_print_units_table(time_units, f);
+}

--- a/lib/roken/parse_time.h
+++ b/lib/roken/parse_time.h
@@ -46,6 +46,11 @@
 #endif
 #endif
 
+#define parse_time rk_parse_time
+#define unparse_time rk_unparse_time
+#define unparse_time_approx rk_unparse_time_approx
+#define print_time_table rk_print_time_table
+
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
 parse_time (const char *s, const char *def_unit);
 

--- a/lib/roken/parse_units.c
+++ b/lib/roken/parse_units.c
@@ -325,3 +325,54 @@ print_flags_table (const struct units *units, FILE *f)
     for(u = units; u->name; ++u)
 	fprintf(f, "%s%s", u->name, (u+1)->name ? ", " : "\n");
 }
+
+#undef parse_units
+#undef unparse_units
+#undef unparse_units_approx
+#undef print_units_table
+#undef parse_flags
+#undef unparse_flags
+#undef print_flags_table
+
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+parse_units(const char *s, const struct units *units,
+	     const char *def_unit)
+{
+    return rk_parse_units(s, units, def_unit);
+}
+
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+unparse_units(int num, const struct units *units, char *s, size_t len)
+{
+    return rk_unparse_units(num, units, s, len);
+}
+
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+unparse_units_approx(int num, const struct units *units, char *s, size_t len)
+{
+    return rk_unparse_units_approx(num, units, s, len);
+}
+
+ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+print_units_table(const struct units *units, FILE *f)
+{
+    print_units_table(units, f);
+}
+
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+parse_flags(const char *s, const struct units *units, int orig)
+{
+    return rk_parse_flags(s, units, orig);
+}
+
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+unparse_flags(int num, const struct units *units, char *s, size_t len)
+{
+    return rk_unparse_flags(num, units, s, len);
+}
+
+ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+print_flags_table (const struct units *units, FILE *f)
+{
+    return rk_print_flags_table (units, f);
+}

--- a/lib/roken/parse_units.h
+++ b/lib/roken/parse_units.h
@@ -54,6 +54,14 @@ struct units {
     unsigned mult;
 };
 
+#define parse_units rk_parse_units
+#define unparse_units rk_unparse_units
+#define unparse_units_approx rk_unparse_units_approx
+#define print_units_table rk_print_units_table
+#define parse_flags rk_parse_flags
+#define unparse_flags rk_unparse_flags
+#define print_flags_table rk_print_flags_table
+
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
 parse_units (const char *s, const struct units *units,
 	     const char *def_unit);

--- a/lib/roken/version-script.map
+++ b/lib/roken/version-script.map
@@ -44,9 +44,9 @@ HEIMDAL_ROKEN_1.0 {
 		rk_cgetent;
 		rk_cgetstr;
 		rk_cloexec;
+		rk_cloexec_dir;
 		rk_cloexec_file;
-                rk_cloexec_dir;
-                rk_cloexec_socket;
+		rk_cloexec_socket;
 		rk_closefrom;
 		rk_copyhostent;
 		rk_dns_free_data;
@@ -89,17 +89,21 @@ HEIMDAL_ROKEN_1.0 {
 		rk_memset_s;
 		rk_mkdir;
 		rk_mkstemp;
+		rk_parse_flags
+		rk_parse_time
+		rk_parse_units;
 		rk_pid_file_delete;
 		rk_pid_file_write;
 		rk_pidfile;
 		rk_pipe_execv;
+		rk_print_flags_table
+		rk_print_time_table
+		rk_print_units_table;
 		rk_random_init;
 		rk_read_environment;
 		rk_readv;
 		rk_realloc;
 		rk_secure_getenv;
-		rk_strerror;
-		rk_strerror_r;
 		rk_setprogname;
 		rk_simple_execle;
 		rk_simple_execlp;
@@ -122,6 +126,8 @@ HEIMDAL_ROKEN_1.0 {
 		rk_socket_set_tos;
 		rk_socket_sockaddr_size;
 		rk_strcollect;
+		rk_strerror;
+		rk_strerror_r;
 		rk_strftime;
 		rk_strlcat;
 		rk_strlcpy;
@@ -143,15 +149,20 @@ HEIMDAL_ROKEN_1.0 {
 		rk_strvis;
 		rk_strvisx;
 		rk_svis;
+		rk_tdelete;
+		rk_tfind;
 		rk_timegm;
 		rk_timevaladd;
 		rk_timevalfix;
 		rk_timevalsub;
-		rk_tdelete;
-		rk_tfind;
 		rk_tsearch;
 		rk_twalk;
 		rk_undumpdata;
+		rk_unparse_flags
+		rk_unparse_time
+		rk_unparse_time_approx
+		rk_unparse_units;
+		rk_unparse_units_approx;
 		rk_unvis;
 		rk_vasnprintf;
 		rk_vasprintf;
@@ -163,8 +174,8 @@ HEIMDAL_ROKEN_1.0 {
 		rk_warnerr;
 		rk_xfree;
 		roken_concat;
-		roken_detach_prep;
 		roken_detach_finish;
+		roken_detach_prep;
 		roken_getaddrinfo_hostspec2;
 		roken_getaddrinfo_hostspec;
 		roken_gethostby_setup;


### PR DESCRIPTION
On Debian stretch systems PAM modules linked against Heimdal run into
symbol conflicts with parse_time() in systemd libraries.  We redefine
parse_time() and friends to rk_parse_time(), ... while keeping the old
names for ABI compatibility with existing clients.

The legacy names should eventually be droppped.