### PR TITLE
WIN32: hint noreturn functions

### DIFF
--- a/cf/make-proto.pl
+++ b/cf/make-proto.pl
@@ -415,34 +415,67 @@ extern \"C\" {
 }
 if ($opt_E) {
     $public_h_header .= "#ifndef $opt_E
-#ifndef ${opt_E}_FUNCTION
-#if defined(_WIN32)
-#define ${opt_E}_FUNCTION __declspec(dllimport)
-#define ${opt_E}_CALL __stdcall
-#define ${opt_E}_VARIABLE __declspec(dllimport)
-#else
-#define ${opt_E}_FUNCTION
-#define ${opt_E}_CALL
-#define ${opt_E}_VARIABLE
-#endif
-#endif
+ #ifndef ${opt_E}_FUNCTION
+  #if defined(_WIN32)
+   #define ${opt_E}_FUNCTION __declspec(dllimport)
+  #else
+   #define ${opt_E}_FUNCTION
+  #endif
+ #endif
+ #ifndef ${opt_E}_NORETURN_FUNCTION
+  #if defined(_WIN32)
+   #define ${opt_E}_NORETURN_FUNCTION __declspec(dllimport noreturn)
+  #else
+   #define ${opt_E}_NORETURN_FUNCTION
+  #endif
+ #endif
+ #ifndef ${opt_E}_CALL
+  #if defined(_WIN32)
+   #define ${opt_E}_CALL __stdcall
+  #else
+   #define ${opt_E}_CALL
+  #endif
+ #endif
+ #ifndef ${opt_E}_VARIABLE
+  #if defined(_WIN32)
+   #define ${opt_E}_VARIABLE __declspec(dllimport)
+  #else
+   #define ${opt_E}_VARIABLE
+  #endif
+ #endif
 #endif
 ";
     
     $private_h_header .= "#ifndef $opt_E
-#ifndef ${opt_E}_FUNCTION
-#if defined(_WIN32)
-#define ${opt_E}_FUNCTION __declspec(dllimport)
-#define ${opt_E}_CALL __stdcall
-#define ${opt_E}_VARIABLE __declspec(dllimport)
-#else
-#define ${opt_E}_FUNCTION
-#define ${opt_E}_CALL
-#define ${opt_E}_VARIABLE
+ #ifndef ${opt_E}_FUNCTION
+  #if defined(_WIN32)
+   #define ${opt_E}_FUNCTION __declspec(dllimport)
+  #else
+   #define ${opt_E}_FUNCTION
+  #endif
+ #endif
+ #ifndef ${opt_E}_NORETURN_FUNCTION
+  #if defined(_WIN32)
+   #define ${opt_E}_NORETURN_FUNCTION __declspec(dllimport noreturn)
+  #else
+   #define ${opt_E}_NORETURN_FUNCTION
+  #endif
+ #endif
+ #ifndef ${opt_E}_CALL
+  #if defined(_WIN32)
+   #define ${opt_E}_CALL __stdcall
+  #else
+   #define ${opt_E}_CALL
+  #endif
+ #endif
+ #ifndef ${opt_E}_VARIABLE
+  #if defined(_WIN32)
+   #define ${opt_E}_VARIABLE __declspec(dllimport)
+  #else
+   #define ${opt_E}_VARIABLE
+  #endif
+ #endif
 #endif
-#endif
-#endif
-
 ";
 }
     

--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -68,6 +68,23 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 #endif
 
 
+#ifdef BUILD_HX509_LIB
+#ifndef HX509_LIB
+#ifdef _WIN32
+#define HX509_LIB_FUNCTION
+#define HX509_LIB_NORETURN_FUNCTION __declspec(noreturn)
+#define HX509_LIB_CALL     __stdcall
+#define HX509_LIB_VARIABLE
+#else
+#define HX509_LIB_FUNCTION
+#define HX509_LIB_NORETURN_FUNCTION
+#define HX509_LIB_CALL
+#define HX509_LIB_VARIABLE
+#endif
+#endif
+#endif
+
+
 #ifdef BUILD_ROKEN_LIB
 #ifndef ROKEN_LIB
 #ifdef _WIN32

--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -55,10 +55,12 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 #ifndef KRB5_LIB
 #ifdef _WIN32
 #define KRB5_LIB_FUNCTION
+#define KRB5_LIB_NORETURN_FUNCTION __declspec(noreturn)
 #define KRB5_LIB_CALL     __stdcall
 #define KRB5_LIB_VARIABLE
 #else
 #define KRB5_LIB_FUNCTION
+#define KRB5_LIB_NORETURN_FUNCTION
 #define KRB5_LIB_CALL
 #define KRB5_LIB_VARIABLE
 #endif
@@ -70,10 +72,12 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 #ifndef ROKEN_LIB
 #ifdef _WIN32
 #define ROKEN_LIB_FUNCTION
+#define ROKEN_LIB_NORETURN_FUNCTION __declspec(noreturn)
 #define ROKEN_LIB_CALL     __cdecl
 #define ROKEN_LIB_VARIABLE
 #else
 #define ROKEN_LIB_FUNCTION
+#define ROKEN_LIB_NORETURN_FUNCTION
 #define ROKEN_LIB_CALL
 #define ROKEN_LIB_VARIABLE
 #endif
@@ -85,10 +89,12 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 #ifndef GSSAPI_LIB
 #ifdef _WIN32
 #define GSSAPI_LIB_FUNCTION
+#define GSSAPI_LIB_NORETURN_FUNCTION __declspec(noreturn)
 #define GSSAPI_LIB_CALL     __stdcall
 #define GSSAPI_LIB_VARIABLE
 #else
 #define GSSAPI_LIB_FUNCTION
+#define GSSAPI_LIB_NORETURN_FUNCTION
 #define GSSAPI_LIB_CALL
 #define GSSAPI_LIB_VARIABLE
 #endif

--- a/lib/hx509/NTMakefile
+++ b/lib/hx509/NTMakefile
@@ -110,6 +110,12 @@ dist_libhx509_la_SOURCES =	\
 	$(SRCDIR)\req.c		\
 	$(SRCDIR)\revoke.c
 
+{}.c{$(OBJ)}.obj::
+	$(C2OBJ_P) -DBUILD_HX509_LIB -DASN1_LIB
+
+{$(OBJ)}.c{$(OBJ)}.obj::
+	$(C2OBJ_P) -DBUILD_HX509_LIB -DASN1_LIB
+
 asn1_compile=$(BINDIR)\asn1_compile.exe
 
 $(gen_files_ocsp:.x=.c): $$(@R).x

