### PR TITLE
krb5/crypto: Fix compiler error in new iovec CTS code

### DIFF
--- a/lib/krb5/crypto-evp.c
+++ b/lib/krb5/crypto-evp.c
@@ -450,6 +450,8 @@ _krb5_evp_encrypt_iov_cts(krb5_context context,
 	 * final partial block */
 	remaining = ((length - 1) & blockmask);
 	partiallen = length - remaining;
+
+	memset(&lastpos, 0, sizeof(lastpos)); /* Keep the compiler happy */
     } else {
 	/* Decryption needs to leave 2 whole blocks and a partial for
 	 * further processing */


### PR DESCRIPTION
Some versions of gcc can't follow the logic in the encryption path
of the _krb5_evp_encrypt_iov_cts code, and believe that it is
possible for the lastpos structure to be used uninitialised.

This isn't actually possible. On entry to the loop, remaining is
guaranteed to be both greater than, and a multiple of blocksize.
In order to exit the loop, remaining must be set to 0. If
cursor.current.length >= remaining, then we set remaining to 0 and
also set lastpos. Otherwise, we calculate the number of whole blocks
in the current iovec, which must be less than remaining, and subtract
that from remaining. Remaining must still be a multiple of and greater
than or equal to blocksize. If remaining == blocksize, we set lastpos,
and set remaining to 0. Otherwise we consume a single block, and go
around again. All of the paths which may set remaining to 0 also
set lastpos, so lastpos must be populated when the loop terminates.

Coverity has a similiar misconception, albeit with ivec2, which is
mistaken for the same reasons.