### PR TITLE
GSS unwrap: wipe copy of DES key when done with it

### DIFF
--- a/lib/gssapi/krb5/unwrap.c
+++ b/lib/gssapi/krb5/unwrap.c
@@ -109,7 +109,7 @@ unwrap_des
       EVP_Cipher(&des_ctx, p, p, input_message_buffer->length - len);
       EVP_CIPHER_CTX_cleanup(&des_ctx);
 
-      memset (&schedule, 0, sizeof(schedule));
+      memset (&deskey, 0, sizeof(deskey));
   }
 
   if (IS_DCE_STYLE(context_handle)) {


### PR DESCRIPTION
Zero out the DES_cblock structure instead of the (not yet used at this point
in the function) key schedule.  The contents could potentially be left
on the stack in the case of an error return from _gssapi_verify_pad().