### PR TITLE
Async iprop fixes

### DIFF
--- a/kadmin/init.c
+++ b/kadmin/init.c
@@ -157,7 +157,7 @@ init(struct init_options *opt, int argc, char **argv)
 	krb5_warn(context, ret, "hdb_open");
 	return 0;
     }
-    ret = kadm5_log_reinit(kadm_handle, 0);
+    ret = kadm5_log_reinit(kadm_handle, 0, 0);
     if (ret)
         krb5_err(context, 1, ret, "Failed iprop log initialization");
     kadm5_log_end(kadm_handle);

--- a/kadmin/load.c
+++ b/kadmin/load.c
@@ -438,7 +438,7 @@ doit(const char *filename, int mergep)
     if (mergep)
         ret = kadm5_log_init(kadm_handle);
     if (ret == 0)
-        ret = kadm5_log_reinit(kadm_handle, 0);
+        ret = kadm5_log_reinit(kadm_handle, 0, 0);
     if (ret) {
 	fclose (f);
 	krb5_warn(context, ret, "kadm5_log_reinit");

--- a/lib/kadm5/iprop-log.c
+++ b/lib/kadm5/iprop-log.c
@@ -394,7 +394,7 @@ iprop_truncate(struct truncate_options *opt, int argc, char **argv)
         /* First recover unconfirmed records */
         ret = kadm5_log_init(server_context);
         if (ret == 0)
-            ret = kadm5_log_reinit(server_context, 0);
+            ret = kadm5_log_reinit(server_context, 0, 0);
     } else {
         ret = kadm5_log_init(server_context);
         if (ret)

--- a/lib/kadm5/iprop.h
+++ b/lib/kadm5/iprop.h
@@ -62,7 +62,9 @@ enum iprop_cmd { I_HAVE = 1,
 		 NOW_YOU_HAVE = 5,
 		 ARE_YOU_THERE = 6,
 		 I_AM_HERE = 7,
-		 YOU_HAVE_LAST_VERSION = 8
+		 YOU_HAVE_LAST_VERSION = 8,
+		 TELL_ME_EVERYTHING = 9,
+                 WHAT_DO_YOU_MEAN = 10, /* Resp. to unexpected/unknown msgs */
 };
 
 extern sig_atomic_t exit_flag;
@@ -74,6 +76,26 @@ enum ipropd_exit_code {
     IPROPD_RESTART_SLOW = 2,
     IPROPD_FATAL = 3,
 };
+
+/*
+ * Version 0 -> 7.5 and earlier.
+ * Version 1 -> after 7.5.
+ */
+#define IPROP_PROTOCOL_VERSION 1
+
+/*
+ * Notes on iprop protocol extensibility:
+ *
+ *  - As of Heimdal 7.4 and earlier, the master and the slave both ignore
+ *    messages with unexpected or unknown iprop_cmd values.  In particular, no
+ *    message is sent back.
+ *
+ *  - As of Heimdal 7.4 and earlier, the master and the slave generally ignore
+ *    unexpected additional payload fields at the end of messages.  But the
+ *    payloads of FOR_YOU, and ONE_PRINC cannot be extended without first
+ *    negotiated via the protocol version number, as they are read to
+ *    HEIM_ERR_EOF, unlike the others.
+ */
 
 int restarter(krb5_context, size_t *);
 

--- a/lib/kadm5/ipropd_common.c
+++ b/lib/kadm5/ipropd_common.c
@@ -38,6 +38,13 @@
 #include <sys/wait.h>
 #endif
 
+int
+version_range_too_big(iprop_version first, iprop_version last)
+{
+    return last.vno - first.vno >= (UINT32_MAX >> 1);
+}
+
+
 sig_atomic_t exit_flag;
 
 static RETSIGTYPE

--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -471,7 +471,7 @@ reinit_log(krb5_context context,
     if (verbose)
         krb5_warnx(context, "truncating log on slave");
 
-    ret = kadm5_log_reinit(server_context, vno);
+    ret = kadm5_log_reinit(server_context, current_version, 0);
     if (ret)
         krb5_err(context, IPROPD_RESTART_SLOW, ret, "kadm5_log_reinit");
 }

--- a/lib/kadm5/log.c
+++ b/lib/kadm5/log.c
@@ -755,6 +755,19 @@ kadm5_log_end(kadm5_server_context *server_context)
     return ret;
 }
 
