### PR TITLE
lib/kadm5: kadmin hook_libraries plugin interface

### DIFF
--- a/lib/kadm5/kadm5-hook.h
+++ b/lib/kadm5/kadm5-hook.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2010
+ *     The Board of Trustees of the Leland Stanford Junior University
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef KADM5_HOOK_H
+#define KADM5_HOOK_H 1
+
+#define KADM5_HOOK_VERSION_V0 0
+
+/*
+ * Each hook is called before the operation using KADM5_STAGE_PRECOMMIT and
+ * then after the operation using KADM5_STAGE_POSTCOMMIT.  If the hook returns
+ * failure during precommit, the operation is aborted without changes to the
+ * database.
+ */
+enum kadm5_hook_stage {
+    KADM5_HOOK_STAGE_PRECOMMIT,
+    KADM5_HOOK_STAGE_POSTCOMMIT
+};
+
+/*
+ * libkadm5srv expects a symbol named kadm5_hook_v0 exported by the dynamicaly
+ * loaded module and of type kadm5_hook.  version must be
+ * KADM5_HOOK_VERSION_V0.  Any or all of the function pointers may be NULL, in
+ * which case that hook will not be called.
+ */
+typedef struct kadm5_hook {
+    const char *name;
+    int version;
+    const char *vendor;
+
+    krb5_error_code (*init)(krb5_context, void **);
+    void (*fini)(krb5_context, void *);
+
+    krb5_error_code (*chpass)(krb5_context, void *, enum kadm5_hook_stage,
+			      krb5_principal, const char *);
+    krb5_error_code (*create)(krb5_context, void *, enum kadm5_hook_stage,
+			      kadm5_principal_ent_t, uint32_t mask,
+			      const char *password);
+    krb5_error_code (*modify)(krb5_context, void *, enum kadm5_hook_stage,
+			      kadm5_principal_ent_t, uint32_t mask);
+
+#if 0
+    krb5_error_code (*delete)(krb5_context, void *, enum kadm5_hook_stage,
+			      krb5_principal);
+    krb5_error_code (*randkey)(krb5_context, void *, enum kadm5_hook_stage,
+			       krb5_principal);
+    krb5_error_code (*rename)(krb5_context, void *, enum kadm5_hook_stage,
+			      krb5_principal source, krb5_principal target);
+#endif
+} kadm5_hook;
+
+#endif /* !KADM5_HOOK_H */

--- a/lib/kadm5/server_hooks.c
+++ b/lib/kadm5/server_hooks.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2010
+ *     The Board of Trustees of the Leland Stanford Junior University
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "kadm5_locl.h"
+#include <dlfcn.h>
+
+#ifndef RTLD_NOW
+# define RTLD_NOW 0
+#endif
+
+/*
+ * Load kadmin server hooks.
+ */
+#ifdef HAVE_DLOPEN
+
+kadm5_ret_t
+_kadm5_s_init_hooks(kadm5_server_context *ctx)
+{
+    krb5_context context = ctx->context;
+    char **libraries;
+    const char *library;
+    int i;
+    void *handle = NULL;
+    struct kadm5_hook *hook;
+    struct kadm5_hook_context *hook_context = NULL;
+    struct kadm5_hook_context **tmp;
+    kadm5_ret_t ret = KADM5_BAD_SERVER_NAME;
+
+    libraries = krb5_config_get_strings(context, NULL,
+					"kadmin", "hook_libraries", NULL);
+    if (libraries == NULL)
+	return 0;
+    for (i = 0; libraries[i] != NULL; i++) {
+	library = libraries[i];
+	handle = dlopen(library, RTLD_NOW);
+	if (handle == NULL) {
+	    krb5_warnx(context, "failed to open `%s': %s", library, dlerror());
+	    goto fail;
+	}
+	hook = dlsym(handle, "kadm5_hook_v0");
+	if (hook == NULL) {
+	    krb5_warnx(context, "didn't find `kadm5_hook_v0' symbol in `%s':"
+		       " %s", library, dlerror());
+	    goto fail;
+	}
+	if (hook->version != KADM5_HOOK_VERSION_V0) {
+	    krb5_warnx(context, "version of loaded library `%s' is %d"
+		       " (expected %d)", library, hook->version,
+		       KADM5_HOOK_VERSION_V0);
+	    goto fail;
+	}
+	hook_context = malloc(sizeof(*hook_context));
+	if (hook_context == NULL) {
+	    krb5_warnx(context, "out of memory");
+	    ret = errno;
+	    goto fail;
+	}
+	hook_context->handle = handle;
+	hook_context->hook = hook;
+	if (hook->init == NULL) {
+	    hook_context->data = NULL;
+	} else {
+	    ret = hook->init(context, &hook_context->data);
+	    if (ret != 0) {
+		krb5_warn(context, ret, "initialization of `%s' failed",
+			  library);
+		goto fail;
+	    }
+	}
+	tmp = realloc(ctx->hooks, (ctx->num_hooks + 1) * sizeof(*tmp));
+	if (tmp == NULL) {
+	    krb5_warnx(context, "out of memory");
+	    ret = errno;
+	    goto fail;
+	}
+	ctx->hooks = tmp;
+	ctx->hooks[ctx->num_hooks] = hook_context;
+	hook_context = NULL;
+	ctx->num_hooks++;
+    }
+    return 0;
+
+fail:
+    _kadm5_s_free_hooks(ctx);
+    if (hook_context != NULL)
+	free(hook_context);
+    if (handle != NULL)
+	dlclose(handle);
+    return ret;
+}
+
+void
+_kadm5_s_free_hooks(kadm5_server_context *ctx)
+{
+    int i;
+    struct kadm5_hook *hook;
+
+    for (i = 0; i < ctx->num_hooks; i++) {
+	if (ctx->hooks[i]->hook->fini != NULL)
+	    ctx->hooks[i]->hook->fini(ctx->context, ctx->hooks[i]->data);
+	dlclose(ctx->hooks[i]->handle);
+	free(ctx->hooks[i]);
+    }
+    free(ctx->hooks);
+    ctx->hooks = NULL;
+    ctx->num_hooks = 0;
+}
+
+# else /* !HAVE_DLOPEN */
+
+kadm5_ret_t
+_kadm5_s_init_hooks(kadm5_server_context *ctx)
+{
+    return 0;
+}
+
+void
+_kadm5_s_free_hooks(kadm5_server_context *ctx)
+{
+    return 0;
+}
+
+#endif /* !HAVE_DLOPEN */


