### PR TITLE
libhcrypto: UI_UTIL_FLAG_VERIFY_SILENT (#469)

### DIFF
--- a/admin/add.c
+++ b/admin/add.c
@@ -94,7 +94,8 @@ kt_add(struct add_options *opt, int argc, char **argv)
 	    goto out;
     }
     if(opt->password_string == NULL && opt->random_flag == 0) {
-	if(UI_UTIL_read_pw_string(buf, sizeof(buf), "Password: ", 1)) {
+	if(UI_UTIL_read_pw_string(buf, sizeof(buf), "Password: ",
+				  UI_UTIL_FLAG_VERIFY)) {
 	    ret = 1;
 	    goto out;
 	}

--- a/appl/otp/otp.c
+++ b/appl/otp/otp.c
@@ -153,7 +153,8 @@ set (int argc, char **argv, OtpAlgorithm *alg, char *inuser)
     strlcpy (ctx.seed, argv[1], sizeof(ctx.seed));
     strlwr(ctx.seed);
     do {
-	if (UI_UTIL_read_pw_string (pw, sizeof(pw), "Pass-phrase: ", 1))
+	if (UI_UTIL_read_pw_string (pw, sizeof(pw), "Pass-phrase: ",
+	    UI_UTIL_FLAG_VERIFY))
 	    return 1;
 	if (strlen (pw) < OTP_MIN_PASSPHRASE)
 	    printf ("Too short pass-phrase.  Use at least %d characters\n",

--- a/kadmin/ank.c
+++ b/kadmin/ank.c
@@ -138,7 +138,9 @@ add_one_principal (const char *name,
 	    krb5_set_error_message(context, ret, "out of memory");
 	    goto out;
 	}
-	ret = UI_UTIL_read_pw_string (pwbuf, sizeof(pwbuf), prompt, 1);
+	ret = UI_UTIL_read_pw_string (pwbuf, sizeof(pwbuf), prompt,
+				      UI_UTIL_FLAG_VERIFY |
+				      UI_UTIL_FLAG_VERIFY_SILENT);
 	free (prompt);
 	if (ret) {
 	    ret = KRB5_LIBOS_BADPWDMATCH;

--- a/kadmin/cpw.c
+++ b/kadmin/cpw.c
@@ -98,7 +98,9 @@ set_password (krb5_principal principal, char *password, int keepold)
 	free (princ_name);
 	if (aret == -1)
 	    return ENOMEM;
-	ret = UI_UTIL_read_pw_string(pwbuf, sizeof(pwbuf), prompt, 1);
+	ret = UI_UTIL_read_pw_string(pwbuf, sizeof(pwbuf), prompt,
+				     UI_UTIL_FLAG_VERIFY |
+				     UI_UTIL_FLAG_VERIFY_SILENT);
 	free (prompt);
 	if(ret){
             return KRB5_LIBOS_BADPWDMATCH;

--- a/kadmin/stash.c
+++ b/kadmin/stash.c
@@ -99,7 +99,8 @@ stash(struct stash_options *opt, int argc, char **argv)
 	    random_password (buf, sizeof(buf));
 	    printf("Using random master stash password: %s\n", buf);
 	} else {
-	    if(UI_UTIL_read_pw_string(buf, sizeof(buf), "Master key: ", 1)) {
+	    if(UI_UTIL_read_pw_string(buf, sizeof(buf), "Master key: ",
+				      UI_UTIL_FLAG_VERIFY)) {
 		hdb_free_master_key(context, mkey);
 		return 0;
 	    }

--- a/kdc/kstash.c
+++ b/kdc/kstash.c
@@ -124,7 +124,8 @@ main(int argc, char **argv)
 		buf[strcspn(buf, "\r\n")] = '\0';
 
 	    } else {
-		if(UI_UTIL_read_pw_string(buf, sizeof(buf), "Master key: ", 1))
+		if(UI_UTIL_read_pw_string(buf, sizeof(buf), "Master key: ",
+					  UI_UTIL_FLAG_VERIFY))
 		    exit(1);
 	    }
 	    krb5_string_to_key_salt(context, enctype, buf, salt, &key);

--- a/kpasswd/kpasswd.c
+++ b/kpasswd/kpasswd.c
@@ -83,7 +83,8 @@ change_password(krb5_context context,
     if (aret == -1 || msg == NULL)
 	krb5_errx (context, 1, "out of memory");
 
-    ret = UI_UTIL_read_pw_string (pwbuf, sizeof(pwbuf), msg, 1);
+    ret = UI_UTIL_read_pw_string (pwbuf, sizeof(pwbuf), msg,
+				  UI_UTIL_FLAG_VERIFY);
     free(msg);
     if (name)
 	free(name);

--- a/lib/hcrypto/ui.c
+++ b/lib/hcrypto/ui.c
@@ -194,7 +194,7 @@ UI_UTIL_read_pw_string(char *buf, int length, const char *prompt, int verify)
     if (ret)
 	return ret;
 
-    if (verify) {
+    if (verify & UI_UTIL_FLAG_VERIFY) {
 	char *buf2;
 	buf2 = malloc(length);
 	if (buf2 == NULL)
@@ -206,8 +206,10 @@ UI_UTIL_read_pw_string(char *buf, int length, const char *prompt, int verify)
 	    return ret;
 	}
 	if (strcmp(buf2, buf) != 0) {
-	    fprintf(stderr, "Verify failure\n");
-	    fflush(stderr);
+	    if (!(verify & UI_UTIL_FLAG_VERIFY_SILENT)) {
+		fprintf(stderr, "Verify failure\n");
+		fflush(stderr);
+	    }
 	    ret = 1;
 	}
 	free(buf2);

--- a/lib/hcrypto/ui.h
+++ b/lib/hcrypto/ui.h
@@ -39,6 +39,10 @@
 /* symbol renaming */
 #define UI_UTIL_read_pw_string hc_UI_UTIL_read_pw_string
 
+/* OpenSSL API extensions */
+#define UI_UTIL_FLAG_VERIFY	    0x1 /* ask to verify password */
+#define UI_UTIL_FLAG_VERIFY_SILENT  0x2 /* silence on verify failure */
+
 int	UI_UTIL_read_pw_string(char *, int, const char *, int); /* XXX */
 
 #endif /* _HEIM_UI_H */


### PR DESCRIPTION
Add flag to `UI_UTIL_read_pw_string()` to suppress verification failure message