### PR TITLE
lib/wind: PY3 gen-punycode-examples.py

### DIFF
--- a/lib/wind/gen-punycode-examples.py
+++ b/lib/wind/gen-punycode-examples.py
@@ -35,13 +35,12 @@
 # SUCH DAMAGE. 
 
 import re
-import string
 import sys
 
 import generate
 
 if len(sys.argv) != 3:
-    print "usage: %s rfc3492.txt" % sys.argv[0]
+    print("usage: %s rfc3492.txt" % sys.argv[0])
     sys.exit(1)
 
 f = open(sys.argv[1], 'r')
@@ -72,7 +71,7 @@ while True:
             else:
                 m = re.search('^ *([uU]+.*) *$', l)
                 if m:
-                    codes.extend(string.split(m.group(1), ' '))
+		    codes.extend(m.group(1).split(' '))
                 else:
                     m = re.search('^ *Punycode: (.*) *$', l)
                     if m:
@@ -115,7 +114,7 @@ for x in cases:
     examples_c.file.write(
         "  {%u, {%s}, \"%s\", \"%s\"},\n" %
         (len(cp),
-         string.join([re.sub('[uU]\+', '0x', x) for x in cp], ', '),
+	 ",".join([re.sub('[uU]\+', '0x', x) for x in cp]),
          pc,
          desc))
 


### PR DESCRIPTION
Update gen-punycode-examples.py for python 3.

gen-punycode-examples.py parses the Sample strings from section 7.1
of rfc3492.txt and generates the punycode_examples.[ch] sources containing
the punycode_examples[].

Python 3 requires that print output be surrounded by parentheses
and the split and join operations have been moved from the "string"
class to built-ins.

This change adds the missing parentheses and switches to the built-in
split and join str operations.

The "string" class is no longer required as an import.

Change-Id: Ic5f341080d2ff2feef692c89e0b28dcbf4e48cb4