### PR DESCRIPTION
This change adds plugin support to the kadmin libraries for performing
actions before and after a password change is committed to the KDC database
and after a change is made to the attributes of a principal (specifically,
a change to DISALLOW_ALL_TIX).

This change adds a hook_libraries configuration option to the [kadmin]
section of krb5.conf (or kdc.conf if you use that file) that must be set
to load the module.  That configuration option is in the form:

    [kadmin]
      hook_libraries = /usr/local/lib/krb5/plugins/kadm5_hook/krb5_sync.so

where the value is the full path to the plugin that you want to load.  If
this option is not present, kadmind will not load a plugin and the changes
from the patch will be inactive.  If this option is given and the plugin
cannot be loaded, kadmind startup will abort with a (hopefully useful)
error message in syslog.

Any plugin used with this patch must expose a public struct named
kadm5_hook.  That struct must contain the following:

    typedef struct kadm5_hook {
        const char *name;
        int version;
        const char *vendor;

        krb5_error_code (*init)(krb5_context, void **);
        void (*fini)(krb5_context, void *);

        krb5_error_code (*chpass)(krb5_context, void *, enum kadm5_hook_stage,
                                  krb5_principal, const char *);
        krb5_error_code (*create)(krb5_context, void *, enum kadm5_hook_stage,
                                  kadm5_principal_ent_t, uint32_t mask,
                                  const char *password);
        krb5_error_code (*modify)(krb5_context, void *, enum kadm5_hook_stage,
                                  kadm5_principal_ent_t, uint32_t mask);
    } kadm5_hook;

where enum kadm5_hook_stage is:

    enum kadm5_hook_stage {
        KADM5_HOOK_STAGE_PRECOMMIT,
        KADM5_HOOK_STAGE_POSTCOMMIT
    };

init creates a hook context that is passed into all subsequent calls.
chpass is called for password changes, create is called for principal
creation (with the newly-created principal in the kadm5_principal_ent_t
argument), and modify is called when a principal is modified.

These functions should follow the normal Kerberos calling convention of
returning 0 on success and a Kerberos error code on failure, setting the
Kerberos error message in the provided context.

This change is submitted under the following license

  Copyright 2012, 2013
    The Board of Trustees of the Leland Stanford Junior University

  Copying and distribution of this file, with or without modification, are
  permitted in any medium without royalty provided the copyright notice and
  this notice are preserved.  This file is offered as-is, without any
  warranty.

Change-Id: Iebf2c0ac5767f79fe72cc4a1c74521f3cb790d12