### PR TITLE
lib/kadm5: improve kadm_c_ error handling

### DIFF
--- a/lib/kadm5/ad.c
+++ b/lib/kadm5/ad.c
@@ -492,7 +492,7 @@ ad_get_cred(kadm5_ad_context *context, const char *password)
     aret = asprintf(&service, "%s/%s@%s", KRB5_TGS_NAME,
 		    context->realm, context->realm);
     if (aret == -1 || service == NULL)
-	return ENOMEM;
+	return krb5_enomem(context->context);
 
     ret = _kadm5_c_get_cred_cache(context->context,
 				  context->client_name,
@@ -641,7 +641,7 @@ kadm5_ad_create_principal(void *server_handle,
 
     realmless_p = strdup(p);
     if (realmless_p == NULL) {
-	ret = ENOMEM;
+	ret = krb5_enomem(context->context);
 	goto out;
     }
     s = strrchr(realmless_p, '@');
@@ -652,7 +652,7 @@ kadm5_ad_create_principal(void *server_handle,
 	/* create computer account */
 	asprintf(&samname, "%s$", fqdn);
 	if (samname == NULL) {
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
 	s = strchr(samname, '.');
@@ -663,7 +663,7 @@ kadm5_ad_create_principal(void *server_handle,
 
 	short_spn = strdup(p);
 	if (short_spn == NULL) {
-	    errno = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
 	s = strchr(short_spn, '.');
@@ -676,7 +676,7 @@ kadm5_ad_create_principal(void *server_handle,
 
 	p_msrealm = strdup(p);
 	if (p_msrealm == NULL) {
-	    errno = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
 	s = strrchr(p_msrealm, '@');
@@ -689,7 +689,7 @@ kadm5_ad_create_principal(void *server_handle,
 
 	asprintf(&dn, "cn=%s, cn=Computers, %s", fqdn, CTX2BASE(context));
 	if (dn == NULL) {
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
 
@@ -1277,7 +1277,7 @@ kadm5_ad_randkey_principal(void *server_handle,
 	krb5_generate_random_block(p, sizeof(p));
 	plen = rk_base64_encode(p, sizeof(p), &password);
 	if (plen < 0)
-	    return ENOMEM;
+	    return krb5_enomem(context->context);
     }
 
     ret = ad_get_cred(context, NULL);
@@ -1304,7 +1304,7 @@ kadm5_ad_randkey_principal(void *server_handle,
 
     *keys = malloc(sizeof(**keys) * 1);
     if (*keys == NULL) {
-        ret = ENOMEM;
+	ret = krb5_enomem(context->context);
         goto out;
     }
     *n_keys = 1;
@@ -1404,8 +1404,8 @@ kadm5_ad_init_with_password_ctx(krb5_context context,
     kadm5_ad_context *ctx;
 
     ctx = malloc(sizeof(*ctx));
-    if(ctx == NULL)
-	return ENOMEM;
+    if (ctx == NULL)
+	return krb5_enomem(context);
     memset(ctx, 0, sizeof(*ctx));
     set_funcs(ctx);
 
@@ -1422,7 +1422,7 @@ kadm5_ad_init_with_password_ctx(krb5_context context,
 	ret = 0;
 	ctx->realm = strdup(realm_params->realm);
 	if (ctx->realm == NULL)
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context);
     } else
 	ret = krb5_get_default_realm(ctx->context, &ctx->realm);
     if (ret) {

--- a/lib/kadm5/chpass_c.c
+++ b/lib/kadm5/chpass_c.c
@@ -66,8 +66,8 @@ kadm5_c_chpass_principal(void *server_handle,
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_store_int32(sp, kadm_chpass);
     if (ret)
@@ -90,8 +90,8 @@ kadm5_c_chpass_principal(void *server_handle,
     krb5_storage_free(sp);
     sp = krb5_storage_from_data(&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)
@@ -99,6 +99,8 @@ kadm5_c_chpass_principal(void *server_handle,
 
   out:
     krb5_clear_error_message(context->context);
+
+  out_keep_error:
     krb5_storage_free(sp);
     krb5_data_free(&reply);
     return ret;
@@ -127,8 +129,8 @@ kadm5_c_chpass_principal_with_key(void *server_handle,
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_store_int32(sp, kadm_chpass_with_key);
     if (ret)
@@ -156,8 +158,8 @@ kadm5_c_chpass_principal_with_key(void *server_handle,
     krb5_storage_free(sp);
     sp = krb5_storage_from_data (&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)

--- a/lib/kadm5/common_glue.c
+++ b/lib/kadm5/common_glue.c
@@ -152,6 +152,7 @@ kadm5_decrypt_key(void *server_handle,
                   krb5_keysalt *keysalt, int *kvnop)
 {
     size_t i;
+    kadm5_server_context *context = server_handle;
 
     if (kvno < 1 || stype != -1)
 	return KADM5_DECRYPT_USAGE_NOSUPP;
@@ -164,7 +165,7 @@ kadm5_decrypt_key(void *server_handle,
 	keyblock->keyvalue.length = entry->key_data[i].key_data_length[0];
 	keyblock->keyvalue.data = malloc(keyblock->keyvalue.length);
 	if (keyblock->keyvalue.data == NULL)
-	    return ENOMEM;
+	    return krb5_enomem(context->context);
 	memcpy(keyblock->keyvalue.data,
 	       entry->key_data[i].key_data_contents[0],
 	       keyblock->keyvalue.length);
@@ -260,6 +261,7 @@ kadm5_setkey_principal_3(void *server_handle,
     kadm5_ret_t ret;
     krb5_key_data *new_key_data = NULL;
     size_t i;
+    kadm5_server_context *context = server_handle;
 
     if (n_keys < 1)
 	return EINVAL;
@@ -286,7 +288,7 @@ kadm5_setkey_principal_3(void *server_handle,
         new_key_data = calloc((n_keys + princ_ent.n_key_data),
                               sizeof(*new_key_data));
 	if (new_key_data == NULL) {
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
 
@@ -295,7 +297,7 @@ kadm5_setkey_principal_3(void *server_handle,
     } else {
 	new_key_data = calloc(n_keys, sizeof(*new_key_data));
 	if (new_key_data == NULL) {
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
     }
@@ -311,7 +313,7 @@ kadm5_setkey_principal_3(void *server_handle,
 	new_key_data[i].key_data_contents[0] =
 	    malloc(keyblocks[i].keyvalue.length);
 	if (new_key_data[i].key_data_contents[0] == NULL) {
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
 	memcpy(new_key_data[i].key_data_contents[0],

--- a/lib/kadm5/context_s.c
+++ b/lib/kadm5/context_s.c
@@ -161,28 +161,28 @@ find_db_spec(kadm5_server_context *ctx)
 	    if (p) {
 		ctx->config.dbname = strdup(p);
                 if (ctx->config.dbname == NULL)
-                    return ENOMEM;
+		    return krb5_enomem(context);
             }
 
 	    p = hdb_dbinfo_get_acl_file(context, d);
 	    if (p) {
 		ctx->config.acl_file = strdup(p);
                 if (ctx->config.acl_file == NULL)
-                    return ENOMEM;
+		    return krb5_enomem(context);
             }
 
 	    p = hdb_dbinfo_get_mkey_file(context, d);
 	    if (p) {
 		ctx->config.stash_file = strdup(p);
                 if (ctx->config.stash_file == NULL)
-                    return ENOMEM;
+		    return krb5_enomem(context);
             }
 
 	    p = hdb_dbinfo_get_log_file(context, d);
 	    if (p) {
 		ctx->log_context.log_file = strdup(p);
                 if (ctx->log_context.log_file == NULL)
-                    return ENOMEM;
+		    return krb5_enomem(context);
             }
 	    break;
 	}
@@ -194,25 +194,25 @@ find_db_spec(kadm5_server_context *ctx)
     if (ctx->config.dbname == NULL) {
 	ctx->config.dbname = strdup(hdb_default_db(context));
         if (ctx->config.dbname == NULL)
-            return ENOMEM;
+	    return krb5_enomem(context);
     }
     if (ctx->config.acl_file == NULL) {
 	aret = asprintf(&ctx->config.acl_file, "%s/kadmind.acl",
 			hdb_db_dir(context));
 	if (aret == -1)
-	    return ENOMEM;
+	    return krb5_enomem(context);
     }
     if (ctx->config.stash_file == NULL) {
 	aret = asprintf(&ctx->config.stash_file, "%s/m-key",
 			hdb_db_dir(context));
 	if (aret == -1)
-	    return ENOMEM;
+	    return krb5_enomem(context);
     }
     if (ctx->log_context.log_file == NULL) {
 	aret = asprintf(&ctx->log_context.log_file, "%s/log",
 			hdb_db_dir(context));
 	if (aret == -1)
-	    return ENOMEM;
+	    return krb5_enomem(context);
     }
 
 #ifndef NO_UNIX_SOCKETS
@@ -233,7 +233,7 @@ _kadm5_s_init_context(kadm5_server_context **ctx,
 
     *ctx = calloc(1, sizeof(**ctx));
     if (*ctx == NULL)
-	return ENOMEM;
+	return krb5_enomem(context);
     (*ctx)->log_context.socket_fd = rk_INVALID_SOCKET;
 
     set_funcs(*ctx);
@@ -244,7 +244,7 @@ _kadm5_s_init_context(kadm5_server_context **ctx,
     if (is_set(REALM)) {
 	(*ctx)->config.realm = strdup(params->realm);
         if ((*ctx)->config.realm == NULL)
-            return ENOMEM;
+	    return krb5_enomem(context);
     } else {
 	ret = krb5_get_default_realm(context, &(*ctx)->config.realm);
         if (ret)
@@ -253,17 +253,17 @@ _kadm5_s_init_context(kadm5_server_context **ctx,
     if (is_set(DBNAME)) {
 	(*ctx)->config.dbname = strdup(params->dbname);
         if ((*ctx)->config.dbname == NULL)
-            return ENOMEM;
+	    return krb5_enomem(context);
     }
     if (is_set(ACL_FILE)) {
 	(*ctx)->config.acl_file = strdup(params->acl_file);
         if ((*ctx)->config.acl_file == NULL)
-            return ENOMEM;
+	    return krb5_enomem(context);
     }
     if (is_set(STASH_FILE)) {
 	(*ctx)->config.stash_file = strdup(params->stash_file);
         if ((*ctx)->config.stash_file == NULL)
-            return ENOMEM;
+	    return krb5_enomem(context);
     }
 
     find_db_spec(*ctx);

--- a/lib/kadm5/create_c.c
+++ b/lib/kadm5/create_c.c
@@ -66,7 +66,7 @@ kadm5_c_create_principal(void *server_handle,
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
+	ret = krb5_enomem(context->context);
 	goto out;
     }
     ret = krb5_store_int32(sp, kadm_create);
@@ -90,8 +90,8 @@ kadm5_c_create_principal(void *server_handle,
     krb5_storage_free(sp);
     sp = krb5_storage_from_data(&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)

--- a/lib/kadm5/delete_c.c
+++ b/lib/kadm5/delete_c.c
@@ -53,8 +53,8 @@ kadm5_c_delete_principal(void *server_handle, krb5_principal princ)
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_store_int32(sp, kadm_delete);
     if (ret)
@@ -71,8 +71,8 @@ kadm5_c_delete_principal(void *server_handle, krb5_principal princ)
     krb5_storage_free(sp);
     sp = krb5_storage_from_data(&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)

--- a/lib/kadm5/delete_c.c
+++ b/lib/kadm5/delete_c.c
@@ -46,32 +46,43 @@ kadm5_c_delete_principal(void *server_handle, krb5_principal princ)
     krb5_data reply;
 
     ret = _kadm5_connect(server_handle);
-    if(ret)
+    if (ret)
 	return ret;
+
+    krb5_data_zero(&reply);
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	krb5_clear_error_message(context->context);
-	return ENOMEM;
+	ret = ENOMEM;
+	goto out;
     }
-    krb5_store_int32(sp, kadm_delete);
-    krb5_store_principal(sp, princ);
-    ret = _kadm5_client_send(context, sp);
-    krb5_storage_free(sp);
+    ret = krb5_store_int32(sp, kadm_delete);
     if (ret)
-	return ret;
+	goto out;
+    ret = krb5_store_principal(sp, princ);
+    if (ret)
+	goto out;
+    ret = _kadm5_client_send(context, sp);
+    if (ret)
+	goto out_keep_error;
     ret = _kadm5_client_recv(context, &reply);
     if (ret)
-	return ret;
-    sp = krb5_storage_from_data (&reply);
-    if(sp == NULL) {
-	krb5_clear_error_message(context->context);
-	krb5_data_free (&reply);
-	return ENOMEM;
-    }
-    krb5_ret_int32(sp, &tmp);
-    krb5_clear_error_message(context->context);
+	goto out_keep_error;
     krb5_storage_free(sp);
-    krb5_data_free (&reply);
-    return tmp;
+    sp = krb5_storage_from_data(&reply);
+    if (sp == NULL) {
+	ret = ENOMEM;
+	goto out;
+    }
+    ret = krb5_ret_int32(sp, &tmp);
+    if (ret == 0)
+	ret = tmp;
+
+  out:
+    krb5_clear_error_message(context->context);
+
+  out_keep_error:
+    krb5_storage_free(sp);
+    krb5_data_free(&reply);
+    return ret;
 }

--- a/lib/kadm5/get_c.c
+++ b/lib/kadm5/get_c.c
@@ -56,8 +56,8 @@ kadm5_c_get_principal(void *server_handle,
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_store_int32(sp, kadm_get);
     if (ret)
@@ -77,8 +77,8 @@ kadm5_c_get_principal(void *server_handle,
     krb5_storage_free(sp);
     sp = krb5_storage_from_data(&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)

--- a/lib/kadm5/get_princs_c.c
+++ b/lib/kadm5/get_princs_c.c
@@ -60,8 +60,8 @@ kadm5_c_get_principals(void *server_handle,
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_store_int32(sp, kadm_get_princs);
     if (ret)
@@ -83,8 +83,8 @@ kadm5_c_get_principals(void *server_handle,
     krb5_storage_free(sp);
     sp = krb5_storage_from_data (&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)
@@ -99,8 +99,8 @@ kadm5_c_get_principals(void *server_handle,
 
     *princs = calloc(tmp + 1, sizeof(**princs));
     if (*princs == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     for (i = 0; i < tmp; i++) {
 	ret = krb5_ret_string(sp, &(*princs)[i]);

--- a/lib/kadm5/get_s.c
+++ b/lib/kadm5/get_s.c
@@ -89,7 +89,7 @@ copy_keyset_to_kadm5(kadm5_server_context *context, krb5_kvno kvno,
 	kd->key_data_length[0] = key->key.keyvalue.length;
 	kd->key_data_contents[0] = malloc(kd->key_data_length[0]);
 	if(kd->key_data_contents[0] == NULL && kd->key_data_length[0] != 0){
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    break;
 	}
 	memcpy(kd->key_data_contents[0], key->key.keyvalue.data,
@@ -104,7 +104,7 @@ copy_keyset_to_kadm5(kadm5_server_context *context, krb5_kvno kvno,
 	if(kd->key_data_length[1] != 0
 	   && kd->key_data_contents[1] == NULL) {
 	    memset(kd->key_data_contents[0], 0, kd->key_data_length[0]);
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    break;
 	}
 	memcpy(kd->key_data_contents[1], sp->data, kd->key_data_length[1]);
@@ -244,7 +244,7 @@ kadm5_s_get_principal(void *server_handle,
 	} else {
 	    out->policy = strdup(ext->data.u.policy);
 	    if (out->policy == NULL) {
-		ret = ENOMEM;
+		ret = krb5_enomem(context->context);
 		goto out;
 	    }
 	}
@@ -275,7 +275,7 @@ kadm5_s_get_principal(void *server_handle,
 	    n_keys += hist_keys->val[i].keys.len;
 	out->key_data = malloc(n_keys * sizeof(*out->key_data));
 	if (out->key_data == NULL && n_keys != 0) {
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
 	out->n_key_data = 0;

--- a/lib/kadm5/init_c.c
+++ b/lib/kadm5/init_c.c
@@ -89,7 +89,7 @@ _kadm5_c_init_context(kadm5_client_context **ctx,
 
     *ctx = malloc(sizeof(**ctx));
     if(*ctx == NULL)
-	return ENOMEM;
+	return krb5_enomem(context);
     memset(*ctx, 0, sizeof(**ctx));
     krb5_add_et_list (context, initialize_kadm5_error_table_r);
     set_funcs(*ctx);
@@ -98,7 +98,7 @@ _kadm5_c_init_context(kadm5_client_context **ctx,
 	ret = 0;
 	(*ctx)->realm = strdup(params->realm);
 	if ((*ctx)->realm == NULL)
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context);
     } else
 	ret = krb5_get_default_realm((*ctx)->context, &(*ctx)->realm);
     if (ret) {
@@ -123,7 +123,7 @@ _kadm5_c_init_context(kadm5_client_context **ctx,
     if ((*ctx)->admin_server == NULL) {
 	free((*ctx)->realm);
 	free(*ctx);
-	return ENOMEM;
+	return krb5_enomem(context);
     }
     colon = strchr ((*ctx)->admin_server, ':');
     if (colon != NULL)
@@ -489,8 +489,7 @@ kadm_connect(kadm5_client_context *ctx)
     if (error == -1 || service_name == NULL) {
 	freeaddrinfo (ai);
 	rk_closesocket(s);
-	krb5_clear_error_message(context);
-	return ENOMEM;
+	return krb5_enomem(context);
     }
 
     ret = krb5_parse_name(context, service_name, &server);

--- a/lib/kadm5/ipropd_master.c
+++ b/lib/kadm5/ipropd_master.c
@@ -331,7 +331,7 @@ dump_one (krb5_context context, HDB *db, hdb_entry_ex *entry, void *v)
     memmove ((char *)data.data + 4, data.data, data.length - 4);
     sp = krb5_storage_from_data(&data);
     if (sp == NULL) {
-	ret = ENOMEM;
+	ret = krb5_enomem(context);
 	goto done;
     }
     ret = krb5_store_uint32(sp, ONE_PRINC);
@@ -466,10 +466,8 @@ send_complete (krb5_context context, slave *s, const char *database,
     char *dfn;
 
     ret = asprintf(&dfn, "%s/ipropd.dumpfile", hdb_db_dir(context));
-    if (ret == -1 || !dfn) {
-	krb5_warn(context, ENOMEM, "Cannot allocate memory");
-	return ENOMEM;
-    }
+    if (ret == -1 || !dfn)
+	return krb5_enomem(context);
 
     fd = open(dfn, O_CREAT|O_RDWR, 0600);
     if (fd == -1) {

--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -216,10 +216,8 @@ append_to_log_file(krb5_context context,
         return EOVERFLOW;
 
     buf = malloc(len);
-    if (buf == NULL && len != 0) {
-        krb5_warn(context, errno, "malloc: no memory");
-        return ENOMEM;
-    }
+    if (buf == NULL && len != 0)
+	return krb5_enomem(context);
 
     if (krb5_storage_seek(sp, start, SEEK_SET) != start) {
         krb5_errx(context, IPROPD_RESTART,

--- a/lib/kadm5/log.c
+++ b/lib/kadm5/log.c
@@ -867,7 +867,7 @@ kadm5_log_flush(kadm5_server_context *context, krb5_storage *sp)
     sp = krb5_storage_from_fd(log_context->log_fd);
     if (sp == NULL) {
         krb5_data_free(&data);
-        return ENOMEM;
+	return krb5_enomem(context->context);
     }
 
     /* Check that we are at the end of the log and fail if not */
@@ -971,7 +971,7 @@ kadm5_log_create(kadm5_server_context *context, hdb_entry *entry)
         return ret;
     sp = krb5_storage_emem();
     if (sp == NULL)
-        ret = ENOMEM;
+	ret = krb5_enomem(context->context);
     if (ret == 0)
         ret = kadm5_log_preamble(context, sp, kadm_create,
                                  log_context->version + 1);
@@ -980,7 +980,7 @@ kadm5_log_create(kadm5_server_context *context, hdb_entry *entry)
     if (ret == 0) {
         bytes = krb5_storage_write(sp, value.data, value.length);
         if (bytes != (krb5_ssize_t)value.length)
-            ret = bytes == -1 ? errno : ENOMEM;
+	    ret = bytes == -1 ? errno : krb5_enomem(context->context);
     }
     if (ret == 0)
         ret = krb5_store_uint32(sp, value.length);
@@ -1054,7 +1054,7 @@ kadm5_log_delete(kadm5_server_context *context,
         return ret;
     sp = krb5_storage_emem();
     if (sp == NULL)
-        ret = ENOMEM;
+	ret = krb5_enomem(context->context);
     if (ret == 0)
         ret = kadm5_log_preamble(context, sp, kadm_delete,
                                  log_context->version + 1);
@@ -1185,7 +1185,7 @@ kadm5_log_rename(kadm5_server_context *context,
     sp = krb5_storage_emem();
     krb5_data_zero(&value);
     if (sp == NULL)
-	ret = ENOMEM;
+	ret = krb5_enomem(context->context);
     if (ret == 0)
         ret = kadm5_log_preamble(context, sp, kadm_rename,
                                  log_context->version + 1);
@@ -1212,7 +1212,7 @@ kadm5_log_rename(kadm5_server_context *context,
         errno = 0;
         bytes = krb5_storage_write(sp, value.data, value.length);
         if (bytes != (krb5_ssize_t)value.length)
-            ret = bytes == -1 ? errno : ENOMEM;
+	    ret = bytes == -1 ? errno : krb5_enomem(context->context);
     }
     if (ret == 0) {
         end_off = krb5_storage_seek(sp, 0, SEEK_CUR);
@@ -1335,7 +1335,7 @@ kadm5_log_modify(kadm5_server_context *context,
     sp = krb5_storage_emem();
     krb5_data_zero(&value);
     if (sp == NULL)
-        ret = ENOMEM;
+	ret = krb5_enomem(context->context);
     if (ret == 0)
         ret = hdb_entry2value(context->context, entry, &value);
     if (ret) {
@@ -1357,7 +1357,7 @@ kadm5_log_modify(kadm5_server_context *context,
     if (ret == 0) {
         bytes = krb5_storage_write(sp, value.data, value.length);
         if (bytes != (krb5_ssize_t)value.length)
-            ret = bytes == -1 ? errno : ENOMEM;
+	    ret = bytes == -1 ? errno : krb5_enomem(context->context);
     }
     if (ret == 0)
         ret = krb5_store_uint32(sp, len);
@@ -1422,8 +1422,7 @@ kadm5_log_replay_modify(kadm5_server_context *context,
 	    if (ent.entry.valid_end == NULL) {
 		ent.entry.valid_end = malloc(sizeof(*ent.entry.valid_end));
 		if (ent.entry.valid_end == NULL) {
-		    ret = ENOMEM;
-		    krb5_set_error_message(context->context, ret, "out of memory");
+		    ret = krb5_enomem(context->context);
 		    goto out;
 		}
 	    }
@@ -1437,8 +1436,7 @@ kadm5_log_replay_modify(kadm5_server_context *context,
 	    if (ent.entry.pw_end == NULL) {
 		ent.entry.pw_end = malloc(sizeof(*ent.entry.pw_end));
 		if (ent.entry.pw_end == NULL) {
-		    ret = ENOMEM;
-		    krb5_set_error_message(context->context, ret, "out of memory");
+		    ret = krb5_enomem(context->context);
 		    goto out;
 		}
 	    }
@@ -1459,8 +1457,7 @@ kadm5_log_replay_modify(kadm5_server_context *context,
 	    if (ent.entry.max_life == NULL) {
 		ent.entry.max_life = malloc (sizeof(*ent.entry.max_life));
 		if (ent.entry.max_life == NULL) {
-		    ret = ENOMEM;
-		    krb5_set_error_message(context->context, ret, "out of memory");
+		    ret = krb5_enomem(context->context);
 		    goto out;
 		}
 	    }
@@ -1471,15 +1468,14 @@ kadm5_log_replay_modify(kadm5_server_context *context,
 	if (ent.entry.modified_by == NULL) {
 	    ent.entry.modified_by = malloc(sizeof(*ent.entry.modified_by));
 	    if (ent.entry.modified_by == NULL) {
-		ret = ENOMEM;
-		krb5_set_error_message(context->context, ret, "out of memory");
+		ret = krb5_enomem(context->context);
 		goto out;
 	    }
 	} else
 	    free_Event(ent.entry.modified_by);
 	ret = copy_Event(log_ent.entry.modified_by, ent.entry.modified_by);
 	if (ret) {
-	    krb5_set_error_message(context->context, ret, "out of memory");
+	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
     }
@@ -1503,8 +1499,7 @@ kadm5_log_replay_modify(kadm5_server_context *context,
 	    if (ent.entry.max_renew == NULL) {
 		ent.entry.max_renew = malloc (sizeof(*ent.entry.max_renew));
 		if (ent.entry.max_renew == NULL) {
-		    ret = ENOMEM;
-		    krb5_set_error_message(context->context, ret, "out of memory");
+		    ret = krb5_enomem(context->context);
 		    goto out;
 		}
 	    }
@@ -1543,8 +1538,7 @@ kadm5_log_replay_modify(kadm5_server_context *context,
 	ent.entry.keys.len = num;
 	ent.entry.keys.val = malloc(len * sizeof(*ent.entry.keys.val));
 	if (ent.entry.keys.val == NULL) {
-	    krb5_set_error_message(context->context, ENOMEM, "out of memory");
-            ret = ENOMEM;
+	    krb5_enomem(context->context);
 	    goto out;
 	}
 	for (i = 0; i < ent.entry.keys.len; ++i) {
@@ -1607,12 +1601,12 @@ log_update_uber(kadm5_server_context *context, off_t off)
 
     mem_sp = krb5_storage_emem();
     if (mem_sp == NULL)
-        return ENOMEM;
+	return krb5_enomem(context->context);
 
     sp = krb5_storage_from_fd(log_context->log_fd);
     if (sp == NULL) {
         krb5_storage_free(mem_sp);
-        return ENOMEM;
+	return krb5_enomem(context->context);
     }
 
     /* Skip first entry's version and timestamp */
@@ -2554,7 +2548,7 @@ kadm5_log_truncate(kadm5_server_context *context, size_t keep, size_t maxbytes)
     (void) lseek(context->log_context.log_fd, off, SEEK_SET);
     sp = kadm5_log_goto_end(context, context->log_context.log_fd);
     if (sp == NULL)
-        return ENOMEM;
+	return krb5_enomem(context->context);
     ret = get_version_prev(sp, &context->log_context.version, &last_tstamp);
     context->log_context.last_time = last_tstamp;
     krb5_storage_free(sp);

--- a/lib/kadm5/modify_c.c
+++ b/lib/kadm5/modify_c.c
@@ -55,8 +55,8 @@ kadm5_c_modify_principal(void *server_handle,
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_store_int32(sp, kadm_modify);
     if (ret)
@@ -76,8 +76,8 @@ kadm5_c_modify_principal(void *server_handle,
     krb5_storage_free(sp);
     sp = krb5_storage_from_data(&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)

--- a/lib/kadm5/modify_s.c
+++ b/lib/kadm5/modify_s.c
@@ -100,7 +100,7 @@ modify_principal(void *server_handle,
 	ext.data.element = choice_HDB_extension_data_policy;
 	ext.data.u.policy = strdup(princ->policy);
 	if (ext.data.u.policy == NULL) {
-	    ret = ENOMEM;
+	    ret = krb5_enomem(context->context);
 	    goto out3;
 	}
 	/* This calls free_HDB_extension(), freeing ext.data.u.policy */

--- a/lib/kadm5/privs_c.c
+++ b/lib/kadm5/privs_c.c
@@ -55,8 +55,8 @@ kadm5_c_get_privs(void *server_handle, uint32_t *privs)
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_store_int32(sp, kadm_get_privs);
     if (ret)
@@ -70,8 +70,8 @@ kadm5_c_get_privs(void *server_handle, uint32_t *privs)
     krb5_storage_free(sp);
     sp = krb5_storage_from_data(&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)

--- a/lib/kadm5/randkey_c.c
+++ b/lib/kadm5/randkey_c.c
@@ -61,8 +61,8 @@ kadm5_c_randkey_principal(void *server_handle,
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
 
     /*
@@ -108,8 +108,8 @@ kadm5_c_randkey_principal(void *server_handle,
     krb5_storage_free(sp);
     sp = krb5_storage_from_data(&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)
@@ -126,8 +126,8 @@ kadm5_c_randkey_principal(void *server_handle,
     }
     k = calloc(tmp, sizeof(*k));
     if (k == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     for (i = 0; ret == 0 && i < tmp; i++) {
 	ret = krb5_ret_keyblock(sp, &k[i]);

--- a/lib/kadm5/rename_c.c
+++ b/lib/kadm5/rename_c.c
@@ -55,8 +55,8 @@ kadm5_c_rename_principal(void *server_handle,
 
     sp = krb5_storage_from_mem(buf, sizeof(buf));
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
 
     ret = krb5_store_int32(sp, kadm_rename);
@@ -77,8 +77,8 @@ kadm5_c_rename_principal(void *server_handle,
     krb5_storage_free(sp);
     sp = krb5_storage_from_data(&reply);
     if (sp == NULL) {
-	ret = ENOMEM;
-	goto out;
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
     }
     ret = krb5_ret_int32(sp, &tmp);
     if (ret == 0)

--- a/lib/kadm5/rename_s.c
+++ b/lib/kadm5/rename_s.c
@@ -80,7 +80,7 @@ kadm5_s_rename_principal(void *server_handle,
 		ent.entry.keys.val[i].salt =
 		    malloc(sizeof(*ent.entry.keys.val[i].salt));
 		if (ent.entry.keys.val[i].salt == NULL)
-		    ret = ENOMEM;
+		    ret = krb5_enomem(context->context);
                 else
                     ret = copy_Salt(&salt, ent.entry.keys.val[i].salt);
 		if (ret)

--- a/lib/kadm5/send_recv.c
+++ b/lib/kadm5/send_recv.c
@@ -61,9 +61,8 @@ _kadm5_client_send(kadm5_client_context *context, krb5_storage *sp)
 
     sock = krb5_storage_from_socket(context->sock);
     if(sock == NULL) {
-	krb5_clear_error_message(context->context);
 	krb5_data_free(&out);
-	return ENOMEM;
+	return krb5_enomem(context->context);
     }
 
     ret = krb5_store_data(sock, out);
@@ -82,11 +81,10 @@ _kadm5_client_recv(kadm5_client_context *context, krb5_data *reply)
     krb5_storage *sock;
 
     sock = krb5_storage_from_socket(context->sock);
-    if(sock == NULL) {
-	krb5_clear_error_message(context->context);
-	return ENOMEM;
-    }
+    if (sock == NULL)
+	return krb5_enomem(context->context);
     ret = krb5_ret_data(sock, &data);
+
     krb5_storage_free(sock);
     krb5_clear_error_message(context->context);
     if(ret == KRB5_CC_END)

--- a/lib/kadm5/set_keys.c
+++ b/lib/kadm5/set_keys.c
@@ -286,7 +286,7 @@ _kadm5_set_keys3(kadm5_server_context *context,
     len  = n_keys;
     keys = malloc (len * sizeof(*keys));
     if (keys == NULL && len != 0)
-	return ENOMEM;
+	return krb5_enomem(context->context);
 
     _kadm5_init_keys (keys, len);
 
@@ -351,7 +351,7 @@ _kadm5_set_keys_randomly (kadm5_server_context *context,
 
    kblock = malloc(num_keys * sizeof(kblock[0]));
    if (kblock == NULL) {
-	ret = ENOMEM;
+	ret = krb5_enomem(context->context);
 	_kadm5_free_keys (context->context, num_keys, keys);
 	return ret;
    }

--- a/lib/kadm5/set_modifier.c
+++ b/lib/kadm5/set_modifier.c
@@ -43,7 +43,7 @@ _kadm5_set_modifier(kadm5_server_context *context,
     if(ent->modified_by == NULL){
 	ent->modified_by = malloc(sizeof(*ent->modified_by));
 	if(ent->modified_by == NULL)
-	    return ENOMEM;
+	    return krb5_enomem(context->context);
     } else
 	free_Event(ent->modified_by);
     ent->modified_by->time = time(NULL);


### PR DESCRIPTION
Perform error checking for each function call and consistently return
errors at the point of failure.

Refactor functions to use a common exit path.  Preserve error messages
stored in the kadm5_client_context.context when appropriate.

Change-Id: I7aa04020e4de3454066f0d88ba805fed999dbd1a