### PR TITLE
kadmin selective prune of historic key for principal

### DIFF
--- a/kadmin/Makefile.am
+++ b/kadmin/Makefile.am
@@ -26,6 +26,7 @@ dist_kadmin_SOURCES =				\
 	kadmin.c				\
 	load.c					\
 	mod.c					\
+	prune.c					\
 	rename.c				\
 	stash.c					\
 	util.c					\

--- a/kadmin/NTMakefile
+++ b/kadmin/NTMakefile
@@ -59,6 +59,7 @@ KADMIN_OBJS=			    \
 	$(OBJ)\kadmin.obj	    \
 	$(OBJ)\load.obj		    \
 	$(OBJ)\mod.obj		    \
+	$(OBJ)\prune.obj	    \
 	$(OBJ)\rename.obj	    \
 	$(OBJ)\stash.obj	    \
 	$(OBJ)\util.obj		    \

--- a/kadmin/kadmin-commands.in
+++ b/kadmin/kadmin-commands.in
@@ -416,6 +416,19 @@ command = {
 	help = "Modifies some attributes of the specified principal."
 }
 command = {
+	name = "prune"
+	argument = "principal"
+	option = {
+		long = "kvno"
+		type = "integer"
+		help = "key version number"
+		default = "0"
+	}
+	min_args = "1"
+	max_args = "1"
+	help = "Delete keys from history by max-ticket-life or kvno."
+}
+command = {
 	name = "privileges"
 	name = "privs"
 	function = "get_privs"

--- a/kadmin/kadmin.1
+++ b/kadmin/kadmin.1
@@ -142,6 +142,19 @@ service belonging to the principal is known to not handle certain
 enctypes.
 .Ed
 .Pp
+.Nm prune
+.Ar principal [kvno]
+.Bd -ragged -offset indent
+Deletes the named principal's keys of the given kvno.  If a kvno is
+not given then this deletes all the named principals keys that are
+too old to be needed for decrypting tickets issued using those keys
+(i.e., any such tickets are necessarily expired).  The determination
+of "too old" is made using the max-ticket-life attribute of the
+principal; though in practice that max ticket life is also constrained
+by the max-ticket-life of the client principals and the krbtgt
+principals, those are not consulted here.
+.Ed
+.Pp
 .Nm ext_keytab
 .Oo Fl k Ar string \*(Ba Xo
 .Fl Fl keytab= Ns Ar string

--- a/kadmin/prune.c
+++ b/kadmin/prune.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Cesnet z.s.p.o.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "kadmin_locl.h"
+#include "kadmin-commands.h"
+
+int
+prune(struct prune_options *opt, int argc, char **argv)
+{
+    krb5_error_code ret = 0;
+    krb5_principal princ_ent = NULL;
+
+    if (argc == 0) {
+        krb5_warnx(context, "prune: missing principal name argument");
+        return 0;
+    }
+    if (argc > 1) {
+        krb5_warnx(context, "prune: too many arguments");
+        return 0;
+    }
+
+    ret = krb5_parse_name(context, argv[0], &princ_ent);
+    if (ret) {
+        krb5_warn(context, ret, "krb5_parse_name %s", argv[0]);
+        goto out2;
+    }
+
+    ret = kadm5_prune_principal(kadm_handle, princ_ent, opt->kvno_integer);
+    if (ret)
+        krb5_warn(context, ret, "kadm5_prune_principal");
+
+out2:
+    return ret != 0;
+}

--- a/lib/hdb/libhdb-exports.def
+++ b/lib/hdb/libhdb-exports.def
@@ -54,6 +54,7 @@ EXPORTS
 	hdb_print_entry
 	hdb_process_master_key
 	hdb_prune_keys
+	hdb_prune_keys_kvno
 	hdb_read_master_key
 	hdb_replace_extension
 	hdb_seal_key

--- a/lib/hdb/version-script.map
+++ b/lib/hdb/version-script.map
@@ -56,6 +56,7 @@ HEIMDAL_HDB_1.0 {
 		hdb_print_entry;
 		hdb_process_master_key;
 		hdb_prune_keys;
+		hdb_prune_keys_kvno;
 		hdb_read_master_key;
 		hdb_replace_extension;
 		hdb_seal_key;

--- a/lib/kadm5/Makefile.am
+++ b/lib/kadm5/Makefile.am
@@ -74,6 +74,7 @@ dist_libkadm5clnt_la_SOURCES =			\
 	modify_c.c				\
 	private.h				\
 	privs_c.c				\
+	prune_c.c				\
 	randkey_c.c				\
 	rename_c.c				\
 	send_recv.c				\
@@ -108,6 +109,7 @@ dist_libkadm5srv_la_SOURCES =			\
 	password_quality.c			\
 	private.h				\
 	privs_s.c				\
+	prune_s.c				\
 	randkey_s.c				\
 	rename_s.c				\
 	server_glue.c				\

--- a/lib/kadm5/NTMakefile
+++ b/lib/kadm5/NTMakefile
@@ -51,6 +51,7 @@ dist_libkadm5clnt_la_SOURCES =	\
 	modify_c.c		\
 	private.h		\
 	privs_c.c		\
+	prune_c.c		\
 	randkey_c.c		\
 	rename_c.c		\
 	send_recv.c		\
@@ -83,6 +84,7 @@ dist_libkadm5srv_la_SOURCES =	\
 	password_quality.c	\
 	private.h		\
 	privs_s.c		\
+	prune_s.c		\
 	randkey_s.c		\
 	rename_s.c		\
 	server_glue.c		\
@@ -110,6 +112,7 @@ LIBKADM5CLNT_OBJS=		    \
 	$(OBJ)\marshall.obj	    \
 	$(OBJ)\modify_c.obj	    \
 	$(OBJ)\privs_c.obj	    \
+	$(OBJ)\prune_c.obj	    \
 	$(OBJ)\randkey_c.obj	    \
 	$(OBJ)\rename_c.obj	    \
 	$(OBJ)\send_recv.obj	    \
@@ -137,6 +140,7 @@ LIBKADM5SRV_OBJS=		    \
 	$(OBJ)\modify_s.obj	    \
 	$(OBJ)\password_quality.obj \
 	$(OBJ)\privs_s.obj	    \
+	$(OBJ)\prune_s.obj	    \
 	$(OBJ)\randkey_s.obj	    \
 	$(OBJ)\rename_s.obj	    \
 	$(OBJ)\server_glue.obj	    \

--- a/lib/kadm5/common_glue.c
+++ b/lib/kadm5/common_glue.c
@@ -428,3 +428,10 @@ kadm5_free_policy_ent(kadm5_policy_ent_t ent)
     return 0;
 }
 
+kadm5_ret_t
+kadm5_prune_principal(void *server_handle,
+                      krb5_principal princ,
+                      int kvno)
+{
+    return __CALL(prune_principal, (server_handle, princ, kvno));
+}

--- a/lib/kadm5/context_s.c
+++ b/lib/kadm5/context_s.c
@@ -106,6 +106,7 @@ set_funcs(kadm5_server_context *c)
     SET(c, get_principals);
     SET(c, get_privs);
     SET(c, modify_principal);
+    SET(c, prune_principal);
     SET(c, randkey_principal);
     SET(c, rename_principal);
     SET(c, lock);

--- a/lib/kadm5/init_c.c
+++ b/lib/kadm5/init_c.c
@@ -72,6 +72,7 @@ set_funcs(kadm5_client_context *c)
     SET(c, get_principals);
     SET(c, get_privs);
     SET(c, modify_principal);
+    SET(c, prune_principal);
     SET(c, randkey_principal);
     SET(c, rename_principal);
     SET(c, lock);

--- a/lib/kadm5/libkadm5srv-exports.def
+++ b/lib/kadm5/libkadm5srv-exports.def
@@ -34,6 +34,7 @@ EXPORTS
         kadm5_lock
         kadm5_modify_policy
 	kadm5_modify_principal
+	kadm5_prune_principal
 	kadm5_randkey_principal
 	kadm5_randkey_principal_3
 	kadm5_rename_principal

--- a/lib/kadm5/private.h
+++ b/lib/kadm5/private.h
@@ -67,6 +67,7 @@ struct kadm_func {
     kadm5_ret_t (*setkey_principal_3) (void *, krb5_principal, krb5_boolean,
 				       int, krb5_key_salt_tuple *,
 				       krb5_keyblock *, int);
+    kadm5_ret_t (*prune_principal) (void *, krb5_principal, int);
 };
 
 typedef struct kadm5_hook_context {
@@ -169,8 +170,9 @@ enum kadm_ops {
     kadm_get_princs,
     kadm_chpass_with_key,
     kadm_nop,
+    kadm_prune,
     kadm_first = kadm_get,
-    kadm_last = kadm_nop
+    kadm_last = kadm_prune
 };
 
 /* FIXME nop types are currently not implemented */

--- a/lib/kadm5/prune_c.c
+++ b/lib/kadm5/prune_c.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 Cesnet z.s.p.o.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "kadm5_locl.h"
+
+RCSID("$Id$");
+
+kadm5_ret_t
+kadm5_c_prune_principal(void *server_handle, krb5_principal princ, int kvno)
+{
+    kadm5_client_context *context = server_handle;
+    kadm5_ret_t ret, ret2;
+    krb5_storage *sp = NULL;
+    unsigned char buf[1024];
+    krb5_data reply;
+
+    krb5_data_zero(&reply);
+    ret = _kadm5_connect(server_handle);
+    if (ret == 0 && (sp = krb5_storage_from_mem(buf, sizeof(buf))) == NULL)
+        ret = krb5_enomem(context->context);
+    if (ret == 0)
+        ret = krb5_store_int32(sp, kadm_prune);
+    if (ret == 0)
+        ret = krb5_store_principal(sp, princ);
+    if (ret == 0)
+        ret = krb5_store_int32(sp, kvno);
+    if (ret == 0)
+        ret = _kadm5_client_send(context, sp);
+    if (ret == 0)
+        ret = _kadm5_client_recv(context, &reply);
+    krb5_storage_free(sp);
+    sp = NULL;
+    if (ret == 0 && (sp = krb5_storage_from_data(&reply)) == NULL)
+        ret = krb5_enomem(context->context);
+    if (ret == 0)
+        ret = krb5_ret_int32(sp, &ret2);
+    if (ret == 0) {
+        krb5_clear_error_message(context->context);
+        ret = ret2;
+    }
+    krb5_data_free(&reply);
+    krb5_storage_free(sp);
+    return ret;
+}

--- a/lib/kadm5/prune_s.c
+++ b/lib/kadm5/prune_s.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2018 Cesnet z.s.p.o.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "kadm5_locl.h"
+
+RCSID("$Id$");
+
+kadm5_ret_t
+kadm5_s_prune_principal(void *server_handle,
+                        krb5_principal princ,
+                        int kvno)
+{
+    kadm5_server_context *context = server_handle;
+    hdb_entry_ex ent;
+    kadm5_ret_t ret;
+
+    memset(&ent, 0, sizeof(ent));
+    if (!context->keep_open) {
+        ret = context->db->hdb_open(context->context, context->db, O_RDWR, 0);
+        if(ret)
+            return ret;
+    }
+
+    ret = kadm5_log_init(context);
+    if (ret)
+        goto out;
+
+    ret = context->db->hdb_fetch_kvno(context->context, context->db, princ,
+                                      HDB_F_GET_ANY|HDB_F_ADMIN_DATA, 0, &ent);
+    if (ret)
+        goto out2;
+
+    ret = hdb_prune_keys_kvno(context->context, &ent.entry, kvno);
+    if (ret)
+        goto out3;
+
+    ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+    if (ret)
+        goto out3;
+
+    ret = kadm5_log_modify(context, &ent.entry, KADM5_KEY_DATA);
+
+out3:
+    hdb_free_entry(context->context, &ent);
+out2:
+    (void) kadm5_log_end(context);
+out:
+    if (!context->keep_open) {
+        kadm5_ret_t ret2;
+        ret2 = context->db->hdb_close(context->context, context->db);
+        if (ret == 0 && ret2 != 0)
+            ret = ret2;
+    }
+    return _kadm5_error_code(ret);
+}

--- a/lib/kadm5/version-script-client.map
+++ b/lib/kadm5/version-script-client.map
@@ -22,6 +22,7 @@ HEIMDAL_KADM5_CLIENT_1.0 {
 		kadm5_c_init_with_skey;
 		kadm5_c_init_with_skey_ctx;
 		kadm5_c_modify_principal;
+		kadm5_c_prune_principal;
 		kadm5_c_randkey_principal;
 		kadm5_c_rename_principal;
 		kadm5_chpass_principal;

--- a/lib/kadm5/version-script.map
+++ b/lib/kadm5/version-script.map
@@ -37,6 +37,7 @@ HEIMDAL_KAMD5_SERVER_1.0 {
 		kadm5_lock;
 		kadm5_modify_principal;
 		kadm5_modify_policy;
+		kadm5_prune_principal;
 		kadm5_randkey_principal;
 		kadm5_randkey_principal_3;
 		kadm5_rename_principal;

--- a/tests/kdc/check-kadmin.in
+++ b/tests/kdc/check-kadmin.in
@@ -87,6 +87,9 @@ ${kadmin} -l add -p "$foopassword" --use-defaults fez@${R} || exit 1
 ${kadmin} -l add -p "$foopassword" --use-defaults hasalias@${R} || exit 1
 ${kadmin} -l add -p "$foopassword" --use-defaults pkinit@${R} || exit 1
 ${kadmin} -l modify --pkinit-acl="CN=baz,DC=test,DC=h5l,DC=se" pkinit@${R} || exit 1
+${kadmin} -l add -p foo --use-defaults prune@${R} || exit 1
+${kadmin} -l cpw --keepold --random-key prune@${R} || exit 1
+${kadmin} -l cpw --keepold --random-key prune@${R} || exit 1
 
 echo "$foopassword" > ${objdir}/foopassword
 
@@ -353,7 +356,33 @@ if test "`cat kadmin.tmp`" != "Attributes" ; then
 fi
 
 #----------------------------------
+${kadmind} -d &
+kadmpid=$!
+sleep 1
 
+echo "kadmin prune"
+env KRB5CCNAME=${cache} \
+${kadmin} prune --kvno=2 prune@${R} \
+        > kadmin.tmp 2>&1 || \
+        { echo "kadmin failed $?"; cat messages.log ; exit 1; }
+wait $kadmpid || { echo "kadmind failed $?"; cat messages.log ; exit 1; }
+
+${kadmind} -d &
+kadmpid=$!
+sleep 1
+
+env KRB5CCNAME=${cache} \
+${kadmin} get prune@${R} \
+        > kadmin.tmp 2>&1 || \
+        { echo "kadmin failed $?"; cat messages.log ; exit 1; }
+wait $kadmpid || { echo "kadmind failed $?"; cat messages.log ; exit 1; }
+
+cat kadmin.tmp | ${EGREP} Keytypes: | cut -d: -f2 | tr ' ' '
+' | sed 's/^.*[[]\(.*\)[]].*$/\1/' | grep '[0-9]' | sort -nu | tr -d '
+' | ${EGREP} '^13$' > /dev/null || \
+        { echo "kadmin prune failed $?"; cat messages.log ; exit 1; }
+
+#----------------------------------
 
 echo "killing kdc (${kdcpid} ${kadmpid})"
 sh ${leaks_kill} kdc $kdcpid || exit 1


### PR DESCRIPTION
Hello,

please consider and at least comment this PR.


In current implementation (without PR)

* the old keys either stays in the database forever or are prunned 
automagically based on max_lifetime (based on prune-key-history), but 
only on `cpw`, and yet it left the old key in history forever.

* Rotating krbtgt/ (or other principals) wihtout `--keepold` would disrupt 
realm operations, eg. long computing grid jobs.



The added functionality:

* can be used to prune historic keys from principal
history by selective kvno. The main usecase is rollover krbtgt/ principals 
(self and crossrealms).

* it should be backward compatible afaik despite new opcode 
`kadm_ops` struct. During operation a 'modify' type is logged into iprop 
journal but data already contains and ipro processes full key history (KEY_TL_DATA),
so even using patched `kadmin --local` on unpatched `kadmind` would work 
as expected on the slaves.