### PR TITLE
Solaris 10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,9 @@ fi
 dnl AC_KRB_PROG_YACC
 AC_PROG_YACC
 AM_PROG_LEX
+AS_IF([$LEX --nounput -V > /dev/null 2>&1 && test $? -eq 0],
+      [AC_SUBST([FLEXNOUNPUTARGS], ["--nounput"])],
+      [AC_SUBST([FLEXNOUNPUTARGS], [""])])
 dnl AC_PROG_RANLIB
 AC_PROG_AWK
 AC_KRB_PROG_LN_S

--- a/lib/com_err/Makefile.am
+++ b/lib/com_err/Makefile.am
@@ -3,6 +3,7 @@
 include $(top_srcdir)/Makefile.am.common
 
 YFLAGS = -d
+LFLAGS = @FLEXNOUNPUTARGS@
 
 lib_LTLIBRARIES = libcom_err.la
 libcom_err_la_LDFLAGS = -version-info 2:3:1

--- a/lib/com_err/lex.l
+++ b/lib/com_err/lex.l
@@ -53,8 +53,6 @@ static int getstring(void);
 
 %}
 
-%option nounput
-
 %%
 et			{ return ET; }
 error_table		{ return ET; }

--- a/lib/libedit/src/makelist
+++ b/lib/libedit/src/makelist
@@ -127,7 +127,7 @@ case $FLAG in
 #
 -fh)
     cat $FILES | $AWK '/el_action_t/ { print $3 }' | \
-    sort | tr '[:lower:]' '[:upper:]' | $AWK '
+    sort | tr '[a-z]' '[A-Z]' | tr -d ' ' | $AWK '
 	BEGIN {
 	    printf("/* Automatically generated file, do not edit */\n");
 	    count = 0;

--- a/lib/sl/Makefile.am
+++ b/lib/sl/Makefile.am
@@ -9,6 +9,7 @@ endif
 AM_CPPFLAGS += $(ROKEN_RENAME)
 
 YFLAGS = -d
+LFLAGS = @FLEXNOUNPUTARGS@
 
 include_HEADERS = sl.h
 

--- a/lib/sl/slc-lex.l
+++ b/lib/sl/slc-lex.l
@@ -53,8 +53,6 @@ static char * handle_string(void);
 
 %}
 
-%option nounput
-
 %%
 [A-Za-z][-A-Za-z0-9_]*	{
 			  yylval.string = strdup ((const char *)yytext);


### PR DESCRIPTION
Update with patch from @nicowilliams for makelist change, and add autoconf detection of flex --nounput option so we avoid warnings if it's available.