### PR TITLE
heimdal: Use #ifdef HAVE_DLOPEN around functions and variables used by HAVE_DLOPEN

### DIFF
--- a/lib/gssapi/mech/gss_mech_switch.c
+++ b/lib/gssapi/mech/gss_mech_switch.c
@@ -37,6 +37,7 @@ struct _gss_mech_switch_list _gss_mechs = { NULL } ;
 gss_OID_set _gss_mech_oids;
 static HEIMDAL_MUTEX _gss_mech_mutex = HEIMDAL_MUTEX_INITIALIZER;
 
+#ifdef HAVE_DLOPEN
 /*
  * Convert a string containing an OID in 'dot' form
  * (e.g. 1.2.840.113554.1.2.2) to a gss_OID.
@@ -148,6 +149,7 @@ _gss_string_to_oid(const char* s, gss_OID oid)
 
 	return (0);
 }
+#endif
 
 #define SYM(name)							\
 do {									\
@@ -227,6 +229,7 @@ void
 _gss_load_mech(void)
 {
 	OM_uint32	major_status, minor_status;
+#ifdef HAVE_DLOPEN
 	FILE		*fp;
 	char		buf[256];
 	char		*p;
@@ -235,6 +238,7 @@ _gss_load_mech(void)
 	void		*so;
 	gss_OID_desc	mech_oid;
 	int		found;
+#endif
 
 
 	HEIMDAL_MUTEX_lock(&_gss_mech_mutex);

--- a/lib/krb5/plugin.c
+++ b/lib/krb5/plugin.c
@@ -209,6 +209,8 @@ struct plugin2 {
     heim_dict_t names;
 };
 
+#ifdef HAVE_DLOPEN
+
 static void
 plug_dealloc(void *ptr)
 {
@@ -258,6 +260,7 @@ resolve_origin(const char *di)
 #endif /* !HAVE_DLADDR */
 }
 
+#endif /* HAVE_DLOPEN */
 
 /**
  * Load plugins (new system) for the given module @name (typically

--- a/lib/krb5/plugin.c
+++ b/lib/krb5/plugin.c
@@ -538,7 +538,7 @@ _krb5_plugin_run_f(krb5_context context,
 		   krb5_error_code (KRB5_LIB_CALL *func)(krb5_context, const void *, void *, void *))
 {
     heim_string_t m = heim_string_create(module);
-    heim_dict_t dict;
+    heim_dict_t dict = NULL;
     void *plug_ctx;
     struct common_plugin_method *cpm;
     struct iter_ctx s;
@@ -561,7 +561,9 @@ _krb5_plugin_run_f(krb5_context context,
     s.ret = KRB5_PLUGIN_NO_HANDLE;
 
     /* Get loaded plugins */
-    dict = heim_dict_copy_value(modules, m);
+    if (modules)
+	dict = heim_dict_copy_value(modules, m);
+
     heim_release(m);
 
     /* Add loaded plugins to s.result array */
@@ -603,7 +605,8 @@ _krb5_plugin_run_f(krb5_context context,
 
     heim_release(s.result);
     heim_release(s.n);
-    heim_release(dict);
+    if (dict)
+	heim_release(dict);
 
     return s.ret;
 }


### PR DESCRIPTION
Samba has a cut-down version of Heimdal in-tree, which does not have HAVE_DLOPEN specified. 

This patch allows this to build in Samba, after an update to current Heimdal.