### PR TITLE
Fix -O3 -Werror=unused-result build in dcache.c

### DIFF
--- a/lib/krb5/dcache.c
+++ b/lib/krb5/dcache.c
@@ -52,10 +52,10 @@ static char *
 primary_create(krb5_dcache *dc)
 {
     char *primary = NULL;
-
-    asprintf(&primary, "%s/primary", dc->dir);
-    if (primary == NULL)
+    int asprintf_ret = asprintf(&primary, "%s/primary", dc->dir);
+    if (asprintf_ret == -1 || primary == NULL) {
 	return NULL;
+    }
 
     return primary;
 }
@@ -75,6 +75,7 @@ set_default_cache(krb5_context context, krb5_dcache *dc, const char *residual)
     struct iovec iov[2];
     size_t len;
     int fd = -1;
+    int asprintf_ret;
 
     if (!is_filename_cacheish(residual)) {
 	krb5_set_error_message(context, KRB5_CC_FORMAT,
@@ -82,9 +83,10 @@ set_default_cache(krb5_context context, krb5_dcache *dc, const char *residual)
 	return KRB5_CC_FORMAT;
     }
 
-    asprintf(&path, "%s/primary-XXXXXX", dc->dir);
-    if (path == NULL)
+    asprintf_ret = asprintf(&path, "%s/primary-XXXXXX", dc->dir);
+    if (asprintf_ret == -1 || path == NULL) {
 	return krb5_enomem(context);
+    }
 
     fd = mkstemp(path);
     if (fd < 0) {
@@ -254,6 +256,7 @@ dcc_resolve(krb5_context context, krb5_ccache *id, const char *res)
     krb5_error_code ret;
     krb5_dcache *dc;
     const char *p;
+    int asprintf_ret;
 
     p = res;
     do {
@@ -337,16 +340,16 @@ dcc_resolve(krb5_context context, krb5_ccache *id, const char *res)
 	    dcc_release(context, dc);
 	    return ret;
 	}
-	asprintf(&dc->name, ":%s/%s", dc->dir, residual);
+	asprintf_ret = asprintf(&dc->name, ":%s/%s", dc->dir, residual);
 	free(residual);
-	if (dc->name == NULL) {
+	if (asprintf_ret == -1 || dc->name == NULL) {
 	    dcc_release(context, dc);
 	    return krb5_enomem(context);
 	}
     }
 
-    asprintf(&filename, "FILE%s", dc->name);
-    if (filename == NULL) {
+    asprintf_ret = asprintf(&filename, "FILE%s", dc->name);
+    if (asprintf_ret == -1 || filename == NULL) {
 	dcc_release(context, dc);
 	return krb5_enomem(context);
     }
@@ -398,6 +401,7 @@ dcc_gen_new(krb5_context context, krb5_ccache *id)
     krb5_dcache *dc;
     int fd;
     size_t len;
+    int asprintf_ret;
 
     name = copy_default_dcc_cache(context);
     if (name == NULL) {
@@ -420,8 +424,8 @@ dcc_gen_new(krb5_context context, krb5_ccache *id)
 
     dc = DCACHE((*id));
 
-    asprintf(&name, ":%s/tktXXXXXX", dc->dir);
-    if (name == NULL) {
+    asprintf_ret = asprintf(&name, ":%s/tktXXXXXX", dc->dir);
+    if (asprintf_ret == -1 || name == NULL) {
 	dcc_close(context, *id);
 	return krb5_enomem(context);
     }


### PR DESCRIPTION
gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.10)
with -O3 -Werror=unused-result

../lib/krb5/dcache.c:85:5: error: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Werror=unused-result]
     asprintf(&path, "%s/primary-XXXXXX", dc->dir);
     ^
../lib/krb5/dcache.c: In function ‘primary_create’:
../lib/krb5/dcache.c:56:5: error: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Werror=unused-result]
     asprintf(&primary, "%s/primary", dc->dir);
     ^
../lib/krb5/dcache.c: In function ‘dcc_gen_new’:
../lib/krb5/dcache.c:423:5: error: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Werror=unused-result]
     asprintf(&name, ":%s/tktXXXXXX", dc->dir);
     ^
../lib/krb5/dcache.c: In function ‘dcc_resolve’:
../lib/krb5/dcache.c:340:2: error: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Werror=unused-result]
  asprintf(&dc->name, ":%s/%s", dc->dir, residual);
  ^
../lib/krb5/dcache.c:348:5: error: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Werror=unused-result]
     asprintf(&filename, "FILE%s", dc->name);
     ^
cc1: all warnings being treated as errors

Signed-off-by: Andrew Bartlett <abartlet@samba.org>