### PR TITLE
ipropd_slave: open hdb around kadm5_log_init in case recovery needed

### DIFF
--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -791,9 +791,19 @@ main(int argc, char **argv)
 
     slave_status(context, status_file, "creating log file");
 
+    ret = server_context->db->hdb_open(context,
+                                       server_context->db,
+                                       O_RDWR | O_CREAT, 0600);
+    if (ret)
+	krb5_err (context, 1, ret, "db->open");
+
     ret = kadm5_log_init (server_context);
     if (ret)
 	krb5_err (context, 1, ret, "kadm5_log_init");
+
+    ret = server_context->db->hdb_close (context, server_context->db);
+    if (ret)
+	krb5_err (context, 1, ret, "db->close");
 
     get_creds(context, keytab_str, &ccache, master);
 

--- a/lib/libedit/config.h.in
+++ b/lib/libedit/config.h.in
@@ -130,7 +130,8 @@
    slash. */
 #undef LSTAT_FOLLOWS_SLASHED_SYMLINK
 
-/* Define to the sub-directory where libtool stores uninstalled libraries. */
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
 #undef LT_OBJDIR
 
 /* Name of package */


### PR DESCRIPTION
log_init in the event a log is found will do recovery. kadm5_log_replay
will call methods which expect an hdb_db to be set but without this
none is