### PR TITLE
Clear DES key (schedule) in unwrap BAD_MIC case

### DIFF
--- a/lib/gssapi/krb5/unwrap.c
+++ b/lib/gssapi/krb5/unwrap.c
@@ -135,8 +135,11 @@ unwrap_des
   DES_set_key_unchecked (&deskey, &schedule);
   DES_cbc_cksum ((void *)hash, (void *)hash, sizeof(hash),
 		 &schedule, &zero);
-  if (ct_memcmp (p - 8, hash, 8) != 0)
+  if (ct_memcmp (p - 8, hash, 8) != 0) {
+    memset_s(&deskey, sizeof(deskey), 0, sizeof(deskey));
+    memset_s(&schedule, sizeof(schedule), 0, sizeof(schedule));
     return GSS_S_BAD_MIC;
+  }
 
   /* verify sequence number */
 


### PR DESCRIPTION
We generally clear out the cryptographic key and key schedule from
local variables before relinquishing control flow, but this case was
missed.  Reported by jhb@FreeBSD.org.