### PR TITLE
Fix check-ldap race condition (fix #482)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 before_install:
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get update -qq; fi
     - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -qq bison comerr-dev flex libcap-ng-dev libdb-dev libedit-dev libjson-perl libldap2-dev libncurses5-dev libperl4-corelibs-perl libsqlite3-dev libkeyutils-dev pkg-config python ss-dev texinfo unzip netbase keyutils; fi
+    - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -qq ldap-utils; fi
     - if [ $TRAVIS_OS_NAME = osx ]; then brew update; fi
     - if [ $TRAVIS_OS_NAME = osx ]; then brew install cpanm bison flex berkeley-db lmdb openldap openssl; fi
     - if [ $TRAVIS_OS_NAME = osx ]; then sudo cpanm install JSON; fi

--- a/tests/ldap/slapd-init.in
+++ b/tests/ldap/slapd-init.in
@@ -44,5 +44,15 @@ cp "`which slapd`" . || true # fails if running
 
 echo "starting slapd"
 ./slapd -d0 -f "${srcdir}/slapd.conf" -h ldapi://.%2Fldap-socket &
+slapd_pid=$!
 
-sleep 4
+tries=0
+while kill -0 $slapd_pid && [ ! -S ldap-socket ] && 
+      ! ldapsearch -l 2 -w '' -D '' -b "o=TEST,dc=H5L,dc=SE" -s base -H ldapi://.%2Fldap-socket >/dev/null &&
+      [ $tries -lt 30 ]; do
+    sleep 1
+    tries=`expr 1 + $tries`
+done
+
+kill -0 $slapd_pid || exit 1
+[ -S ldap-socket ] || exit 1

--- a/tests/ldap/slapd.conf
+++ b/tests/ldap/slapd.conf
@@ -18,7 +18,7 @@ allow update_anon bind_anon_dn
 
 include modules.conf
 
-defaultsearchbase "ou=TEST,dc=H5L,dc=SE"
+defaultsearchbase "o=TEST,dc=H5L,dc=SE"
 
 database	bdb
 suffix		"o=TEST,dc=H5L,dc=SE"


### PR DESCRIPTION
From the commit:

```
We start slapd in the foreground (-d0) but backgrounded in the shell,
then we wait 4 seconds.  This causes a race condition however.  This
commit makes the slapd-init script more robust and limits the wait to
however many seconds (up to 30) that slapd needs to start service.
```

The fix is to loop up to N times checking that `slapd` is responsive, sleeping a second in between.