### PR TITLE
libedit: makelist should default to awk, but not force it

### DIFF
--- a/lib/libedit/src/makelist
+++ b/lib/libedit/src/makelist
@@ -35,7 +35,10 @@
 
 # makelist.sh: Automatically generate header files...
 
-AWK=awk
+if [ "x$AWK" = "x" ]
+then
+    AWK=awk
+fi
 USAGE="Usage: $0 -h|-fc|-fh|-bh <filenames>"
 
 if [ "x$1" = "x" ]


### PR DESCRIPTION
solaris needs gawk; we should allow the makefile to override awk
with gawk (or whatever else)