+static uint32_t
+now_u32(void)
+{
+    uint32_t now = time(NULL);
+
+    assert(now > 0 && now < UINT32_MAX);
+    if (now > 0 && now < UINT32_MAX)
+        return now;
+    if (now < 1)
+        return 0;
+    return UINT32_MAX;
+}
+
 /*
  * Write the version, timestamp, and op for a new entry.
  *
@@ -770,7 +783,7 @@ kadm5_log_preamble(kadm5_server_context *context,
 		   uint32_t vno)
 {
     kadm5_log_context *log_context = &context->log_context;
-    time_t now = time(NULL);
+    uint32_t now = now_u32();
     kadm5_ret_t ret;
 
     ret = krb5_store_uint32(sp, vno);
@@ -1771,7 +1784,7 @@ struct replay_cb_data {
  */
 static kadm5_ret_t
 recover_replay(kadm5_server_context *context,
-               uint32_t ver, time_t timestamp, enum kadm_ops op,
+               uint32_t ver, uint32_t timestamp, enum kadm_ops op,
                uint32_t len, krb5_storage *sp, void *ctx)
 {
     struct replay_cb_data *data = ctx;
@@ -1858,7 +1871,7 @@ kadm5_log_foreach(kadm5_server_context *context,
                   enum kadm_iter_opts iter_opts,
                   off_t *off_lastp,
 		  kadm5_ret_t (*func)(kadm5_server_context *server_context,
-                                      uint32_t ver, time_t timestamp,
+                                      uint32_t ver, uint32_t timestamp,
                                       enum kadm_ops op, uint32_t len,
                                       krb5_storage *sp, void *ctx),
 		  void *ctx)
@@ -1935,7 +1948,7 @@ kadm5_log_foreach(kadm5_server_context *context,
     for (;;) {
 	uint32_t ver, ver2, len, len2;
 	uint32_t tstamp;
-        time_t timestamp;
+        uint32_t timestamp;
         enum kadm_ops op;
 
         if ((iter_opts & kadm_backward)) {
@@ -2193,7 +2206,7 @@ kadm5_ret_t
 kadm5_log_previous(krb5_context context,
 		   krb5_storage *sp,
 		   uint32_t *verp,
-		   time_t *tstampp,
+		   uint32_t *tstampp,
 		   enum kadm_ops *opp,
 		   uint32_t *lenp)
 {
@@ -2292,7 +2305,7 @@ struct load_entries_data {
 static kadm5_ret_t
 load_entries_cb(kadm5_server_context *server_context,
             uint32_t ver,
-            time_t timestamp,
+            uint32_t timestamp,
             enum kadm_ops op,
             uint32_t len,
             krb5_storage *sp,
@@ -2430,7 +2443,7 @@ kadm5_log_truncate(kadm5_server_context *context, size_t keep, size_t maxbytes)
 {
     kadm5_ret_t ret;
     uint32_t first, last, last_tstamp;
-    time_t now = time(NULL);
+    uint32_t now = now_u32();
     krb5_data entries;
     krb5_storage *sp;
     ssize_t bytes;

--- a/lib/kadm5/log.c
+++ b/lib/kadm5/log.c
@@ -469,6 +469,19 @@ get_max_log_size(krb5_context context)
                                     "kdc",
                                     "log-max-size",
                                     NULL);
+    /*
+     * ipropd-master's send_diffs() uses a single krb5_data to send all the
+     * diffs, so we can't have a log larger than 4GB...
+     *
+     * Also, we need to limit the number of entries to avoid the distance
+     * between the first and the last being more than half the range of
+     * uint32_t (i.e., 2^31 max entries).  But we don't want to slow the kadm5
+     * log code any more, so we don't bother checking the first entry, and
+     * instead we check that st_size is less than some value.  Let's say 1GB,
+     * though in practice the really max would be 24 * 2^31.
+     */
+    if (n > (1<<30))
+        n = 1<<30;
     if (n >= 4 * (LOG_UBER_LEN + LOG_WRAPPER_SZ) && n == (size_t)n)
         return (size_t)n;
     return 0;

--- a/lib/kadm5/private.h
+++ b/lib/kadm5/private.h
@@ -89,6 +89,7 @@ typedef struct kadm5_log_context {
     int lock_mode;
     uint32_t version;
     time_t last_time;
+    time_t set_time;
 #ifndef NO_UNIX_SOCKETS
     struct sockaddr_un socket_name;
 #else

--- a/lib/kadm5/private.h
+++ b/lib/kadm5/private.h
@@ -186,6 +186,20 @@ enum kadm_recover_mode {
 #define KADMIN_APPL_VERSION "KADM0.1"
 #define KADMIN_OLD_APPL_VERSION "KADM0.0"
 
+/*
+ * We identify iprop log records by their version and timestamp.
+ *
+ * Timestamps are only ever compared for equality.  We do not assume monotonic
+ * time.
+ */
+
+typedef struct iprop_version {
+    uint32_t vno;
+    uint32_t tstamp;
+} iprop_version;
+
+int version_range_too_big(iprop_version, iprop_version);
+
 #include "kadm5-private.h"
 
 #endif /* __kadm5_privatex_h__ */


### PR DESCRIPTION
This is still WIP in that `tests/kdc/check-iprop` needs to test more things.  Also, I need to test graceful rolling upgrade semantics, though that I won't script.

TODO:

 - on non-reinit truncation, make sure we always keep at least one non-uber record
 - add version number wraparound protection -- probably just reinit when the latest record's version gets too close to wrapping
 - test more cases in check-iprop
 - test *two* slaves in check-iprop and check that send_complete()s interleave -- this is going to be very difficult to check for considering how small the HDB is in check-iprop, so maybe this will be better done by hand
 - finish the non-blocking I/O work in `ipropd-master` to make sure that no slave can cause the master to block without servicing the others.