### PR TITLE
Samba Heimdal upgrade

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -807,7 +807,7 @@ tgs_make_reply(krb5_context context,
     if(ret)
 	goto out;
 
-    ret = copy_Realm(&server_principal->realm, &rep.ticket.realm);
+    ret = copy_Realm(&server->entry.principal->realm, &rep.ticket.realm);
     if (ret)
 	goto out;
     _krb5_principal2principalname(&rep.ticket.sname, server_principal);

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -1058,7 +1058,7 @@ get_princ(krb5_context context, krb5_principal *principal, const char *name)
     user_realm = get_user_realm(context);
 
     if (name) {
-	if (canonicalize_flag || enterprise_flag)
+	if (enterprise_flag)
 	    parseflags |= KRB5_PRINCIPAL_PARSE_ENTERPRISE;
 
 	parse_name_realm(context, name, parseflags, user_realm, &tmp);

--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -940,6 +940,12 @@ get_cred_kdc_capath(krb5_context context,
     return ret;
 }
 
+static krb5_boolean skip_referrals(krb5_principal server,
+				   krb5_kdc_flags *flags)
+{
+    return server->name.name_string.len < 2 && !flags->b.canonicalize;
+}
+
 /*
  * Get a service ticket from a KDC by chasing referrals from a start realm.
  *
@@ -966,7 +972,7 @@ get_cred_kdc_referral(krb5_context context,
     int want_tgt;
     size_t i;
 
-    if (in_creds->server->name.name_string.len < 2 && !flags.b.canonicalize) {
+    if (skip_referrals(in_creds->server, &flags)) {
 	krb5_set_error_message(context, KRB5KDC_ERR_PATH_NOT_ACCEPTED,
 			       N_("Name too short to do referals, skipping", ""));
 	return KRB5KDC_ERR_PATH_NOT_ACCEPTED;
@@ -1213,7 +1219,7 @@ _krb5_get_cred_kdc_any(krb5_context context,
                                   second_ticket,
                                   out_creds,
                                   ret_tgts);
-        if (ret == 0)
+        if (ret == 0 || skip_referrals(in_creds->server, &flags))
             return ret;
     }
 

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -426,9 +426,7 @@ get_init_creds_common(krb5_context context,
     if (ctx->keyproc == NULL)
 	ctx->keyproc = default_s2k_func;
 
-    /* Enterprise name implicitly turns on canonicalize */
-    if ((ctx->ic_flags & KRB5_INIT_CREDS_CANONICALIZE) ||
-	krb5_principal_get_type(context, client) == KRB5_NT_ENTERPRISE_PRINCIPAL)
+    if (ctx->ic_flags & KRB5_INIT_CREDS_CANONICALIZE)
 	ctx->flags.canonicalize = 1;
 
     ctx->pre_auth_types = NULL;

--- a/tests/kdc/check-pkinit.in
+++ b/tests/kdc/check-pkinit.in
@@ -202,7 +202,7 @@ ${kgetcred} ${server}@${R} || { ec=1 ; eval "${testfailed}"; }
 ${kdestroy}
 
 echo "Trying pk-init (ms upn, enterprise)"; > messages.log
-${kinit}  --canonicalize \
+${kinit}  --canonicalize --enterprise \
 	-C FILE:${base}/pkinit4.crt,${keyfile2} baz2@test.h5l.se@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
 ${kgetcred} ${server}@${R} || { ec=1 ; eval "${testfailed}"; }

--- a/tests/kdc/check-referral.in
+++ b/tests/kdc/check-referral.in
@@ -137,7 +137,7 @@ ${klist} | grep "Principal: foo@${R}" > /dev/null || \
 ${kdestroy}
 
 echo "Getting client client tickets (default realm, enterprisename)"; > messages.log
-${kinit} --canonicalize \
+${kinit} --canonicalize --enterprise \
 	--password-file=${objdir}/foopassword foo@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
 echo "checking that we got back right principal"
@@ -146,7 +146,7 @@ ${klist} | grep "Principal: foo@${R}" > /dev/null || \
 ${kdestroy}
 
 echo "Getting client alias1 tickets"; > messages.log
-${kinit} --canonicalize \
+${kinit} --canonicalize --enterprise \
 	--password-file=${objdir}/foopassword foo@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
 echo "checking that we got back right principal"
@@ -156,7 +156,7 @@ ${kdestroy}
 
 
 echo "Getting client alias2 tickets"; > messages.log
-${kinit} --canonicalize \
+${kinit} --canonicalize --enterprise \
 	--password-file=${objdir}/foopassword alias2@${R}@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
 echo "checking that we got back right principal"
@@ -171,7 +171,7 @@ ${kinit} --password-file=${objdir}/foopassword \
 
 echo "Getting client alias2 tickets (removed)"; > messages.log
 ${kadmin} modify --alias=alias1 foo@${R} || { ec=1 ; eval "${testfailed}"; }
-${kinit} --canonicalize \
+${kinit} --canonicalize --enterprise \
 	--password-file=${objdir}/foopassword \
 	alias2@${R}@${R} > /dev/null 2>/dev/null && \
 	{ ec=1 ; eval "${testfailed}"; }


### PR DESCRIPTION
Recently I got involved in @abartlet's efforts to upgrade Heimdal in Samba, and have come up with some patches to help with that.

Note about the last commit, enterprise vs canonicalize; this is now needed in order to be able to test and exercise flows where enterprise name type is used without canonicalize kdc-req-option, and confirm the name is not being canonicalized by the KDC. It used to be done in Samba torture tests by hooking via send_to_kdc and removing the canonicalize flag but this now fails due to PA-REQ-ENC-PA-REP protection.

I noticed a related discussion in issue #452, if we prefer to keep the alignment of the two flags for convenience then perhaps we can move both to kinit code so that other consumer of the API could chose whether or not the canonicalize flag is set (also, this will avoid changing the tests).