### PR TITLE
Correct "princial" typos.

### DIFF
--- a/kadmin/kadmin-commands.in
+++ b/kadmin/kadmin-commands.in
@@ -229,7 +229,7 @@ command = {
 		long = "password"
 		short = "p"
 		type = "string"
-		help = "princial's password"
+		help = "principal's password"
 	}
 	option = {
 		long = "key"

--- a/lib/krb5/doxygen.c
+++ b/lib/krb5/doxygen.c
@@ -572,7 +572,7 @@
  * Fields and their types are:
  *
  * @code
- * 	Quoted princial (quote character is \) [string]
+ * 	Quoted principal (quote character is \) [string]
  * 	Keys [keys]
  * 	Created by [event]
  * 	Modified by [event optional]


### PR DESCRIPTION
Should be "principal".