--- a/lib/hx509/ca.c
+++ b/lib/hx509/ca.c
@@ -77,7 +77,7 @@ struct hx509_ca_tbs {
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_init(hx509_context context, hx509_ca_tbs *tbs)
 {
     *tbs = calloc(1, sizeof(**tbs));
@@ -95,7 +95,7 @@ hx509_ca_tbs_init(hx509_context context, hx509_ca_tbs *tbs)
  * @ingroup hx509_ca
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_ca_tbs_free(hx509_ca_tbs *tbs)
 {
     if (tbs == NULL || *tbs == NULL)
@@ -132,7 +132,7 @@ hx509_ca_tbs_free(hx509_ca_tbs *tbs)
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_notBefore(hx509_context context,
 			   hx509_ca_tbs tbs,
 			   time_t t)
@@ -153,7 +153,7 @@ hx509_ca_tbs_set_notBefore(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_notAfter(hx509_context context,
 			   hx509_ca_tbs tbs,
 			   time_t t)
@@ -174,7 +174,7 @@ hx509_ca_tbs_set_notAfter(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_notAfter_lifetime(hx509_context context,
 				   hx509_ca_tbs tbs,
 				   time_t delta)
@@ -202,7 +202,7 @@ static const struct units templatebits[] = {
  * @ingroup hx509_ca
  */
 
-const struct units *
+HX509_LIB_FUNCTION const struct units * HX509_LIB_CALL
 hx509_ca_tbs_template_units(void)
 {
     return templatebits;
@@ -222,7 +222,7 @@ hx509_ca_tbs_template_units(void)
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_template(hx509_context context,
 			  hx509_ca_tbs tbs,
 			  int flags,
@@ -300,7 +300,7 @@ hx509_ca_tbs_set_template(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_ca(hx509_context context,
 		    hx509_ca_tbs tbs,
 		    int pathLenConstraint)
@@ -324,7 +324,7 @@ hx509_ca_tbs_set_ca(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_proxy(hx509_context context,
 		       hx509_ca_tbs tbs,
 		       int pathLenConstraint)
@@ -346,7 +346,7 @@ hx509_ca_tbs_set_proxy(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_domaincontroller(hx509_context context,
 				  hx509_ca_tbs tbs)
 {
@@ -368,7 +368,7 @@ hx509_ca_tbs_set_domaincontroller(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_spki(hx509_context context,
 		      hx509_ca_tbs tbs,
 		      const SubjectPublicKeyInfo *spki)
@@ -393,7 +393,7 @@ hx509_ca_tbs_set_spki(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_serialnumber(hx509_context context,
 			      hx509_ca_tbs tbs,
 			      const heim_integer *serialNumber)
@@ -418,7 +418,7 @@ hx509_ca_tbs_set_serialnumber(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_add_eku(hx509_context context,
 		     hx509_ca_tbs tbs,
 		     const heim_oid *oid)
@@ -462,7 +462,7 @@ hx509_ca_tbs_add_eku(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_add_crl_dp_uri(hx509_context context,
 			    hx509_ca_tbs tbs,
 			    const char *uri,
@@ -567,7 +567,7 @@ out:
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_add_san_otherName(hx509_context context,
 			       hx509_ca_tbs tbs,
 			       const heim_oid *oid,
@@ -596,7 +596,7 @@ hx509_ca_tbs_add_san_otherName(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_add_san_pkinit(hx509_context context,
 			    hx509_ca_tbs tbs,
 			    const char *principal)
@@ -731,7 +731,7 @@ out:
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_add_san_ms_upn(hx509_context context,
 			    hx509_ca_tbs tbs,
 			    const char *principal)
@@ -752,7 +752,7 @@ hx509_ca_tbs_add_san_ms_upn(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_add_san_jid(hx509_context context,
 			 hx509_ca_tbs tbs,
 			 const char *jid)
@@ -777,7 +777,7 @@ hx509_ca_tbs_add_san_jid(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_add_san_hostname(hx509_context context,
 			      hx509_ca_tbs tbs,
 			      const char *dnsname)
@@ -805,7 +805,7 @@ hx509_ca_tbs_add_san_hostname(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_add_san_rfc822name(hx509_context context,
 				hx509_ca_tbs tbs,
 				const char *rfc822Name)
@@ -832,7 +832,7 @@ hx509_ca_tbs_add_san_rfc822name(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_subject(hx509_context context,
 			 hx509_ca_tbs tbs,
 			 hx509_name subject)
@@ -860,7 +860,7 @@ hx509_ca_tbs_set_subject(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_unique(hx509_context context,
 			hx509_ca_tbs tbs,
 			const heim_bit_string *subjectUniqueID,
@@ -900,7 +900,7 @@ hx509_ca_tbs_set_unique(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_subject_expand(hx509_context context,
 			    hx509_ca_tbs tbs,
 			    hx509_env env)
@@ -920,7 +920,7 @@ hx509_ca_tbs_subject_expand(hx509_context context,
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_signature_algorithm(hx509_context context,
 				     hx509_ca_tbs tbs,
 				     const AlgorithmIdentifier *sigalg)
@@ -1583,7 +1583,7 @@ out:
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_sign(hx509_context context,
 	      hx509_ca_tbs tbs,
 	      hx509_cert signer,
@@ -1627,7 +1627,7 @@ out:
  * @ingroup hx509_ca
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_sign_self(hx509_context context,
 		   hx509_ca_tbs tbs,
 		   hx509_private_key signer,

--- a/lib/hx509/cert.c
+++ b/lib/hx509/cert.c
@@ -113,7 +113,7 @@ init_context_once(void *ignored)
  * @ingroup hx509
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_context_init(hx509_context *context)
 {
     static heim_base_once_t init_context = HEIM_BASE_ONCE_INIT;
@@ -158,7 +158,7 @@ hx509_context_init(hx509_context *context)
  * @ingroup hx509_verify
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_context_set_missing_revoke(hx509_context context, int flag)
 {
     if (flag)
@@ -175,7 +175,7 @@ hx509_context_set_missing_revoke(hx509_context context, int flag)
  * @ingroup hx509
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_context_free(hx509_context *context)
 {
     hx509_clear_error_string(*context);
@@ -196,7 +196,7 @@ hx509_context_free(hx509_context *context)
  *
  */
 
-Certificate *
+HX509_LIB_FUNCTION Certificate * HX509_LIB_CALL
 _hx509_get_cert(hx509_cert cert)
 {
     return cert->data;
@@ -206,7 +206,7 @@ _hx509_get_cert(hx509_cert cert)
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_cert_get_version(const Certificate *t)
 {
     return t->tbsCertificate.version ? *t->tbsCertificate.version + 1 : 1;
@@ -225,7 +225,7 @@ _hx509_cert_get_version(const Certificate *t)
  * @ingroup hx509_cert
  */
 
-hx509_cert
+HX509_LIB_FUNCTION hx509_cert HX509_LIB_CALL
 hx509_cert_init(hx509_context context, const Certificate *c, heim_error_t *error)
 {
     hx509_cert cert;
@@ -281,7 +281,7 @@ hx509_cert_init(hx509_context context, const Certificate *c, heim_error_t *error
  * @ingroup hx509_cert
  */
 
-hx509_cert
+HX509_LIB_FUNCTION hx509_cert HX509_LIB_CALL
 hx509_cert_init_data(hx509_context context,
 		     const void *ptr,
 		     size_t len,
@@ -311,7 +311,7 @@ hx509_cert_init_data(hx509_context context,
     return cert;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_cert_set_release(hx509_cert cert,
 			_hx509_cert_release_func release,
 			void *ctx)
@@ -323,7 +323,7 @@ _hx509_cert_set_release(hx509_cert cert,
 
 /* Doesn't make a copy of `private_key'. */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_cert_assign_key(hx509_cert cert, hx509_private_key private_key)
 {
     if (cert->private_key)
@@ -341,7 +341,7 @@ _hx509_cert_assign_key(hx509_cert cert, hx509_private_key private_key)
  * @ingroup hx509_cert
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_cert_free(hx509_cert cert)
 {
     size_t i;
@@ -386,7 +386,7 @@ hx509_cert_free(hx509_cert cert)
  * @ingroup hx509_cert
  */
 
-hx509_cert
+HX509_LIB_FUNCTION hx509_cert HX509_LIB_CALL
 hx509_cert_ref(hx509_cert cert)
 {
     if (cert == NULL)
@@ -411,7 +411,7 @@ hx509_cert_ref(hx509_cert cert)
  * @ingroup hx509_verify
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_verify_init_ctx(hx509_context context, hx509_verify_ctx *ctx)
 {
     hx509_verify_ctx c;
@@ -435,7 +435,7 @@ hx509_verify_init_ctx(hx509_context context, hx509_verify_ctx *ctx)
  * @ingroup hx509_verify
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_verify_destroy_ctx(hx509_verify_ctx ctx)
 {
     if (ctx) {
@@ -458,7 +458,7 @@ hx509_verify_destroy_ctx(hx509_verify_ctx ctx)
  * @ingroup hx509_verify
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_verify_attach_anchors(hx509_verify_ctx ctx, hx509_certs set)
 {
     if (ctx->trust_anchors)
@@ -479,7 +479,7 @@ hx509_verify_attach_anchors(hx509_verify_ctx ctx, hx509_certs set)
  * @ingroup hx509_verify
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_verify_attach_revoke(hx509_verify_ctx ctx, hx509_revoke_ctx revoke_ctx)
 {
     if (ctx->revoke_ctx)
@@ -499,14 +499,14 @@ hx509_verify_attach_revoke(hx509_verify_ctx ctx, hx509_revoke_ctx revoke_ctx)
  * @ingroup hx509_verify
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_verify_set_time(hx509_verify_ctx ctx, time_t t)
 {
     ctx->flags |= HX509_VERIFY_CTX_F_TIME_SET;
     ctx->time_now = t;
 }
 
-time_t
+HX509_LIB_FUNCTION time_t HX509_LIB_CALL
 _hx509_verify_get_time(hx509_verify_ctx ctx)
 {
     return ctx->time_now;
@@ -523,7 +523,7 @@ _hx509_verify_get_time(hx509_verify_ctx ctx)
  * @ingroup hx509_verify
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_verify_set_max_depth(hx509_verify_ctx ctx, unsigned int max_depth)
 {
     ctx->max_depth = max_depth;
@@ -538,7 +538,7 @@ hx509_verify_set_max_depth(hx509_verify_ctx ctx, unsigned int max_depth)
  * @ingroup hx509_verify
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_verify_set_proxy_certificate(hx509_verify_ctx ctx, int boolean)
 {
     if (boolean)
@@ -558,7 +558,7 @@ hx509_verify_set_proxy_certificate(hx509_verify_ctx ctx, int boolean)
  * @ingroup hx509_verify
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_verify_set_strict_rfc3280_verification(hx509_verify_ctx ctx, int boolean)
 {
     if (boolean)
@@ -581,7 +581,7 @@ hx509_verify_set_strict_rfc3280_verification(hx509_verify_ctx ctx, int boolean)
  * @ingroup hx509_cert
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_verify_ctx_f_allow_default_trustanchors(hx509_verify_ctx ctx, int boolean)
 {
     if (boolean)
@@ -590,7 +590,7 @@ hx509_verify_ctx_f_allow_default_trustanchors(hx509_verify_ctx ctx, int boolean)
 	ctx->flags |= HX509_VERIFY_CTX_F_NO_DEFAULT_ANCHORS;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_verify_ctx_f_allow_best_before_signature_algs(hx509_context ctx,
 						    int boolean)
 {
@@ -634,7 +634,7 @@ find_extension_auth_key_id(const Certificate *subject,
 					 ai, &size);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_find_extension_subject_key_id(const Certificate *issuer,
 				     SubjectKeyIdentifier *si)
 {
@@ -734,7 +734,7 @@ add_to_list(hx509_octet_string_list *list, const heim_octet_string *entry)
  * @ingroup hx509_misc
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_free_octet_string_list(hx509_octet_string_list *list)
 {
     size_t i;
@@ -762,7 +762,7 @@ hx509_free_octet_string_list(hx509_octet_string_list *list)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_find_subjectAltName_otherName(hx509_context context,
 					 hx509_cert cert,
 					 const heim_oid *oid,
@@ -858,7 +858,7 @@ check_key_usage(hx509_context context, const Certificate *cert,
  * KeyUsage extension.
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_check_key_usage(hx509_context context, hx509_cert cert,
 		       unsigned flags, int req_present)
 {
@@ -924,7 +924,7 @@ check_basic_constraints(hx509_context context, const Certificate *cert,
     return ret;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_cert_is_parent_cmp(const Certificate *subject,
 			  const Certificate *issuer,
 			  int allow_self_signed)
@@ -1203,7 +1203,7 @@ is_proxy_cert(hx509_context context,
  * internal so we can do easy searches.
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_path_append(hx509_context context, hx509_path *path, hx509_cert cert)
 {
     hx509_cert *val;
@@ -1220,7 +1220,7 @@ _hx509_path_append(hx509_context context, hx509_path *path, hx509_cert cert)
     return 0;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_path_free(hx509_path *path)
 {
     unsigned i;
@@ -1249,7 +1249,7 @@ _hx509_path_free(hx509_path *path)
  * failure.
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_calculate_path(hx509_context context,
 		      int flags,
 		      time_t time_now,
@@ -1305,7 +1305,7 @@ _hx509_calculate_path(hx509_context context,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_AlgorithmIdentifier_cmp(const AlgorithmIdentifier *p,
 			       const AlgorithmIdentifier *q)
 {
@@ -1327,7 +1327,7 @@ _hx509_AlgorithmIdentifier_cmp(const AlgorithmIdentifier *p,
     }
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_Certificate_cmp(const Certificate *p, const Certificate *q)
 {
     int diff;
@@ -1355,7 +1355,7 @@ _hx509_Certificate_cmp(const Certificate *p, const Certificate *q)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_cmp(hx509_cert p, hx509_cert q)
 {
     return _hx509_Certificate_cmp(p->data, q->data);
@@ -1373,7 +1373,7 @@ hx509_cert_cmp(hx509_cert p, hx509_cert q)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_get_issuer(hx509_cert p, hx509_name *name)
 {
     return _hx509_name_from_Name(&p->data->tbsCertificate.issuer, name);
@@ -1391,7 +1391,7 @@ hx509_cert_get_issuer(hx509_cert p, hx509_name *name)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_get_subject(hx509_cert p, hx509_name *name)
 {
     return _hx509_name_from_Name(&p->data->tbsCertificate.subject, name);
@@ -1414,7 +1414,7 @@ hx509_cert_get_subject(hx509_cert p, hx509_name *name)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_get_base_subject(hx509_context context, hx509_cert c,
 			    hx509_name *name)
 {
@@ -1441,7 +1441,7 @@ hx509_cert_get_base_subject(hx509_context context, hx509_cert c,
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_get_serialnumber(hx509_cert p, heim_integer *i)
 {
     return der_copy_heim_integer(&p->data->tbsCertificate.serialNumber, i);
@@ -1457,7 +1457,7 @@ hx509_cert_get_serialnumber(hx509_cert p, heim_integer *i)
  * @ingroup hx509_cert
  */
 
-time_t
+HX509_LIB_FUNCTION time_t HX509_LIB_CALL
 hx509_cert_get_notBefore(hx509_cert p)
 {
     return _hx509_Time2time_t(&p->data->tbsCertificate.validity.notBefore);
@@ -1473,7 +1473,7 @@ hx509_cert_get_notBefore(hx509_cert p)
  * @ingroup hx509_cert
  */
 
-time_t
+HX509_LIB_FUNCTION time_t HX509_LIB_CALL
 hx509_cert_get_notAfter(hx509_cert p)
 {
     return _hx509_Time2time_t(&p->data->tbsCertificate.validity.notAfter);
@@ -1492,7 +1492,7 @@ hx509_cert_get_notAfter(hx509_cert p)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_get_SPKI(hx509_context context, hx509_cert p, SubjectPublicKeyInfo *spki)
 {
     int ret;
@@ -1518,7 +1518,7 @@ hx509_cert_get_SPKI(hx509_context context, hx509_cert p, SubjectPublicKeyInfo *s
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_get_SPKI_AlgorithmIdentifier(hx509_context context,
 					hx509_cert p,
 					AlgorithmIdentifier *alg)
@@ -1565,7 +1565,7 @@ get_x_unique_id(hx509_context context, const char *name,
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_get_issuer_unique_id(hx509_context context, hx509_cert p, heim_bit_string *issuer)
 {
     return get_x_unique_id(context, "issuer", p->data->tbsCertificate.issuerUniqueID, issuer);
@@ -1585,27 +1585,27 @@ hx509_cert_get_issuer_unique_id(hx509_context context, hx509_cert p, heim_bit_st
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_get_subject_unique_id(hx509_context context, hx509_cert p, heim_bit_string *subject)
 {
     return get_x_unique_id(context, "subject", p->data->tbsCertificate.subjectUniqueID, subject);
 }
 
 
-hx509_private_key
+HX509_LIB_FUNCTION hx509_private_key HX509_LIB_CALL
 _hx509_cert_private_key(hx509_cert p)
 {
     return p->private_key;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_have_private_key(hx509_cert p)
 {
     return p->private_key ? 1 : 0;
 }
 
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_cert_private_key_exportable(hx509_cert p)
 {
     if (p->private_key == NULL)
@@ -1613,7 +1613,7 @@ _hx509_cert_private_key_exportable(hx509_cert p)
     return _hx509_private_key_exportable(p->private_key);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_cert_private_decrypt(hx509_context context,
 			    const heim_octet_string *ciphertext,
 			    const heim_oid *encryption_oid,
@@ -1636,7 +1636,7 @@ _hx509_cert_private_decrypt(hx509_context context,
 					      cleartext);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_public_encrypt(hx509_context context,
 			   const heim_octet_string *cleartext,
 			   const hx509_cert p,
@@ -1652,7 +1652,7 @@ hx509_cert_public_encrypt(hx509_context context,
  *
  */
 
-time_t
+HX509_LIB_FUNCTION time_t HX509_LIB_CALL
 _hx509_Time2time_t(const Time *t)
 {
     switch(t->element) {
@@ -1987,7 +1987,7 @@ free_name_constraints(hx509_name_constraints *nc)
  * @ingroup hx509_verify
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_verify_path(hx509_context context,
 		  hx509_verify_ctx ctx,
 		  hx509_cert cert,
@@ -2415,7 +2415,7 @@ out:
  * @ingroup hx509_crypto
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_verify_signature(hx509_context context,
 		       const hx509_cert signer,
 		       const AlgorithmIdentifier *alg,
@@ -2425,7 +2425,7 @@ hx509_verify_signature(hx509_context context,
     return _hx509_verify_signature(context, signer, alg, data, sig);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_verify_signature_bitstring(hx509_context context,
 				  const hx509_cert signer,
 				  const AlgorithmIdentifier *alg,
@@ -2468,7 +2468,7 @@ _hx509_verify_signature_bitstring(hx509_context context,
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_verify_hostname(hx509_context context,
 		      const hx509_cert cert,
 		      int flags,
@@ -2561,7 +2561,7 @@ hx509_verify_hostname(hx509_context context,
     return ret;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_set_cert_attribute(hx509_context context,
 			  hx509_cert cert,
 			  const heim_oid *oid,
@@ -2607,7 +2607,7 @@ _hx509_set_cert_attribute(hx509_context context,
  * @ingroup hx509_cert
  */
 
-hx509_cert_attribute
+HX509_LIB_FUNCTION hx509_cert_attribute HX509_LIB_CALL
 hx509_cert_get_attribute(hx509_cert cert, const heim_oid *oid)
 {
     size_t i;
@@ -2628,7 +2628,7 @@ hx509_cert_get_attribute(hx509_cert cert, const heim_oid *oid)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_set_friendly_name(hx509_cert cert, const char *name)
 {
     if (cert->friendlyname)
@@ -2650,7 +2650,7 @@ hx509_cert_set_friendly_name(hx509_cert cert, const char *name)
  * @ingroup hx509_cert
  */
 
-const char *
+HX509_LIB_FUNCTION const char * HX509_LIB_CALL
 hx509_cert_get_friendly_name(hx509_cert cert)
 {
     hx509_cert_attribute a;
@@ -2703,7 +2703,7 @@ hx509_cert_get_friendly_name(hx509_cert cert)
     return cert->friendlyname;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_query_clear(hx509_query *q)
 {
     memset(q, 0, sizeof(*q));
@@ -2720,7 +2720,7 @@ _hx509_query_clear(hx509_query *q)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_query_alloc(hx509_context context, hx509_query **q)
 {
     *q = calloc(1, sizeof(**q));
@@ -2741,7 +2741,7 @@ hx509_query_alloc(hx509_context context, hx509_query **q)
  * @ingroup hx509_cert
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_query_match_option(hx509_query *q, hx509_query_option option)
 {
     switch(option) {
@@ -2776,7 +2776,7 @@ hx509_query_match_option(hx509_query *q, hx509_query_option option)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_query_match_issuer_serial(hx509_query *q,
 				const Name *issuer,
 				const heim_integer *serialNumber)
@@ -2823,7 +2823,7 @@ hx509_query_match_issuer_serial(hx509_query *q,
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_query_match_friendly_name(hx509_query *q, const char *name)
 {
     if (q->friendlyname)
@@ -2848,7 +2848,7 @@ hx509_query_match_friendly_name(hx509_query *q, const char *name)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_query_match_eku(hx509_query *q, const heim_oid *eku)
 {
     int ret;
@@ -2879,7 +2879,7 @@ hx509_query_match_eku(hx509_query *q, const heim_oid *eku)
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_query_match_expr(hx509_context context, hx509_query *q, const char *expr)
 {
     if (q->expr) {
@@ -2911,7 +2911,7 @@ hx509_query_match_expr(hx509_context context, hx509_query *q, const char *expr)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_query_match_cmp_func(hx509_query *q,
 			   int (*func)(hx509_context, hx509_cert, void *),
 			   void *ctx)
@@ -2934,7 +2934,7 @@ hx509_query_match_cmp_func(hx509_query *q,
  * @ingroup hx509_cert
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_query_free(hx509_context context, hx509_query *q)
 {
     if (q == NULL)
@@ -2961,7 +2961,7 @@ hx509_query_free(hx509_context context, hx509_query *q)
     free(q);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_query_match_cert(hx509_context context, const hx509_query *q, hx509_cert cert)
 {
     Certificate *c = _hx509_get_cert(cert);
@@ -3122,7 +3122,7 @@ _hx509_query_match_cert(hx509_context context, const hx509_query *q, hx509_cert 
  * @ingroup hx509_cert
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_query_statistic_file(hx509_context context, const char *fn)
 {
     if (context->querystat)
@@ -3130,7 +3130,7 @@ hx509_query_statistic_file(hx509_context context, const char *fn)
     context->querystat = strdup(fn);
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_query_statistic(hx509_context context, int type, const hx509_query *q)
 {
     FILE *f;
@@ -3193,7 +3193,7 @@ stat_sort(const void *a, const void *b)
  * @ingroup hx509_cert
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_query_unparse_stats(hx509_context context, int printtype, FILE *out)
 {
     rtbl_t t;
@@ -3282,7 +3282,7 @@ hx509_query_unparse_stats(hx509_context context, int printtype, FILE *out)
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_check_eku(hx509_context context, hx509_cert cert,
 		     const heim_oid *eku, int allow_any_eku)
 {
@@ -3315,7 +3315,7 @@ hx509_cert_check_eku(hx509_context context, hx509_cert cert,
     return HX509_CERTIFICATE_MISSING_EKU;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_cert_get_keyusage(hx509_context context,
 			 hx509_cert c,
 			 KeyUsage *ku)
@@ -3343,7 +3343,7 @@ _hx509_cert_get_keyusage(hx509_context context,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_cert_get_eku(hx509_context context,
 		    hx509_cert cert,
 		    ExtKeyUsage *e)
@@ -3373,7 +3373,7 @@ _hx509_cert_get_eku(hx509_context context,
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_binary(hx509_context context, hx509_cert c, heim_octet_string *os)
 {
     size_t size;
@@ -3391,7 +3391,6 @@ hx509_cert_binary(hx509_context context, hx509_cert c, heim_octet_string *os)
     }
     if (os->length != size)
 	_hx509_abort("internal ASN.1 encoder error");
-
     return ret;
 }
 
@@ -3402,7 +3401,7 @@ hx509_cert_binary(hx509_context context, hx509_cert c, heim_octet_string *os)
 #undef __attribute__
 #define __attribute__(X)
 
-void
+HX509_LIB_NORETURN_FUNCTION void HX509_LIB_CALL
 _hx509_abort(const char *fmt, ...)
      __attribute__ ((__noreturn__, __format__ (__printf__, 1, 2)))
 {
@@ -3423,7 +3422,7 @@ _hx509_abort(const char *fmt, ...)
  * @ingroup hx509_misc
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_xfree(void *ptr)
 {
     free(ptr);
@@ -3433,7 +3432,7 @@ hx509_xfree(void *ptr)
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_cert_to_env(hx509_context context, hx509_cert cert, hx509_env *env)
 {
     ExtKeyUsage eku;
@@ -3582,7 +3581,7 @@ out:
  * @ingroup hx509_cert
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_print_cert(hx509_context context, hx509_cert cert, FILE *out)
 {
     hx509_name name;

--- a/lib/hx509/cms.c
+++ b/lib/hx509/cms.c
@@ -71,7 +71,7 @@
  * @ingroup hx509_cms
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cms_wrap_ContentInfo(const heim_oid *oid,
 			   const heim_octet_string *buf,
 			   heim_octet_string *res)
@@ -125,7 +125,7 @@ hx509_cms_wrap_ContentInfo(const heim_oid *oid,
  * @ingroup hx509_cms
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cms_unwrap_ContentInfo(const heim_octet_string *in,
 			     heim_oid *oid,
 			     heim_octet_string *out,
@@ -349,7 +349,7 @@ find_CMSIdentifier(hx509_context context,
  * @ingroup hx509_cms
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cms_unenvelope(hx509_context context,
 		     hx509_certs certs,
 		     int flags,
@@ -555,7 +555,7 @@ out:
  * @ingroup hx509_cms
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cms_envelope_1(hx509_context context,
 		     int flags,
 		     hx509_cert cert,
@@ -789,7 +789,7 @@ find_attribute(const CMSAttributes *attr, const heim_oid *oid)
  * @ingroup hx509_cms
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cms_verify_signed(hx509_context context,
 			hx509_verify_ctx ctx,
 			unsigned int flags,
@@ -1158,7 +1158,7 @@ add_one_attribute(Attribute **attr,
  * @ingroup hx509_cms
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cms_create_signed_1(hx509_context context,
 			  int flags,
 			  const heim_oid *eContentType,
@@ -1451,7 +1451,7 @@ cmp_AlgorithmIdentifier(const AlgorithmIdentifier *p, const AlgorithmIdentifier 
     return der_heim_oid_cmp(&p->algorithm, &q->algorithm);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cms_create_signed(hx509_context context,
 			int flags,
 			const heim_oid *eContentType,
@@ -1600,7 +1600,7 @@ out:
     return ret;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cms_decrypt_encrypted(hx509_context context,
 			    hx509_lock lock,
 			    const void *data,

--- a/lib/hx509/collector.c
+++ b/lib/hx509/collector.c
@@ -50,7 +50,7 @@ struct hx509_collector {
 };
 
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_collector_alloc(hx509_context context, hx509_lock lock, struct hx509_collector **collector)
 {
     struct hx509_collector *c;
@@ -85,14 +85,14 @@ _hx509_collector_alloc(hx509_context context, hx509_lock lock, struct hx509_coll
     return 0;
 }
 
-hx509_lock
+HX509_LIB_FUNCTION hx509_lock HX509_LIB_CALL
 _hx509_collector_get_lock(struct hx509_collector *c)
 {
     return c->lock;
 }
 
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_collector_certs_add(hx509_context context,
 			   struct hx509_collector *c,
 			   hx509_cert cert)
@@ -110,7 +110,7 @@ free_private_key(struct private_key *key)
     free(key);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_collector_private_key_add(hx509_context context,
 				 struct hx509_collector *c,
 				 const AlgorithmIdentifier *alg,
@@ -247,7 +247,7 @@ match_keys(hx509_context context, struct private_key *value, hx509_certs certs)
     return found;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_collector_collect_certs(hx509_context context,
 			       struct hx509_collector *c,
 			       hx509_certs *ret_certs)
@@ -282,7 +282,7 @@ _hx509_collector_collect_certs(hx509_context context,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_collector_collect_private_keys(hx509_context context,
 				      struct hx509_collector *c,
 				      hx509_private_key **keys)
@@ -313,7 +313,7 @@ _hx509_collector_collect_private_keys(hx509_context context,
 }
 
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_collector_free(struct hx509_collector *c)
 {
     size_t i;

--- a/lib/hx509/crypto-ec.c
+++ b/lib/hx509/crypto-ec.c
@@ -49,7 +49,7 @@ extern const AlgorithmIdentifier _hx509_signature_sha384_data;
 extern const AlgorithmIdentifier _hx509_signature_sha256_data;
 extern const AlgorithmIdentifier _hx509_signature_sha1_data;
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_private_eckey_free(void *eckey)
 {
 #ifdef HAVE_HCRYPTO_W_OPENSSL
@@ -512,7 +512,7 @@ const struct signature_alg ecdsa_with_sha1_alg = {
 
 #endif /* HAVE_HCRYPTO_W_OPENSSL */
 
-const AlgorithmIdentifier *
+HX509_LIB_FUNCTION const AlgorithmIdentifier * HX509_LIB_CALL
 hx509_signature_ecPublicKey(void)
 {
 #ifdef HAVE_HCRYPTO_W_OPENSSL
@@ -522,7 +522,7 @@ hx509_signature_ecPublicKey(void)
 #endif /* HAVE_HCRYPTO_W_OPENSSL */
 }
 
-const AlgorithmIdentifier *
+HX509_LIB_FUNCTION const AlgorithmIdentifier * HX509_LIB_CALL
 hx509_signature_ecdsa_with_sha256(void)
 {
 #ifdef HAVE_HCRYPTO_W_OPENSSL

--- a/lib/hx509/crypto.c
+++ b/lib/hx509/crypto.c
@@ -136,7 +136,7 @@ heim_int2BN(const heim_integer *i)
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_set_digest_alg(DigestAlgorithmIdentifier *id,
                       const heim_oid *oid,
                       const void *param, size_t length)
@@ -1041,7 +1041,7 @@ static struct hx509_private_key_ops *private_algs[] = {
     NULL
 };
 
-hx509_private_key_ops *
+HX509_LIB_FUNCTION hx509_private_key_ops * HX509_LIB_CALL
 hx509_find_private_alg(const heim_oid *oid)
 {
     int i;
@@ -1059,7 +1059,7 @@ hx509_find_private_alg(const heim_oid *oid)
  * des, make sure the its before the time `t'.
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_signature_is_weak(hx509_context context, const AlgorithmIdentifier *alg)
 {
     const struct signature_alg *md;
@@ -1077,7 +1077,7 @@ _hx509_signature_is_weak(hx509_context context, const AlgorithmIdentifier *alg)
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_self_signed_valid(hx509_context context,
 			 const AlgorithmIdentifier *alg)
 {
@@ -1098,7 +1098,7 @@ _hx509_self_signed_valid(hx509_context context,
 }
 
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_verify_signature(hx509_context context,
 			const hx509_cert cert,
 			const AlgorithmIdentifier *alg,
@@ -1136,7 +1136,7 @@ _hx509_verify_signature(hx509_context context,
     return (*md->verify_signature)(context, md, signer, alg, data, sig);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_create_signature(hx509_context context,
 			const hx509_private_key signer,
 			const AlgorithmIdentifier *alg,
@@ -1163,7 +1163,7 @@ _hx509_create_signature(hx509_context context,
 				   signatureAlgorithm, sig);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_create_signature_bitstring(hx509_context context,
 				  const hx509_private_key signer,
 				  const AlgorithmIdentifier *alg,
@@ -1183,7 +1183,7 @@ _hx509_create_signature_bitstring(hx509_context context,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_public_encrypt(hx509_context context,
 		      const heim_octet_string *cleartext,
 		      const Certificate *cert,
@@ -1246,7 +1246,7 @@ _hx509_public_encrypt(hx509_context context,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_private_key_private_decrypt(hx509_context context,
 				   const heim_octet_string *ciphertext,
 				   const heim_oid *encryption_oid,
@@ -1289,7 +1289,7 @@ hx509_private_key_private_decrypt(hx509_context context,
 }
 
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_parse_private_key(hx509_context context,
 			 const AlgorithmIdentifier *keyai,
 			 const void *data,
@@ -1325,7 +1325,7 @@ hx509_parse_private_key(hx509_context context,
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_private_key2SPKI(hx509_context context,
 			hx509_private_key private_key,
 			SubjectPublicKeyInfo *spki)
@@ -1339,7 +1339,7 @@ hx509_private_key2SPKI(hx509_context context,
     return (*ops->get_spki)(context, private_key, spki);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_generate_private_key_init(hx509_context context,
 				 const heim_oid *oid,
 				 struct hx509_generate_private_context **ctx)
@@ -1362,7 +1362,7 @@ _hx509_generate_private_key_init(hx509_context context,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_generate_private_key_is_ca(hx509_context context,
 				  struct hx509_generate_private_context *ctx)
 {
@@ -1370,7 +1370,7 @@ _hx509_generate_private_key_is_ca(hx509_context context,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_generate_private_key_bits(hx509_context context,
 				 struct hx509_generate_private_context *ctx,
 				 unsigned long bits)
@@ -1380,14 +1380,14 @@ _hx509_generate_private_key_bits(hx509_context context,
 }
 
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_generate_private_key_free(struct hx509_generate_private_context **ctx)
 {
     free(*ctx);
     *ctx = NULL;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_generate_private_key(hx509_context context,
 			    struct hx509_generate_private_context *ctx,
 			    hx509_private_key *private_key)
@@ -1495,7 +1495,7 @@ const AlgorithmIdentifier * _hx509_crypto_default_secret_alg =
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_private_key_init(hx509_private_key *key,
 			hx509_private_key_ops *ops,
 			void *keydata)
@@ -1509,7 +1509,7 @@ hx509_private_key_init(hx509_private_key *key,
     return 0;
 }
 
-hx509_private_key
+HX509_LIB_FUNCTION hx509_private_key HX509_LIB_CALL
 _hx509_private_key_ref(hx509_private_key key)
 {
     if (key->ref == 0)
@@ -1520,13 +1520,13 @@ _hx509_private_key_ref(hx509_private_key key)
     return key;
 }
 
-const char *
+HX509_LIB_FUNCTION const char * HX509_LIB_CALL
 _hx509_private_pem_name(hx509_private_key key)
 {
     return key->ops->pemtype;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_private_key_free(hx509_private_key *key)
 {
     if (key == NULL || *key == NULL)
@@ -1551,7 +1551,7 @@ hx509_private_key_free(hx509_private_key *key)
     return 0;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_private_key_assign_rsa(hx509_private_key key, void *ptr)
 {
     if (key->private_key.rsa)
@@ -1561,7 +1561,7 @@ hx509_private_key_assign_rsa(hx509_private_key key, void *ptr)
     key->md = &pkcs1_rsa_sha1_alg;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_private_key_oid(hx509_context context,
 		       const hx509_private_key key,
 		       heim_oid *data)
@@ -1573,7 +1573,7 @@ _hx509_private_key_oid(hx509_context context,
     return ret;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_private_key_exportable(hx509_private_key key)
 {
     if (key->ops->export == NULL)
@@ -1581,7 +1581,7 @@ _hx509_private_key_exportable(hx509_private_key key)
     return 1;
 }
 
-BIGNUM *
+HX509_LIB_FUNCTION BIGNUM * HX509_LIB_CALL
 _hx509_private_key_get_internal(hx509_context context,
 				hx509_private_key key,
 				const char *type)
@@ -1591,7 +1591,7 @@ _hx509_private_key_get_internal(hx509_context context,
     return (*key->ops->get_internal)(context, key, type);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_private_key_export(hx509_context context,
 			  const hx509_private_key key,
 			  hx509_key_format_t format,
@@ -1880,7 +1880,7 @@ find_cipher_by_name(const char *name)
 }
 
 
-const heim_oid *
+HX509_LIB_FUNCTION const heim_oid * HX509_LIB_CALL
 hx509_crypto_enctype_by_name(const char *name)
 {
     const struct hx509cipher *cipher;
@@ -1891,7 +1891,7 @@ hx509_crypto_enctype_by_name(const char *name)
     return cipher->oid;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_init(hx509_context context,
 		  const char *provider,
 		  const heim_oid *enctype,
@@ -1928,13 +1928,13 @@ hx509_crypto_init(hx509_context context,
     return 0;
 }
 
-const char *
+HX509_LIB_FUNCTION const char * HX509_LIB_CALL
 hx509_crypto_provider(hx509_crypto crypto)
 {
     return "unknown";
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_crypto_destroy(hx509_crypto crypto)
 {
     if (crypto->name)
@@ -1948,19 +1948,19 @@ hx509_crypto_destroy(hx509_crypto crypto)
     free(crypto);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_set_key_name(hx509_crypto crypto, const char *name)
 {
     return 0;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_crypto_allow_weak(hx509_crypto crypto)
 {
     crypto->flags |= ALLOW_WEAK;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_crypto_set_padding(hx509_crypto crypto, int padding_type)
 {
     switch (padding_type) {
@@ -1977,7 +1977,7 @@ hx509_crypto_set_padding(hx509_crypto crypto, int padding_type)
     }
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_set_key_data(hx509_crypto crypto, const void *data, size_t length)
 {
     if (EVP_CIPHER_key_length(crypto->c) > (int)length)
@@ -1997,7 +1997,7 @@ hx509_crypto_set_key_data(hx509_crypto crypto, const void *data, size_t length)
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_set_random_key(hx509_crypto crypto, heim_octet_string *key)
 {
     if (crypto->key.data) {
@@ -2023,7 +2023,7 @@ hx509_crypto_set_random_key(hx509_crypto crypto, heim_octet_string *key)
 	return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_set_params(hx509_context context,
 			hx509_crypto crypto,
 			const heim_octet_string *param,
@@ -2032,7 +2032,7 @@ hx509_crypto_set_params(hx509_context context,
     return (*crypto->cipher->set_params)(context, param, crypto, ivec);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_get_params(hx509_context context,
 			hx509_crypto crypto,
 			const heim_octet_string *ivec,
@@ -2041,7 +2041,7 @@ hx509_crypto_get_params(hx509_context context,
     return (*crypto->cipher->get_params)(context, crypto, ivec, param);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_random_iv(hx509_crypto crypto, heim_octet_string *ivec)
 {
     ivec->length = EVP_CIPHER_iv_length(crypto->c);
@@ -2060,7 +2060,7 @@ hx509_crypto_random_iv(hx509_crypto crypto, heim_octet_string *ivec)
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_encrypt(hx509_crypto crypto,
 		     const void *data,
 		     const size_t length,
@@ -2148,7 +2148,7 @@ hx509_crypto_encrypt(hx509_crypto crypto,
     return ret;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_decrypt(hx509_crypto crypto,
 		     const void *data,
 		     const size_t length,
@@ -2365,7 +2365,7 @@ find_string2key(const heim_oid *oid,
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_pbe_encrypt(hx509_context context,
 		   hx509_lock lock,
 		   const AlgorithmIdentifier *ai,
@@ -2380,7 +2380,7 @@ _hx509_pbe_encrypt(hx509_context context,
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_pbe_decrypt(hx509_context context,
 		   hx509_lock lock,
 		   const AlgorithmIdentifier *ai,
@@ -2530,7 +2530,7 @@ match_keys_ec(hx509_cert c, hx509_private_key private_key)
 }
 
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_match_keys(hx509_cert c, hx509_private_key key)
 {
     if (!key->ops)
@@ -2558,7 +2558,7 @@ find_keytype(const hx509_private_key key)
     return md->key_oid;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_select(const hx509_context context,
 		    int type,
 		    const hx509_private_key source,
@@ -2638,7 +2638,7 @@ hx509_crypto_select(const hx509_context context,
     return ret;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crypto_available(hx509_context context,
 		       int type,
 		       hx509_cert source,
@@ -2723,7 +2723,7 @@ out:
     return ENOMEM;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_crypto_free_algs(AlgorithmIdentifier *val,
 		       unsigned int len)
 {

--- a/lib/hx509/env.c
+++ b/lib/hx509/env.c
@@ -52,7 +52,7 @@
  * @ingroup hx509_env
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_env_add(hx509_context context, hx509_env *env,
 	      const char *key, const char *value)
 {
@@ -103,7 +103,7 @@ hx509_env_add(hx509_context context, hx509_env *env,
  * @ingroup hx509_env
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_env_add_binding(hx509_context context, hx509_env *env,
 		      const char *key, hx509_env list)
 {
@@ -150,7 +150,7 @@ hx509_env_add_binding(hx509_context context, hx509_env *env,
  * @ingroup hx509_env
  */
 
-const char *
+HX509_LIB_FUNCTION const char * HX509_LIB_CALL
 hx509_env_lfind(hx509_context context, hx509_env env,
 		const char *key, size_t len)
 {
@@ -175,7 +175,7 @@ hx509_env_lfind(hx509_context context, hx509_env env,
  * @ingroup hx509_env
  */
 
-const char *
+HX509_LIB_FUNCTION const char * HX509_LIB_CALL
 hx509_env_find(hx509_context context, hx509_env env, const char *key)
 {
     while(env) {
@@ -236,7 +236,7 @@ env_free(hx509_env b)
  * @ingroup hx509_env
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_env_free(hx509_env *env)
 {
     if (*env)

--- a/lib/hx509/error.c
+++ b/lib/hx509/error.c
@@ -53,7 +53,7 @@ struct hx509_error_data {
  * @ingroup hx509_error
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_clear_error_string(hx509_context context)
 {
     if (context) {
@@ -76,7 +76,7 @@ hx509_clear_error_string(hx509_context context)
  * @ingroup hx509_error
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_set_error_stringv(hx509_context context, int flags, int code,
 			const char *fmt, va_list ap)
 {
@@ -108,7 +108,7 @@ hx509_set_error_stringv(hx509_context context, int flags, int code,
  * @ingroup hx509_error
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_set_error_string(hx509_context context, int flags, int code,
 		       const char *fmt, ...)
 {
@@ -130,7 +130,7 @@ hx509_set_error_string(hx509_context context, int flags, int code,
  * @ingroup hx509_error
  */
 
-char *
+HX509_LIB_FUNCTION char * HX509_LIB_CALL
 hx509_get_error_string(hx509_context context, int error_code)
 {
     heim_error_t msg = context->error;
@@ -169,7 +169,7 @@ hx509_get_error_string(hx509_context context, int error_code)
  * @ingroup hx509_error
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_free_error_string(char *str)
 {
     free(str);
@@ -187,7 +187,7 @@ hx509_free_error_string(char *str)
  * @ingroup hx509_error
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_err(hx509_context context, int exit_code,
 	  int error_code, const char *fmt, ...)
 {

--- a/lib/hx509/file.c
+++ b/lib/hx509/file.c
@@ -33,7 +33,7 @@
 
 #include "hx_locl.h"
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_map_file_os(const char *fn, heim_octet_string *os)
 {
     size_t length;
@@ -48,13 +48,13 @@ _hx509_map_file_os(const char *fn, heim_octet_string *os)
     return ret;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_unmap_file_os(heim_octet_string *os)
 {
     rk_xfree(os->data);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_write_file(const char *fn, const void *data, size_t length)
 {
     rk_dumpdata(fn, data, length);
@@ -71,7 +71,7 @@ print_pem_stamp(FILE *f, const char *type, const char *str)
     fprintf(f, "-----%s %s-----\n", type, str);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_pem_write(hx509_context context, const char *type,
 		hx509_pem_header *headers, FILE *f,
 		const void *data, size_t size)
@@ -119,7 +119,7 @@ hx509_pem_write(hx509_context context, const char *type,
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_pem_add_header(hx509_pem_header **headers,
 		     const char *header, const char *value)
 {
@@ -146,7 +146,7 @@ hx509_pem_add_header(hx509_pem_header **headers,
     return 0;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_pem_free_header(hx509_pem_header *headers)
 {
     hx509_pem_header *h;
@@ -163,7 +163,7 @@ hx509_pem_free_header(hx509_pem_header *headers)
  *
  */
 
-const char *
+HX509_LIB_FUNCTION const char * HX509_LIB_CALL
 hx509_pem_find_header(const hx509_pem_header *h, const char *header)
 {
     while(h) {
@@ -179,7 +179,7 @@ hx509_pem_find_header(const hx509_pem_header *h, const char *header)
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_pem_read(hx509_context context,
 	       FILE *f,
 	       hx509_pem_read_func func,

--- a/lib/hx509/keyset.c
+++ b/lib/hx509/keyset.c
@@ -77,7 +77,7 @@ _hx509_ks_type(hx509_context context, const char *type)
     return NULL;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_ks_register(hx509_context context, struct hx509_keyset_ops *ops)
 {
     struct hx509_keyset_ops **val;
@@ -112,7 +112,7 @@ _hx509_ks_register(hx509_context context, struct hx509_keyset_ops *ops)
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_init(hx509_context context,
 		 const char *name, int flags,
 		 hx509_lock lock, hx509_certs *certs)
@@ -183,7 +183,7 @@ hx509_certs_init(hx509_context context,
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_store(hx509_context context,
 		  hx509_certs certs,
 		  int flags,
@@ -201,7 +201,7 @@ hx509_certs_store(hx509_context context,
 }
 
 
-hx509_certs
+HX509_LIB_FUNCTION hx509_certs HX509_LIB_CALL
 hx509_certs_ref(hx509_certs certs)
 {
     if (certs == NULL)
@@ -222,7 +222,7 @@ hx509_certs_ref(hx509_certs certs)
  * @ingroup hx509_keyset
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_certs_free(hx509_certs *certs)
 {
     if (*certs) {
@@ -252,7 +252,7 @@ hx509_certs_free(hx509_certs *certs)
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_start_seq(hx509_context context,
 		      hx509_certs certs,
 		      hx509_cursor *cursor)
@@ -288,7 +288,7 @@ hx509_certs_start_seq(hx509_context context,
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_next_cert(hx509_context context,
 		      hx509_certs certs,
 		      hx509_cursor cursor,
@@ -310,7 +310,7 @@ hx509_certs_next_cert(hx509_context context,
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_end_seq(hx509_context context,
 		    hx509_certs certs,
 		    hx509_cursor cursor)
@@ -335,7 +335,7 @@ hx509_certs_end_seq(hx509_context context,
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_iter_f(hx509_context context,
 		   hx509_certs certs,
 		   int (*func)(hx509_context, void *, hx509_cert),
@@ -392,7 +392,7 @@ certs_iter(hx509_context context, void *ctx, hx509_cert cert)
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_iter(hx509_context context,
 		 hx509_certs certs,
 		 int (^func)(hx509_cert))
@@ -415,7 +415,7 @@ hx509_certs_iter(hx509_context context,
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ci_print_names(hx509_context context, void *ctx, hx509_cert c)
 {
     Certificate *cert;
@@ -452,7 +452,7 @@ hx509_ci_print_names(hx509_context context, void *ctx, hx509_cert c)
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_add(hx509_context context, hx509_certs certs, hx509_cert cert)
 {
     if (certs->ops->add == NULL) {
@@ -479,7 +479,7 @@ hx509_certs_add(hx509_context context, hx509_certs certs, hx509_cert cert)
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_find(hx509_context context,
 		 hx509_certs certs,
 		 const hx509_query *q,
@@ -543,7 +543,7 @@ hx509_certs_find(hx509_context context,
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_filter(hx509_context context,
 		   hx509_certs certs,
 		   const hx509_query *q,
@@ -619,7 +619,7 @@ certs_merge_func(hx509_context context, void *ctx, hx509_cert c)
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_merge(hx509_context context, hx509_certs to, hx509_certs from)
 {
     if (from == NULL)
@@ -642,7 +642,7 @@ hx509_certs_merge(hx509_context context, hx509_certs to, hx509_certs from)
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_append(hx509_context context,
 		   hx509_certs to,
 		   hx509_lock lock,
@@ -671,7 +671,7 @@ hx509_certs_append(hx509_context context,
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_get_one_cert(hx509_context context, hx509_certs certs, hx509_cert *c)
 {
     hx509_cursor cursor;
@@ -714,7 +714,7 @@ certs_info_stdio(void *ctx, const char *str)
  * @ingroup hx509_keyset
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_certs_info(hx509_context context,
 		 hx509_certs certs,
 		 int (*func)(void *, const char *),
@@ -733,7 +733,7 @@ hx509_certs_info(hx509_context context,
 				    func, ctx);
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_pi_printf(int (*func)(void *, const char *), void *ctx,
 		 const char *fmt, ...)
 {
@@ -750,7 +750,7 @@ _hx509_pi_printf(int (*func)(void *, const char *), void *ctx,
     free(str);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_certs_keys_get(hx509_context context,
 		      hx509_certs certs,
 		      hx509_private_key **keys)
@@ -762,7 +762,7 @@ _hx509_certs_keys_get(hx509_context context,
     return (*certs->ops->getkeys)(context, certs, certs->ops_data, keys);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_certs_keys_add(hx509_context context,
 		      hx509_certs certs,
 		      hx509_private_key key)
@@ -778,7 +778,7 @@ _hx509_certs_keys_add(hx509_context context,
 }
 
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_certs_keys_free(hx509_context context,
 		       hx509_private_key *keys)
 {

--- a/lib/hx509/ks_dir.c
+++ b/lib/hx509/ks_dir.c
@@ -217,7 +217,7 @@ static struct hx509_keyset_ops keyset_dir = {
     NULL
 };
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_ks_dir_register(hx509_context context)
 {
     _hx509_ks_register(context, &keyset_dir);

--- a/lib/hx509/ks_file.c
+++ b/lib/hx509/ks_file.c
@@ -688,7 +688,7 @@ static struct hx509_keyset_ops keyset_derfile = {
 };
 
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_ks_file_register(hx509_context context)
 {
     _hx509_ks_register(context, &keyset_file);

--- a/lib/hx509/ks_keychain.c
+++ b/lib/hx509/ks_keychain.c
@@ -610,7 +610,7 @@ struct hx509_keyset_ops keyset_keychain = {
  *
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_ks_keychain_register(hx509_context context)
 {
 #ifdef HAVE_FRAMEWORK_SECURITY

--- a/lib/hx509/ks_mem.c
+++ b/lib/hx509/ks_mem.c
@@ -216,7 +216,7 @@ static struct hx509_keyset_ops keyset_mem = {
     mem_addkey
 };
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_ks_mem_register(hx509_context context)
 {
     _hx509_ks_register(context, &keyset_mem);

--- a/lib/hx509/ks_null.c
+++ b/lib/hx509/ks_null.c
@@ -93,7 +93,7 @@ struct hx509_keyset_ops keyset_null = {
     NULL
 };
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_ks_null_register(hx509_context context)
 {
     _hx509_ks_register(context, &keyset_null);

--- a/lib/hx509/ks_p11.c
+++ b/lib/hx509/ks_p11.c
@@ -1211,7 +1211,7 @@ static struct hx509_keyset_ops keyset_pkcs11 = {
 
 #endif /* HAVE_DLOPEN */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_ks_pkcs11_register(hx509_context context)
 {
 #ifdef HAVE_DLOPEN

--- a/lib/hx509/ks_p12.c
+++ b/lib/hx509/ks_p12.c
@@ -707,7 +707,7 @@ static struct hx509_keyset_ops keyset_pkcs12 = {
     NULL
 };
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_ks_pkcs12_register(hx509_context context)
 {
     _hx509_ks_register(context, &keyset_pkcs12);

--- a/lib/hx509/lock.c
+++ b/lib/hx509/lock.c
@@ -59,7 +59,7 @@ hx509_lock _hx509_empty_lock = &empty_lock_data;
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_lock_init(hx509_context context, hx509_lock *lock)
 {
     hx509_lock l;
@@ -86,7 +86,7 @@ hx509_lock_init(hx509_context context, hx509_lock *lock)
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_lock_add_password(hx509_lock lock, const char *password)
 {
     void *d;
@@ -109,19 +109,19 @@ hx509_lock_add_password(hx509_lock lock, const char *password)
     return 0;
 }
 
-const struct _hx509_password *
+HX509_LIB_FUNCTION const struct _hx509_password * HX509_LIB_CALL
 _hx509_lock_get_passwords(hx509_lock lock)
 {
     return &lock->password;
 }
 
-hx509_certs
+HX509_LIB_FUNCTION hx509_certs HX509_LIB_CALL
 _hx509_lock_unlock_certs(hx509_lock lock)
 {
     return lock->certs;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_lock_reset_passwords(hx509_lock lock)
 {
     size_t i;
@@ -132,19 +132,19 @@ hx509_lock_reset_passwords(hx509_lock lock)
     lock->password.len = 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_lock_add_cert(hx509_context context, hx509_lock lock, hx509_cert cert)
 {
     return hx509_certs_add(context, lock->certs, cert);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_lock_add_certs(hx509_context context, hx509_lock lock, hx509_certs certs)
 {
     return hx509_certs_merge(context, lock->certs, certs);
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_lock_reset_certs(hx509_context context, hx509_lock lock)
 {
     hx509_certs certs = lock->certs;
@@ -161,14 +161,14 @@ hx509_lock_reset_certs(hx509_context context, hx509_lock lock)
 	lock->certs = certs;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_lock_find_cert(hx509_lock lock, const hx509_query *q, hx509_cert *c)
 {
     *c = NULL;
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_lock_set_prompter(hx509_lock lock, hx509_prompter_fct prompt, void *data)
 {
     lock->prompt = prompt;
@@ -176,7 +176,7 @@ hx509_lock_set_prompter(hx509_lock lock, hx509_prompter_fct prompt, void *data)
     return 0;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_lock_reset_promper(hx509_lock lock)
 {
     lock->prompt = NULL;
@@ -206,7 +206,7 @@ default_prompter(void *data, const hx509_prompt *prompter)
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_lock_prompt(hx509_lock lock, hx509_prompt *prompt)
 {
     if (lock->prompt == NULL)
@@ -214,7 +214,7 @@ hx509_lock_prompt(hx509_lock lock, hx509_prompt *prompt)
     return (*lock->prompt)(lock->prompt_data, prompt);
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_lock_free(hx509_lock lock)
 {
     if (lock) {
@@ -225,7 +225,7 @@ hx509_lock_free(hx509_lock lock)
     }
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_prompt_hidden(hx509_prompt_type type)
 {
     /* default to hidden if unknown */
@@ -239,7 +239,7 @@ hx509_prompt_hidden(hx509_prompt_type type)
     }
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_lock_command_string(hx509_lock lock, const char *string)
 {
     if (strncasecmp(string, "PASS:", 5) == 0) {

--- a/lib/hx509/name.c
+++ b/lib/hx509/name.c
@@ -191,13 +191,13 @@ stringtooid(const char *name, size_t len, heim_oid *oid)
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_name_to_string(const hx509_name name, char **str)
 {
     return _hx509_Name_to_string(&name->der_name, str);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_Name_to_string(const Name *n, char **str)
 {
     size_t total_len = 0;
@@ -419,7 +419,7 @@ dsstringprep(const DirectoryString *ds, uint32_t **rname, size_t *rlen)
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_name_ds_cmp(const DirectoryString *ds1,
 		   const DirectoryString *ds2,
 		   int *diff)
@@ -452,7 +452,7 @@ _hx509_name_ds_cmp(const DirectoryString *ds1,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_name_cmp(const Name *n1, const Name *n2, int *c)
 {
     int ret;
@@ -498,7 +498,7 @@ _hx509_name_cmp(const Name *n1, const Name *n2, int *c)
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_name_cmp(hx509_name n1, hx509_name n2)
 {
     int ret, diff;
@@ -509,7 +509,7 @@ hx509_name_cmp(hx509_name n1, hx509_name n2)
 }
 
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_name_from_Name(const Name *n, hx509_name *name)
 {
     int ret;
@@ -524,7 +524,7 @@ _hx509_name_from_Name(const Name *n, hx509_name *name)
     return ret;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_name_modify(hx509_context context,
 		   Name *name,
 		   int append,
@@ -582,7 +582,7 @@ _hx509_name_modify(hx509_context context,
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_parse_name(hx509_context context, const char *str, hx509_name *name)
 {
     const char *p, *q;
@@ -686,7 +686,7 @@ out:
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_name_copy(hx509_context context, const hx509_name from, hx509_name *to)
 {
     int ret;
@@ -714,13 +714,13 @@ hx509_name_copy(hx509_context context, const hx509_name from, hx509_name *to)
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_name_to_Name(const hx509_name from, Name *to)
 {
     return copy_Name(&from->der_name, to);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_name_normalize(hx509_context context, hx509_name name)
 {
     return 0;
@@ -739,7 +739,7 @@ hx509_name_normalize(hx509_context context, hx509_name name)
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_name_expand(hx509_context context,
 		  hx509_name name,
 		  hx509_env env)
@@ -842,7 +842,7 @@ hx509_name_expand(hx509_context context,
  * @ingroup hx509_name
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_name_free(hx509_name *name)
 {
     free_Name(&(*name)->der_name);
@@ -863,7 +863,7 @@ hx509_name_free(hx509_name *name)
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_unparse_der_name(const void *data, size_t length, char **str)
 {
     Name name;
@@ -891,7 +891,7 @@ hx509_unparse_der_name(const void *data, size_t length, char **str)
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_name_binary(const hx509_name name, heim_octet_string *os)
 {
     size_t size;
@@ -906,7 +906,7 @@ hx509_name_binary(const hx509_name name, heim_octet_string *os)
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_unparse_Name(const Name *aname, char **str)
 {
     hx509_name name;
@@ -931,7 +931,7 @@ _hx509_unparse_Name(const Name *aname, char **str)
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_name_is_null_p(const hx509_name name)
 {
     return name->der_name.u.rdnSequence.len == 0;
@@ -948,7 +948,7 @@ hx509_name_is_null_p(const hx509_name name)
  * @ingroup hx509_name
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_general_name_unparse(GeneralName *name, char **str)
 {
     struct rk_strpool *strpool = NULL;

--- a/lib/hx509/peer.c
+++ b/lib/hx509/peer.c
@@ -55,7 +55,7 @@
  * @ingroup hx509_peer
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_peer_info_alloc(hx509_context context, hx509_peer_info *peer)
 {
     *peer = calloc(1, sizeof(**peer));
@@ -88,7 +88,7 @@ free_cms_alg(hx509_peer_info peer)
  * @ingroup hx509_peer
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_peer_info_free(hx509_peer_info peer)
 {
     if (peer == NULL)
@@ -111,7 +111,7 @@ hx509_peer_info_free(hx509_peer_info peer)
  * @ingroup hx509_peer
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_peer_info_set_cert(hx509_peer_info peer,
 			 hx509_cert cert)
 {
@@ -133,7 +133,7 @@ hx509_peer_info_set_cert(hx509_peer_info peer,
  * @ingroup hx509_peer
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_peer_info_add_cms_alg(hx509_context context,
 			    hx509_peer_info peer,
 			    const AlgorithmIdentifier *val)
@@ -168,7 +168,7 @@ hx509_peer_info_add_cms_alg(hx509_context context,
  * @ingroup hx509_peer
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_peer_info_set_cms_algs(hx509_context context,
 			     hx509_peer_info peer,
 			     const AlgorithmIdentifier *val,
@@ -203,14 +203,14 @@ hx509_peer_info_set_cms_algs(hx509_context context,
  * S/MIME
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_peer_info_parse_smime(hx509_peer_info peer,
 			    const heim_octet_string *data)
 {
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_peer_info_unparse_smime(hx509_peer_info peer,
 			      heim_octet_string *data)
 {
@@ -221,14 +221,14 @@ hx509_peer_info_unparse_smime(hx509_peer_info peer,
  * For storing hx509_peer_info to be able to cache them.
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_peer_info_parse(hx509_peer_info peer,
 		      const heim_octet_string *data)
 {
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_peer_info_unparse(hx509_peer_info peer,
 			heim_octet_string *data)
 {

--- a/lib/hx509/print.c
+++ b/lib/hx509/print.c
@@ -93,7 +93,7 @@ Time2string(const Time *T, char **str)
  * @ingroup hx509_print
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_print_stdout(void *ctx, const char *fmt, va_list va)
 {
     FILE *f = ctx;
@@ -122,7 +122,7 @@ print_func(hx509_vprint_func func, void *ctx, const char *fmt, ...)
  * @ingroup hx509_print
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_oid_sprint(const heim_oid *oid, char **str)
 {
     return der_print_heim_oid(oid, '.', str);
@@ -139,7 +139,7 @@ hx509_oid_sprint(const heim_oid *oid, char **str)
  * @ingroup hx509_print
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_oid_print(const heim_oid *oid, hx509_vprint_func func, void *ctx)
 {
     char *str;
@@ -159,7 +159,7 @@ hx509_oid_print(const heim_oid *oid, hx509_vprint_func func, void *ctx)
  * @ingroup hx509_print
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_bitstring_print(const heim_bit_string *b,
 		      hx509_vprint_func func, void *ctx)
 {
@@ -187,7 +187,7 @@ hx509_bitstring_print(const heim_bit_string *b,
  * @ingroup hx509_print
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_cert_keyusage_print(hx509_context context, hx509_cert c, char **s)
 {
     KeyUsage ku;
@@ -807,7 +807,7 @@ struct {
  * @ingroup hx509_print
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_validate_ctx_init(hx509_context context, hx509_validate_ctx *ctx)
 {
     *ctx = malloc(sizeof(**ctx));
@@ -829,7 +829,7 @@ hx509_validate_ctx_init(hx509_context context, hx509_validate_ctx *ctx)
  * @ingroup hx509_print
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_validate_ctx_set_print(hx509_validate_ctx ctx,
 			     hx509_vprint_func func,
 			     void *c)
@@ -850,7 +850,7 @@ hx509_validate_ctx_set_print(hx509_validate_ctx ctx,
  * @ingroup hx509_print
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_validate_ctx_add_flags(hx509_validate_ctx ctx, int flags)
 {
     ctx->flags |= flags;
@@ -864,7 +864,7 @@ hx509_validate_ctx_add_flags(hx509_validate_ctx ctx, int flags)
  * @ingroup hx509_print
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_validate_ctx_free(hx509_validate_ctx ctx)
 {
     free(ctx);
@@ -882,7 +882,7 @@ hx509_validate_ctx_free(hx509_validate_ctx ctx)
  * @ingroup hx509_print
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_validate_cert(hx509_context context,
 		    hx509_validate_ctx ctx,
 		    hx509_cert cert)

--- a/lib/hx509/req.c
+++ b/lib/hx509/req.c
@@ -45,7 +45,7 @@ struct hx509_request_data {
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_request_init(hx509_context context, hx509_request *req)
 {
     *req = calloc(1, sizeof(**req));
@@ -55,7 +55,7 @@ hx509_request_init(hx509_context context, hx509_request *req)
     return 0;
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_request_free(hx509_request *req)
 {
     if ((*req)->name)
@@ -68,7 +68,7 @@ hx509_request_free(hx509_request *req)
     *req = NULL;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_request_set_name(hx509_context context,
 			hx509_request req,
 			hx509_name name)
@@ -83,7 +83,7 @@ hx509_request_set_name(hx509_context context,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_request_get_name(hx509_context context,
 			hx509_request req,
 			hx509_name *name)
@@ -95,7 +95,7 @@ hx509_request_get_name(hx509_context context,
     return hx509_name_copy(context, req->name, name);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_request_set_SubjectPublicKeyInfo(hx509_context context,
 					hx509_request req,
 					const SubjectPublicKeyInfo *key)
@@ -104,7 +104,7 @@ hx509_request_set_SubjectPublicKeyInfo(hx509_context context,
     return copy_SubjectPublicKeyInfo(key, &req->key);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_request_get_SubjectPublicKeyInfo(hx509_context context,
 					hx509_request req,
 					SubjectPublicKeyInfo *key)
@@ -112,7 +112,7 @@ hx509_request_get_SubjectPublicKeyInfo(hx509_context context,
     return copy_SubjectPublicKeyInfo(&req->key, key);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_request_add_eku(hx509_context context,
 		       hx509_request req,
 		       const heim_oid *oid)
@@ -134,7 +134,7 @@ _hx509_request_add_eku(hx509_context context,
     return 0;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_request_add_dns_name(hx509_context context,
 			    hx509_request req,
 			    const char *hostname)
@@ -149,7 +149,7 @@ _hx509_request_add_dns_name(hx509_context context,
     return add_GeneralNames(&req->san, &name);
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_request_add_email(hx509_context context,
 			 hx509_request req,
 			 const char *email)
@@ -166,7 +166,7 @@ _hx509_request_add_email(hx509_context context,
 
 
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_request_to_pkcs10(hx509_context context,
 			 const hx509_request req,
 			 const hx509_private_key signer,
@@ -237,7 +237,7 @@ out:
     return ret;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_request_parse(hx509_context context,
 		     const char *path,
 		     hx509_request *req)
@@ -305,7 +305,7 @@ _hx509_request_parse(hx509_context context,
 }
 
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_request_print(hx509_context context, hx509_request req, FILE *f)
 {
     int ret;

--- a/lib/hx509/revoke.c
+++ b/lib/hx509/revoke.c
@@ -91,7 +91,7 @@ struct hx509_revoke_ctx_data {
  * @ingroup hx509_revoke
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_revoke_init(hx509_context context, hx509_revoke_ctx *ctx)
 {
     *ctx = calloc(1, sizeof(**ctx));
@@ -107,7 +107,7 @@ hx509_revoke_init(hx509_context context, hx509_revoke_ctx *ctx)
     return 0;
 }
 
-hx509_revoke_ctx
+HX509_LIB_FUNCTION hx509_revoke_ctx HX509_LIB_CALL
 _hx509_revoke_ref(hx509_revoke_ctx ctx)
 {
     if (ctx == NULL)
@@ -137,7 +137,7 @@ free_ocsp(struct revoke_ocsp *ocsp)
  * @ingroup hx509_revoke
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_revoke_free(hx509_revoke_ctx *ctx)
 {
     size_t i ;
@@ -399,7 +399,7 @@ load_ocsp(hx509_context context, struct revoke_ocsp *ocsp)
  * @ingroup hx509_revoke
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_revoke_add_ocsp(hx509_context context,
 		      hx509_revoke_ctx ctx,
 		      const char *path)
@@ -636,7 +636,7 @@ load_crl(hx509_context context, const char *path, time_t *t, CRLCertificateList 
  * @ingroup hx509_revoke
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_revoke_add_crl(hx509_context context,
 		     hx509_revoke_ctx ctx,
 		     const char *path)
@@ -706,7 +706,7 @@ hx509_revoke_add_crl(hx509_context context,
  * @ingroup hx509_revoke
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_revoke_verify(hx509_context context,
 		    hx509_revoke_ctx ctx,
 		    hx509_certs certs,
@@ -994,7 +994,7 @@ out:
  * @ingroup hx509_revoke
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ocsp_request(hx509_context context,
 		   hx509_certs reqcerts,
 		   hx509_certs pool,
@@ -1194,7 +1194,7 @@ print_crl(hx509_context context, struct revoke_crl *crl, FILE *out)
  *
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_revoke_print(hx509_context context,
 		   hx509_revoke_ctx ctx,
 		   FILE *out)
@@ -1241,7 +1241,7 @@ hx509_revoke_print(hx509_context context,
  * @ingroup hx509_revoke
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_revoke_ocsp_print(hx509_context context, const char *path, FILE *out)
 {
     struct revoke_ocsp ocsp;
@@ -1287,7 +1287,7 @@ hx509_revoke_ocsp_print(hx509_context context, const char *path, FILE *out)
  * @ingroup hx509_verify
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ocsp_verify(hx509_context context,
 		  time_t now,
 		  hx509_cert cert,
@@ -1396,7 +1396,7 @@ struct hx509_crl {
  * @ingroup hx509_verify
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crl_alloc(hx509_context context, hx509_crl *crl)
 {
     int ret;
@@ -1429,7 +1429,7 @@ hx509_crl_alloc(hx509_context context, hx509_crl *crl)
  * @ingroup hx509_verify
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crl_add_revoked_certs(hx509_context context,
 			    hx509_crl crl,
 			    hx509_certs certs)
@@ -1450,7 +1450,7 @@ hx509_crl_add_revoked_certs(hx509_context context,
  * @ingroup hx509_verify
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crl_lifetime(hx509_context context, hx509_crl crl, int delta)
 {
     crl->expire = time(NULL) + delta;
@@ -1466,7 +1466,7 @@ hx509_crl_lifetime(hx509_context context, hx509_crl crl, int delta)
  * @ingroup hx509_verify
  */
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 hx509_crl_free(hx509_context context, hx509_crl *crl)
 {
     if (*crl == NULL)
@@ -1525,7 +1525,7 @@ add_revoked(hx509_context context, void *ctx, hx509_cert cert)
  * @ingroup hx509_verify
  */
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_crl_sign(hx509_context context,
 	       hx509_cert signer,
 	       hx509_crl crl,

--- a/lib/hx509/sel.c
+++ b/lib/hx509/sel.c
@@ -33,7 +33,7 @@
 
 #include "hx_locl.h"
 
-struct hx_expr *
+HX509_LIB_FUNCTION struct hx_expr * HX509_LIB_CALL
 _hx509_make_expr(enum hx_expr_op op, void *arg1, void *arg2)
 {
     struct hx_expr *expr;
@@ -155,7 +155,7 @@ eval_comp(hx509_context context, hx509_env env, struct hx_expr *expr)
     return FALSE;
 }
 
-int
+HX509_LIB_FUNCTION int HX509_LIB_CALL
 _hx509_expr_eval(hx509_context context, hx509_env env, struct hx_expr *expr)
 {
     switch (expr->op) {
@@ -179,7 +179,7 @@ _hx509_expr_eval(hx509_context context, hx509_env env, struct hx_expr *expr)
     }
 }
 
-void
+HX509_LIB_FUNCTION void HX509_LIB_CALL
 _hx509_expr_free(struct hx_expr *expr)
 {
     switch (expr->op) {
@@ -204,7 +204,7 @@ _hx509_expr_free(struct hx_expr *expr)
     free(expr);
 }
 
-struct hx_expr *
+HX509_LIB_FUNCTION struct hx_expr * HX509_LIB_CALL
 _hx509_expr_parse(const char *buf)
 {
     _hx509_expr_input.buf = buf;

--- a/lib/krb5/warn.c
+++ b/lib/krb5/warn.c
@@ -181,7 +181,7 @@ krb5_warnx(krb5_context context, const char *fmt, ...)
  * @ingroup krb5_error
  */
 
-KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+KRB5_LIB_NORETURN_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_verr(krb5_context context, int eval, krb5_error_code code,
 	  const char *fmt, va_list ap)
      __attribute__ ((__noreturn__, __format__ (__printf__, 4, 0)))
@@ -203,7 +203,7 @@ krb5_verr(krb5_context context, int eval, krb5_error_code code,
  * @ingroup krb5_error
  */
 
-KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+KRB5_LIB_NORETURN_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_err(krb5_context context, int eval, krb5_error_code code,
 	 const char *fmt, ...)
      __attribute__ ((__noreturn__, __format__ (__printf__, 4, 5)))
@@ -224,7 +224,7 @@ krb5_err(krb5_context context, int eval, krb5_error_code code,
  * @ingroup krb5_error
  */
 
-KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+KRB5_LIB_NORETURN_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_verrx(krb5_context context, int eval, const char *fmt, va_list ap)
      __attribute__ ((__noreturn__, __format__ (__printf__, 3, 0)))
 {
@@ -243,7 +243,7 @@ krb5_verrx(krb5_context context, int eval, const char *fmt, va_list ap)
  * @ingroup krb5_error
  */
 
-KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+KRB5_LIB_NORETURN_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_errx(krb5_context context, int eval, const char *fmt, ...)
      __attribute__ ((__noreturn__, __format__ (__printf__, 3, 4)))
 {
@@ -264,7 +264,7 @@ krb5_errx(krb5_context context, int eval, const char *fmt, ...)
  * @ingroup krb5_error
  */
 
-KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+KRB5_LIB_NORETURN_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_vabort(krb5_context context, krb5_error_code code,
 	    const char *fmt, va_list ap)
      __attribute__ ((__noreturn__, __format__ (__printf__, 3, 0)))
@@ -286,7 +286,7 @@ krb5_vabort(krb5_context context, krb5_error_code code,
  * @ingroup krb5_error
  */
 
-KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+KRB5_LIB_NORETURN_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_abort(krb5_context context, krb5_error_code code, const char *fmt, ...)
      __attribute__ ((__noreturn__, __format__ (__printf__, 3, 4)))
 {
@@ -295,7 +295,7 @@ krb5_abort(krb5_context context, krb5_error_code code, const char *fmt, ...)
     UNREACHABLE(return 0);
 }
 
-KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+KRB5_LIB_NORETURN_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_vabortx(krb5_context context, const char *fmt, va_list ap)
      __attribute__ ((__noreturn__, __format__ (__printf__, 2, 0)))
 {
@@ -314,7 +314,7 @@ krb5_vabortx(krb5_context context, const char *fmt, va_list ap)
  * @ingroup krb5_error
  */
 
-KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+KRB5_LIB_NORETURN_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_abortx(krb5_context context, const char *fmt, ...)
      __attribute__ ((__noreturn__, __format__ (__printf__, 2, 3)))
 {

--- a/lib/roken/err.hin
+++ b/lib/roken/err.hin
@@ -47,30 +47,39 @@
 #endif
 
 #ifndef ROKEN_LIB_FUNCTION
-#ifdef _WIN32
-#define ROKEN_LIB_FUNCTION
-#define ROKEN_LIB_CALL     __cdecl
-#else
-#define ROKEN_LIB_FUNCTION
-#define ROKEN_LIB_CALL
+  #define ROKEN_LIB_FUNCTION
 #endif
+#ifndef ROKEN_LIB_NORETURN_FUNCTION
+ #ifdef _WIN32
+  #define ROKEN_LIB_NORETURN_FUNCTION _declspec(noreturn)
+ #else
+  #define ROKEN_LIB_NORETURN_FUNCTION
+ #endif
+#endif
+#ifndef ROKEN_LIB_CALL
+ #ifdef _WIN32
+  #define ROKEN_LIB_CALL     __cdecl
+ #else
+  #define ROKEN_LIB_CALL
+ #endif
 #endif
 
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+ROKEN_LIB_NORETURN_FUNCTION void ROKEN_LIB_CALL
 verr(int eval, const char *fmt, va_list ap)
      __attribute__ ((__noreturn__, __format__ (__printf__, 2, 0)));
 
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+ROKEN_LIB_NORETURN_FUNCTION void ROKEN_LIB_CALL
 err(int eval, const char *fmt, ...)
      __attribute__ ((__noreturn__, __format__ (__printf__, 2, 3)));
 
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+ROKEN_LIB_NORETURN_FUNCTION void ROKEN_LIB_CALL
 verrx(int eval, const char *fmt, va_list ap)
      __attribute__ ((__noreturn__, __format__ (__printf__, 2, 0)));
 
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+ROKEN_LIB_NORETURN_FUNCTION void ROKEN_LIB_CALL
 errx(int eval, const char *fmt, ...)
      __attribute__ ((__noreturn__, __format__ (__printf__, 2, 3)));
+
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
 vwarn(const char *fmt, va_list ap)
      __attribute__ ((__format__ (__printf__, 1, 0)));

--- a/lib/roken/errx.c
+++ b/lib/roken/errx.c
@@ -35,7 +35,7 @@
 
 #include "err.h"
 
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+ROKEN_LIB_NORETURN_FUNCTION void ROKEN_LIB_CALL
 errx(int eval, const char *fmt, ...)
 {
   va_list ap;

--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -52,22 +52,49 @@
 #include <util.h>
 #endif
 
-#ifndef ROKEN_LIB_FUNCTION
-#ifdef _WIN32
-#  define ROKEN_LIB_CALL     __cdecl
-#  ifdef ROKEN_LIB_DYNAMIC
+# ifndef ROKEN_LIB_FUNCTION
+#  ifdef _WIN32
+#   ifdef ROKEN_LIB_DYNAMIC
 #    define ROKEN_LIB_FUNCTION __declspec(dllimport)
-#    define ROKEN_LIB_VARIABLE __declspec(dllimport)
-#  else
+#   else
 #    define ROKEN_LIB_FUNCTION
-#    define ROKEN_LIB_VARIABLE
+#   endif
+#  else
+#   define ROKEN_LIB_FUNCTION
 #  endif
-#else
-#define ROKEN_LIB_FUNCTION
-#define ROKEN_LIB_CALL
-#define ROKEN_LIB_VARIABLE
-#endif
-#endif
+# endif
+
+# ifndef ROKEN_LIB_NORETURN_FUNCTION
+#  ifdef _WIN32
+#   ifdef ROKEN_LIB_DYNAMIC
+#    define ROKEN_LIB_NORETURN_FUNCTION __declspec(dllimport noreturn)
+#   else
+#    define ROKEN_LIB_NORETURN_FUNCTION _declspec(noreturn)
+#   endif
+#  else
+#   define ROKEN_LIB_NORETURN_FUNCTION
+#  endif
+# endif
+
+# ifndef ROKEN_LIB_CALL
+#  ifdef _WIN32
+#   define ROKEN_LIB_CALL     __cdecl
+#  else
+#   define ROKEN_LIB_CALL
+#  endif
+# endif
+
+# ifndef ROKEN_LIB_VARIABLE
+#  ifdef _WIN32
+#   ifdef ROKEN_LIB_DYNAMIC
+#    define ROKEN_LIB_VARIABLE __declspec(dllimport)
+#   else
+#    define ROKEN_LIB_VARIABLE
+#   endif
+#  else
+#   define ROKEN_LIB_VARIABLE
+#  endif
+# endif
 
 #ifdef HAVE_WINSOCK
 /* Declarations for Microsoft Windows */

--- a/lib/roken/verrx.c
+++ b/lib/roken/verrx.c
@@ -36,7 +36,7 @@
 #include "roken.h"
 #include <err.h>
 
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+ROKEN_LIB_NORETURN_FUNCTION void ROKEN_LIB_CALL
 verrx(int eval, const char *fmt, va_list ap)
 {
     rk_warnerr(0, fmt, ap);

--- a/lib/wind/gen-punycode-examples.py
+++ b/lib/wind/gen-punycode-examples.py
@@ -71,7 +71,7 @@ while True:
             else:
                 m = re.search('^ *([uU]+.*) *$', l)
                 if m:
-		    codes.extend(m.group(1).split(' '))
+                    codes.extend(m.group(1).split(' '))
                 else:
                     m = re.search('^ *Punycode: (.*) *$', l)
                     if m:
@@ -80,7 +80,7 @@ while True:
         if re.match('^7\.1', l):
             start = True
             cases = []
-            
+
 f.close()
 
 examples_h.file.write(
@@ -114,7 +114,7 @@ for x in cases:
     examples_c.file.write(
         "  {%u, {%s}, \"%s\", \"%s\"},\n" %
         (len(cp),
-	 ",".join([re.sub('[uU]\+', '0x', x) for x in cp]),
+         ",".join([re.sub('[uU]\+', '0x', x) for x in cp]),
          pc,
          desc))
 


### PR DESCRIPTION
apply __declspec(noreturn) compiler hints to functions that
do not return.

Change-Id: I3c6c4703c7235d1df3e21dccad5272ea4cddfd36