### PR TITLE
Remove an extra line which uses a deleted command.

### DIFF
--- a/tests/gss/check-context.in
+++ b/tests/gss/check-context.in
@@ -54,7 +54,6 @@ cache="FILE:krb5ccfile"
 
 kinit="${TESTS_ENVIRONMENT} ../../kuser/kinit -c $cache ${afs_no_afslog}"
 klist="${TESTS_ENVIRONMENT} ../../kuser/heimtools klist -c $cache"
-klist="${TESTS_ENVIRONMENT} ../../kuser/klist -c $cache"
 kgetcred="${TESTS_ENVIRONMENT} ../../kuser/kgetcred -c $cache"
 kadmin="${TESTS_ENVIRONMENT} ../../kadmin/kadmin -l -r $R"
 kdc="${TESTS_ENVIRONMENT} ../../kdc/kdc --addresses=localhost -P $port"


### PR DESCRIPTION
There is an extra line in tests/gss/check-context.in.  It uses a deleted command.