### PR TITLE
lib/roken: rk_random_init HAVE_ARC4RANDOM #401

### DIFF
--- a/lib/roken/rand.c
+++ b/lib/roken/rand.c
@@ -69,7 +69,7 @@ void ROKEN_LIB_FUNCTION
 rk_random_init(void)
 {
 #if defined(HAVE_ARC4RANDOM)
-    arc4random_stir();
+    /* nothing to do */;
 #elif defined(HAVE_SRANDOMDEV)
     srandomdev();
 #elif defined(HAVE_RANDOM)


### PR DESCRIPTION
When arc4random() is available, rk_random_init() does not have to
call arc4random_stir().  ac4random_stir() will be called as a result
of the first call to arc4random().

Change-Id: I6f4a3be7c39752746657945ed15896472908f889