### PR TITLE
hcrypto: implement missed symbol renaming in camellia-ntt and rand

### DIFF
--- a/lib/hcrypto/camellia-ntt.h
+++ b/lib/hcrypto/camellia-ntt.h
@@ -32,6 +32,11 @@
 extern "C" {
 #endif
 
+/* symbol renaming */
+#define Camellia_DecryptBlock hc_Camellia_DecryptBlock
+#define Camellia_Ekeygen hc_Camellia_Ekeygen
+#define Camellia_EncryptBlock hc_Camellia_EncryptBlock
+
 #define CAMELLIA_BLOCK_SIZE 16
 #define CAMELLIA_TABLE_BYTE_LEN 272
 #define CAMELLIA_TABLE_WORD_LEN (CAMELLIA_TABLE_BYTE_LEN / 4)

--- a/lib/hcrypto/rand.h
+++ b/lib/hcrypto/rand.h
@@ -59,6 +59,7 @@ typedef struct RAND_METHOD RAND_METHOD;
 #define RAND_write_file hc_RAND_write_file
 #define RAND_status hc_RAND_status
 #define RAND_fortuna_method hc_RAND_fortuna_method
+#define RAND_timer_method hc_RAND_timer_method
 #define RAND_unix_method hc_RAND_unix_method
 #define RAND_w32crypto_method hc_RAND_w32crypto_method
 


### PR DESCRIPTION
camellia-ntt had none of its symbols renamed into the hc_ namespace,
and rand's missed timer_method (while all other methods were done). rename
these like we do for others