### PR TITLE
s4-heimdal: Fix the format-truncation errors.

### DIFF
--- a/lib/com_err/compile_et.c
+++ b/lib/com_err/compile_et.c
@@ -61,8 +61,8 @@ int yydebug = 1;
 #endif
 
 char *filename;
-char hfn[128];
-char cfn[128];
+char hfn[130];
+char cfn[130];
 
 struct error_code *codes = NULL;
 
@@ -129,7 +129,7 @@ static int
 generate_h(void)
 {
     struct error_code *ec;
-    char fn[128];
+    char fn[134];
     FILE *h_file = fopen(hfn, "w");
     char *p;
 


### PR DESCRIPTION
../lib/com_err/compile_et.c: In function ‘generate_h’:
../lib/com_err/compile_et.c:138:33: error: ‘%s’ directive output may be truncated writing up to 127 bytes into a region of size 126 [-Werror=format-truncation=]
     snprintf(fn, sizeof(fn), "__%s__", hfn);
                                 ^~     ~~~
../lib/com_err/compile_et.c:138:5: note: ‘snprintf’ output between 5 and 132 bytes into a destination of size 128
     snprintf(fn, sizeof(fn), "__%s__", hfn);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../lib/com_err/compile_et.c: In function ‘main’:
../lib/com_err/compile_et.c:234:35: error: ‘.h’ directive output may be truncated writing 2 bytes into a region of size between 1 and 128 [-Werror=format-truncation=]
     snprintf(hfn, sizeof(hfn), "%s.h", Basename);
                                   ^~
../lib/com_err/compile_et.c:234:5: note: ‘snprintf’ output between 3 and 130 bytes into a destination of size 128
     snprintf(hfn, sizeof(hfn), "%s.h", Basename);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../lib/com_err/compile_et.c:235:35: error: ‘.c’ directive output may be truncated writing 2 bytes into a region of size between 1 and 128 [-Werror=format-truncation=]
     snprintf(cfn, sizeof(cfn), "%s.c", Basename);
                                   ^~
../lib/com_err/compile_et.c:235:5: note: ‘snprintf’ output between 3 and 130 bytes into a destination of size 128
     snprintf(cfn, sizeof(cfn), "%s.c", Basename);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors

BUG: https://bugzilla.samba.org/show_bug.cgi?id=13437

Guenther

Signed-off-by: Günther Deschner <gd@samba.org>
Reviewed-by: Andreas Schneider <asn@samba.org>

Autobuild-User(master): Andreas Schneider <asn@cryptomilk.org>
Autobuild-Date(master): Fri Jun  8 13:23:51 CEST 2018 on sn-devel-144
(cherry picked from Samba commit 7ddbf6035dfec6806536f99d0257245f70661363)