### PR TITLE
hcrypto: print failure on password mismatch (#469)

### DIFF
--- a/lib/hcrypto/ui.c
+++ b/lib/hcrypto/ui.c
@@ -205,8 +205,11 @@ UI_UTIL_read_pw_string(char *buf, int length, const char *prompt, int verify)
 	    free(buf2);
 	    return ret;
 	}
-	if (strcmp(buf2, buf) != 0)
+	if (strcmp(buf2, buf) != 0) {
+	    fprintf(stderr, "Verify failure\n");
+	    fflush(stderr);
 	    ret = 1;
+	}
 	free(buf2);
     }
     return ret;


### PR DESCRIPTION
UI_UTIL_read_pw_string(), an interface borrowed from OpenSSL, should report password verification failure to stderr.