### PR TITLE
lib/krb5: Do not re-send the AS-REQ if fast was disabled

### DIFF
--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -2414,6 +2414,9 @@ krb5_init_creds_step(krb5_context context,
  
  		if (ctx->fast_state.flags & KRB5_FAST_DISABLED)
  		    goto out;
+		if (!(ctx->fast_state.flags & KRB5_FAST_EXPECTED)) {
+		    goto out;
+		}
  		if (ctx->fast_state.flags & (KRB5_FAST_REQUIRED | KRB5_FAST_EXPECTED))
  		    goto out;
  


### PR DESCRIPTION
Without this, in an AS-REQ that has no local key for FAST
we would send the AS-REQ again, which can bump the bad
password count on the KDC twice.

So only try again if FAST was actually tried.

Signed-off-by: Andrew Bartlett <abartlet@samba.org>