### PR TITLE
ipropd_slave: open hdb around kadm5_log_init in case recovery needed

### DIFF
--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -974,7 +974,8 @@ main(int argc, char **argv)
 					       server_context->db,
 					       O_RDWR | O_CREAT, 0600);
 	    if (ret)
-		krb5_err (context, 1, ret, "db->open");
+		krb5_err (context, 1, ret, "db->open while handling a "
+			  "message from the master");
 
             ret = kadm5_log_init(server_context);
             if (ret) {
@@ -983,7 +984,8 @@ main(int argc, char **argv)
             }
 	    ret = server_context->db->hdb_close (context, server_context->db);
 	    if (ret)
-		krb5_err (context, 1, ret, "db->close");
+		krb5_err (context, 1, ret, "db->close while handling a "
+			  "message from the master");
 
 	    switch (tmp) {
 	    case FOR_YOU :

--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -791,9 +791,19 @@ main(int argc, char **argv)
 
     slave_status(context, status_file, "creating log file");
 
+    ret = server_context->db->hdb_open(context,
+                                       server_context->db,
+                                       O_RDWR | O_CREAT, 0600);
+    if (ret)
+	krb5_err (context, 1, ret, "db->open");
+
     ret = kadm5_log_init (server_context);
     if (ret)
 	krb5_err (context, 1, ret, "kadm5_log_init");
+
+    ret = server_context->db->hdb_close (context, server_context->db);
+    if (ret)
+	krb5_err (context, 1, ret, "db->close");
 
     get_creds(context, keytab_str, &ccache, master);
 
@@ -960,11 +970,21 @@ main(int argc, char **argv)
                 continue;
             }
 
+	    ret = server_context->db->hdb_open(context,
+					       server_context->db,
+					       O_RDWR | O_CREAT, 0600);
+	    if (ret)
+		krb5_err (context, 1, ret, "db->open");
+
             ret = kadm5_log_init(server_context);
             if (ret) {
                 krb5_err(context, IPROPD_RESTART, ret, "kadm5_log_init while "
                          "handling a message from the master");
             }
+	    ret = server_context->db->hdb_close (context, server_context->db);
+	    if (ret)
+		krb5_err (context, 1, ret, "db->close");
+
 	    switch (tmp) {
 	    case FOR_YOU :
                 if (verbose)


### PR DESCRIPTION
log_init in the event a log is found will do recovery. kadm5_log_replay
will call methods which expect an hdb_db to be set but without this
none is