### PR TITLE
kdc: Add initializer for stack pointers

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1628,7 +1628,7 @@ _kdc_as_rep(kdc_request_t r,
     KDCOptions f;
     krb5_enctype setype;
     krb5_error_code ret = 0;
-    Key *skey;
+    Key *skey = NULL;
     int found_pa = 0;
     int i, flags = HDB_F_FOR_AS_REQ;
     METHOD_DATA error_method;


### PR DESCRIPTION
Another patch from Samba's lorikeet-heimdal branch.

This helps ensure we know these are NULL until set.

This is only for clarity and for the good practice (in Samba)
of initializing stack pointers.  If _kdc_get_preferred_key()
returns 0 then skey must have been validly provided by
hdb_enctype2key().

Signed-off-by: Andrew Bartlett <abartlet@samba.org>
(similar to Samba commit a998c0073f508437714f462661165309049c1b10)

Signed-off-by: Andrew Bartlett <abartlet@samba.org>