### PR TITLE
kadmin: do not assign passwords at realm initialization

### DIFF
--- a/kadmin/init.c
+++ b/kadmin/init.c
@@ -52,11 +52,6 @@ create_random_entry(krb5_principal princ,
     krb5_keyblock *keys;
     int n_keys, i;
     char *name;
-    const char *password;
-    char pwbuf[512];
-
-    random_password(pwbuf, sizeof(pwbuf));
-    password = pwbuf;
 
     ret = krb5_unparse_name(context, princ, &name);
     if (ret) {
@@ -76,14 +71,14 @@ create_random_entry(krb5_principal princ,
 	mask |= KADM5_MAX_RLIFE;
     }
     ent.attributes |= attributes | KRB5_KDB_DISALLOW_ALL_TIX;
-    mask |= KADM5_ATTRIBUTES;
+    mask |= KADM5_ATTRIBUTES | KADM5_KEY_DATA;
 
-    /* Create the entry with a random password */
-    ret = kadm5_create_principal(kadm_handle, &ent, mask, password);
+    /* Create the entry with no keys or password */
+    ret = kadm5_s_create_principal_with_key(kadm_handle, &ent, mask);
     if(ret) {
 	if (ret == KADM5_DUP && (flags & CRE_DUP_OK))
 	    goto out;
-	krb5_warn(context, ret, "create_random_entry(%s): randkey failed",
+	krb5_warn(context, ret, "create_random_entry(%s): create failed",
 		  name);
 	goto out;
     }

--- a/lib/kadm5/libkadm5srv-exports.def
+++ b/lib/kadm5/libkadm5srv-exports.def
@@ -58,6 +58,7 @@ EXPORTS
 	kadm5_s_init_with_creds_ctx
 	kadm5_s_init_with_creds
 	kadm5_s_chpass_principal_cond
+	kadm5_s_create_principal_with_key
 	kadm5_log_set_version
 	kadm5_log_signal_master
 ;!	kadm5_log_signal_socket

--- a/lib/kadm5/version-script.map
+++ b/lib/kadm5/version-script.map
@@ -61,6 +61,7 @@ HEIMDAL_KAMD5_SERVER_1.0 {
 		kadm5_s_init_with_creds_ctx;
 		kadm5_s_init_with_creds;
 		kadm5_s_chpass_principal_cond;
+		kadm5_s_create_principal_with_key;
 		kadm5_log_set_version;
 		kadm5_log_signal_master;
 		kadm5_log_signal_socket;


### PR DESCRIPTION
WIP – tests are failing on my end

Since c6bf100b password quality checks have been moved out of kadmindd and into libkadm5. This means that all password changes are subject to quality checks, if enforce_on_admin_set is true (the default). In rare instances it could be possible for realm initialization to fail because the randomly generated passwords do not pass the password quality test. Fix this by creating principals with no password or key, rather than with a random password.

Random *keys* continue to be set immediately after the principal is created, and before DISALLOW_ALL_TIX is unset, so there should be no functionality or security implications from this change. It is safe to call a server-side API such as kadm5_s_create_principal_with_key() as local_flag is asserted to be true.