### PR TITLE
getauxval: fall through to auxv gfter getauxval errno test

### DIFF
--- a/lib/roken/getauxval.c
+++ b/lib/roken/getauxval.c
@@ -159,6 +159,7 @@ rk_getprocauxval(unsigned long type)
 ROKEN_LIB_FUNCTION unsigned long ROKEN_LIB_CALL
 rk_getauxval(unsigned long type)
 {
+    const auxv_t *a;
 #ifdef HAVE_GETAUXVAL
 #ifdef GETAUXVAL_SETS_ERRNO
     if (rk_injected_auxv)
@@ -184,8 +185,6 @@ rk_getauxval(unsigned long type)
     }
 
     if (getauxval_sets_errno == 0) {
-	const auxv_t *a;
-
         errno = save_errno;
 	a = rk_getauxv(type);
 	if (a == NULL) {
@@ -214,15 +213,12 @@ rk_getauxval(unsigned long type)
     getauxval_sets_errno = 0;
     errno = save_errno;
 #endif
-#else
-    const auxv_t *a;
-
+#endif
     if ((a = rk_getauxv(type)) == NULL) {
         errno = ENOENT;
         return 0;
     }
     return a->a_un.a_val;
-#endif
 }
 
 /**

--- a/lib/roken/issuid.c
+++ b/lib/roken/issuid.c
@@ -188,7 +188,7 @@ issuid(void)
      * race.
      */
     {
-        unsigned long p = getauxval(AT_EXECPATH);
+        unsigned long p = rk_getauxval(AT_EXECPATH);
         struct stat st;
         
         if (p != 0 && *(const char *)p == '/' &&


### PR DESCRIPTION
if when we need to determine if getauxval sets errno, we determine it doesn't
after getting a 0 return code, make sure we return a value, since we didn't
previously. fall through to code we'd otherwise have called in this case
above.