### PR TITLE
Address some compiler warnings

### DIFF
--- a/lib/krb5/addr_families.c
+++ b/lib/krb5/addr_families.c
@@ -804,7 +804,7 @@ static struct addr_operations at[] = {
     }
 };
 
-static int num_addrs = sizeof(at) / sizeof(at[0]);
+static size_t num_addrs = sizeof(at) / sizeof(at[0]);
 
 static size_t max_sockaddr_size = 0;
 
@@ -815,22 +815,26 @@ static size_t max_sockaddr_size = 0;
 static struct addr_operations *
 find_af(int af)
 {
-    struct addr_operations *a;
+    size_t i;
 
-    for (a = at; a < at + num_addrs; ++a)
-	if (af == a->af)
-	    return a;
+    for (i = 0; i < num_addrs; i++) {
+	if (af == at[i].af) {
+		return &at[i];
+	}
+    }
     return NULL;
 }
 
 static struct addr_operations *
 find_atype(krb5_address_type atype)
 {
-    struct addr_operations *a;
+    size_t i;
 
-    for (a = at; a < at + num_addrs; ++a)
-	if (atype == a->atype)
-	    return a;
+    for (i = 0; i < num_addrs; i++) {
+	if (atype == at[i].atype) {
+		return &at[i];
+	}
+    }
     return NULL;
 }
 
@@ -950,10 +954,11 @@ KRB5_LIB_FUNCTION size_t KRB5_LIB_CALL
 krb5_max_sockaddr_size (void)
 {
     if (max_sockaddr_size == 0) {
-	struct addr_operations *a;
+	size_t i;
 
-	for(a = at; a < at + num_addrs; ++a)
-	    max_sockaddr_size = max(max_sockaddr_size, a->max_sockaddr_size);
+	for (i = 0; i < num_addrs; i++) {
+	    max_sockaddr_size = max(max_sockaddr_size, at[i].max_sockaddr_size);
+	}
     }
     return max_sockaddr_size;
 }

--- a/lib/krb5/config_file.c
+++ b/lib/krb5/config_file.c
@@ -1081,7 +1081,7 @@ krb5_config_vget_strings(krb5_context context,
 			 va_list args)
 {
     char **strings = NULL;
-    int nstr = 0;
+    size_t nstr = 0;
     const krb5_config_binding *b = NULL;
     const char *p;
 

--- a/lib/krb5/keytab_any.c
+++ b/lib/krb5/keytab_any.c
@@ -222,11 +222,11 @@ any_remove_entry(krb5_context context,
 {
     struct any_data *a = id->data;
     krb5_error_code ret;
-    int found = 0;
+    krb5_boolean found = FALSE;
     while(a != NULL) {
 	ret = krb5_kt_remove_entry(context, a->kt, entry);
 	if(ret == 0)
-	    found++;
+	    found = TRUE;
 	else {
 	    if(ret != KRB5_KT_NOWRITE && ret != KRB5_KT_NOTFOUND) {
 		krb5_set_error_message(context, ret,

--- a/lib/krb5/krbhst.c
+++ b/lib/krb5/krbhst.c
@@ -353,14 +353,15 @@ krb5_krbhst_format_string(krb5_context context, const krb5_krbhst_info *host,
 			  char *hostname, size_t hostlen)
 {
     const char *proto = "";
-    char portstr[7] = "";
     if(host->proto == KRB5_KRBHST_TCP)
 	proto = "tcp/";
     else if(host->proto == KRB5_KRBHST_HTTP)
 	proto = "http://";
-    if(host->port != host->def_port)
-	snprintf(portstr, sizeof(portstr), ":%d", host->port);
-    snprintf(hostname, hostlen, "%s%s%s", proto, host->hostname, portstr);
+    if (host->port != host->def_port) {
+	snprintf(hostname, hostlen, "%s%s:%d", proto, host->hostname, host->port);
+    } else {
+	snprintf(hostname, hostlen, "%s%s", proto, host->hostname);
+    }
     return 0;
 }
 


### PR DESCRIPTION
These compiler warnings come via Samba.

Some were already submitted in #354 but I re-raise them with the justifications requested as far as I've been able to reproduce on Ubuntu 16.04 gcc 5.4.0

I realise not all the patches and chunks have a justification, but increasing the type width in (eg) asn1.c is pretty low-risk. 

It would be very helpful if these could be accepted upstream as it will reduce the number of patches we need to maintain in our lorikeet-heimdal fork.

Thanks!