### PR TITLE
PY3: fix "TabError: inconsistent use of tabs and spaces"

### DIFF
--- a/lib/wind/UnicodeData.py
+++ b/lib/wind/UnicodeData.py
@@ -50,7 +50,7 @@ def read(filename):
             continue
         f = l.split(';')
         key = int(f[0], 0x10)
-	if key in ret:
+        if key in ret:
             raise Exception('Duplicate key in UnicodeData')
         ret[key] = f[1:]
     ud.close()


### PR DESCRIPTION
From Samba

Python2 is EOL soon and Samba builds with python3 by default now so it would be helpful to have this merged upstream. 
