### PR TITLE
getauxval: return 0 in case returning 0 when getauxval doesn't set errno

### DIFF
--- a/lib/roken/getauxval.c
+++ b/lib/roken/getauxval.c
@@ -213,6 +213,7 @@ rk_getauxval(unsigned long type)
 
     getauxval_sets_errno = 0;
     errno = save_errno;
+    return 0;
 #endif
 #else
     const auxv_t *a;


### PR DESCRIPTION
if when we need to determine if getauxval sets errno, we determine it doesn't
after getting a 0 return code, make sure we return a value, since we didn't
previously.