### PR TITLE
hdb-mitdb: Commit 57f1545a broke support of REQUIRES_PWCHANGE during MIT DB imports

### DIFF
--- a/lib/hdb/hdb-mitdb.c
+++ b/lib/hdb/hdb-mitdb.c
@@ -108,6 +108,7 @@ attr_to_flags(unsigned attr, HDBFlags *flags)
     flags->invalid =	       !!(attr & KRB5_KDB_DISALLOW_ALL_TIX);
     flags->require_preauth =   !!(attr & KRB5_KDB_REQUIRES_PRE_AUTH);
     flags->require_hwauth =    !!(attr & KRB5_KDB_REQUIRES_HW_AUTH);
+    flags->require_pwchange =    !!(attr & KRB5_KDB_REQUIRES_PWCHANGE);
     flags->server =		!(attr & KRB5_KDB_DISALLOW_SVR);
     flags->change_pw = 	       !!(attr & KRB5_KDB_PWCHANGE_SERVICE);
     flags->client =	        1; /* XXX */


### PR DESCRIPTION
Hi,
Here's a small patch to repair some changes made in 57f1545a. It seems like a line has been mistakenly deleted.

Cheers,

Romain