### PR TITLE
hdb: dereference principal aliases in all KDC lookups (#452)

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -807,7 +807,7 @@ tgs_make_reply(krb5_context context,
     if(ret)
 	goto out;
 
-    ret = copy_Realm(&server->entry.principal->realm, &rep.ticket.realm);
+    ret = copy_Realm(&server_principal->realm, &rep.ticket.realm);
     if (ret)
 	goto out;
     _krb5_principal2principalname(&rep.ticket.sname, server_principal);

--- a/lib/hdb/hdb.asn1
+++ b/lib/hdb/hdb.asn1
@@ -49,6 +49,9 @@ HDBFlags ::= BIT STRING {
 	locked-out(17),			-- Account is locked out,
 					-- authentication will be denied
 	require-pwchange(18),		-- require a passwd change
+	force-canonicalize(30),		-- force the KDC to return the canonical
+					-- principal irrespective of the setting
+					-- of the canonicalize KDC option
 	do-not-store(31)		-- Not to be modified and stored in HDB
 }
 


### PR DESCRIPTION
e11abf41 added support in libhdb for always dereferencing principal aliases during an AS-REQ (where dereferencing refers to enabling alias lookups, and rewriting the returned entry with the alias name unless canonicalization was enabled).

Due to the KDC setting `HDB_F_FOR_AS_REQ` for all lookups from the AS, this allowed aliases on the TGS itself to be dereferenced during an AS-REQ; however, on presenting the TGT, the TGS would fail to resolve. Creating an explicit TGS principal for the aliased realm would work (at least prior to c555ed6a), but  this could be confusing to deploy.

This commit changes enables alias dereferencing when `HDB_F_GET_ANY` is set, which essentially means dereference whenever the request is coming from the KDC (as opposed to, say, kadmin).

We also backout c555ed6a, which changed the TGS to always canonicalize the server realm, as this breaks serving multiple realms from a single KDC, where server principals in different realms share a single canonical entry. `HDB_F_CANON `is now passed to the backend as a hint only, and per RFC 6806 the principal name is never changed in TGS replies. (However, for Samba interop, backends can override this by setting the `force-canonicalize` HDB flag.)