### PR TITLE
lib/krb5: send_to_kdc KRB5KDC_ERR_SVC_UNAVAILABLE infinite loop #346

### DIFF
--- a/lib/krb5/send_to_kdc.c
+++ b/lib/krb5/send_to_kdc.c
@@ -281,7 +281,7 @@ _krb5_kdc_retry(krb5_context context, krb5_sendto_ctx ctx, void *data,
 	break;
     }
     case KRB5KDC_ERR_SVC_UNAVAILABLE:
-	*action = KRB5_SENDTO_CONTINUE;
+	*action = KRB5_SENDTO_RESET;
 	break;
     }
     return 0;


### PR DESCRIPTION
Prior to this change a KDC response of KRB5KDC_ERR_SVC_UNAVAILABLE
would result in the client looping forever.  Setting the action to
KRB5_SENTO_CONTINUE repeats the current loop without altering the
current state.  Hence the infinite loop.

As of this change, the action is set to KRB5_SENDTO_RESET which
forces the current kdc's response to be cleared and then to retry.
If KRB5KDC_ERR_SVC_UNAVAILABLE continues to be returned, the retry
limit will be reached and the loop will end.

This bug was filed by multiple sources including Samba and ScottUrban
on github.

Change-Id: If1611be0ada3422cefae89541ed3b3df1f6efe29