### PR TITLE
del_enctype with specific kvno (cpw --keepold counterpart)

### DIFF
--- a/kadmin/del_enctype.c
+++ b/kadmin/del_enctype.c
@@ -39,7 +39,7 @@
  */
 
 int
-del_enctype(void *opt, int argc, char **argv)
+del_enctype(struct del_enctype_options *opt, int argc, char **argv)
 {
     kadm5_principal_ent_rec princ;
     krb5_principal princ_ent = NULL;
@@ -98,7 +98,7 @@ del_enctype(void *opt, int argc, char **argv)
 	key = &princ.key_data[i];
 
 	for (k = 0; k < n_etypes; ++k) {
-	    if (etypes[k] == key->key_data_type[0]) {
+	    if (etypes[k] == key->key_data_type[0] && (opt->kvno_integer == -1 || opt->kvno_integer == key->key_data_kvno)) {
 		docopy = 0;
 		break;
 	    }

--- a/kadmin/kadmin-commands.in
+++ b/kadmin/kadmin-commands.in
@@ -256,9 +256,15 @@ command = {
 }
 command = {
 	name = "del_enctype"
+	option = {
+		long = "kvno"
+		type = "integer"
+		help = "key version number"
+		default = "-1"
+	}
 	argument = "principal enctype..."
 	min_args = "2"
-	help = "Delete all the mentioned enctypes for principal."
+	help = "Delete the mentioned enctypes for principal."
 }
 command = {
 	name = "add_enctype"


### PR DESCRIPTION
usecase for the PR is the krbtgt/ rollover. one can add new keys using `cpw --keepold` but removing old keys/enctypes with specific kvno is not currenly supported.