### PR TITLE
gssapi: gss_compare_name() both ways (#503)

### DIFF
--- a/lib/gssapi/mech/gss_compare_name.c
+++ b/lib/gssapi/mech/gss_compare_name.c
@@ -68,6 +68,19 @@ gss_compare_name(OM_uint32 *minor_status,
 						name_equal));
 			}
 		}
+		HEIM_SLIST_FOREACH(mn2, &name2->gn_mn, gmn_link) {
+			OM_uint32 major_status;
+
+			major_status = _gss_find_mn(minor_status, name1,
+						    mn2->gmn_mech_oid, &mn1);
+			if (major_status == GSS_S_COMPLETE && mn1) {
+				return (mn2->gmn_mech->gm_compare_name(
+						minor_status,
+						mn2->gmn_name,
+						mn1->gmn_name,
+						name_equal));
+			}
+		}
 		*name_equal = 0;
 	}
 


### PR DESCRIPTION
In the case that one name has no MNs and the second name only has an MN, then the order in which the two names are passed in matters, but it shouldn't. Run the comparison both ways.