### PR TITLE
Fix assorted typos

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -355,8 +355,8 @@ pa_pkinit_validate(kdc_request_t r, const PA_DATA *pa)
 	goto out;
     }
 #if 0
-    ret = _kdc_add_inital_verified_cas(r->context, r->config,
-				       pkp, &r->et);
+    ret = _kdc_add_initial_verified_cas(r->context, r->config,
+					pkp, &r->et);
 #endif
  out:
     if (pkp)

--- a/kdc/pkinit.c
+++ b/kdc/pkinit.c
@@ -1827,10 +1827,10 @@ add_principal_mapping(krb5_context context,
 }
 
 krb5_error_code
-_kdc_add_inital_verified_cas(krb5_context context,
-			     krb5_kdc_configuration *config,
-			     pk_client_params *cp,
-			     EncTicketPart *tkt)
+_kdc_add_initial_verified_cas(krb5_context context,
+			      krb5_kdc_configuration *config,
+			      pk_client_params *cp,
+			      EncTicketPart *tkt)
 {
     AD_INITIAL_VERIFIED_CAS cas;
     krb5_error_code ret;

--- a/lib/gssapi/gss_acquire_cred.3
+++ b/lib/gssapi/gss_acquire_cred.3
@@ -558,7 +558,7 @@ it may match several mechanism names (MN).
 .Pp
 The resulting name from
 .Fn gss_display_name
-must not be used for acccess control.
+must not be used for access control.
 .Sh FUNCTIONS
 .Fn gss_display_name
 takes the gss name in

--- a/lib/hcrypto/rand-fortuna.c
+++ b/lib/hcrypto/rand-fortuna.c
@@ -446,7 +446,7 @@ static unsigned	resend_bytes;
 static HEIMDAL_MUTEX fortuna_mutex = HEIMDAL_MUTEX_INITIALIZER;
 
 /*
- * Try our best to do an inital seed
+ * Try our best to do an initial seed
  */
 #define INIT_BYTES	128
 

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -1530,7 +1530,7 @@ _krb5_init_etype(krb5_context context,
 }
 
 /*
- * Allow homedir accces
+ * Allow homedir access
  */
 
 static HEIMDAL_MUTEX homedir_mutex = HEIMDAL_MUTEX_INITIALIZER;

--- a/lib/krb5/data.c
+++ b/lib/krb5/data.c
@@ -34,7 +34,7 @@
 #include "krb5_locl.h"
 
 /**
- * Reset the (potentially uninitalized) krb5_data structure.
+ * Reset the (potentially uninitialized) krb5_data structure.
  *
  * @param p krb5_data to reset.
  *

--- a/tests/ldap/check-ldap.in
+++ b/tests/ldap/check-ldap.in
@@ -133,7 +133,7 @@ echo "Getting ${server} ticket"
 ${kgetcred} ${server}@${R} || { ec=1 ; eval "${testfailed}"; }
 
 
-echo "Getting *@$R inital ticket (fail)";
+echo "Getting *@$R initial ticket (fail)";
 ${kinit} --password-file=${objdir}/foopassword '*'@$R 2>/dev/null && \
 	{ ec=1 ; eval "${testfailed}"; }
 


### PR DESCRIPTION
There are some further uses of "inital"/"initalize" in changelog files and old NEWS entries which I left for now as some projects are reluctant to fix typos in such files.  Also some in `lib/sqlite/` but that seems to be an embedded code copy.