### PR TITLE
kdc: perform AS-REQ canonicalization in kdc

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1654,7 +1654,7 @@ _kdc_as_rep(kdc_request_t r,
     krb5_error_code ret = 0;
     Key *skey;
     int found_pa = 0;
-    int i, flags = HDB_F_FOR_AS_REQ;
+    int i, cflags, sflags;
     METHOD_DATA error_method;
     const PA_DATA *pa;
 
@@ -1673,9 +1673,6 @@ _kdc_as_rep(kdc_request_t r,
 
     b = &req->req_body;
     f = b->kdc_options;
-
-    if (f.canonicalize)
-	flags |= HDB_F_CANON;
 
     if(b->sname == NULL){
 	ret = KRB5KRB_ERR_GENERIC;
@@ -1715,6 +1712,19 @@ _kdc_as_rep(kdc_request_t r,
     kdc_log(context, config, 0, "AS-REQ %s from %s for %s",
 	    r->client_name, from, r->server_name);
 
+    /* Client enterprise principal names are always canonicalized */
+    cflags = HDB_F_FOR_AS_REQ | HDB_F_GET_CLIENT;
+    if (f.canonicalize ||
+	r->client_princ->name.name_type == KRB5_NT_ENTERPRISE_PRINCIPAL)
+	cflags |= HDB_F_CANON;
+
+    sflags = HDB_F_FOR_AS_REQ | HDB_F_GET_SERVER;
+    if (f.canonicalize)
+	sflags |= HDB_F_CANON;
+    /* Only set HDB_F_GET_KRBTGT if we are resolving a TGS */
+    if (krb5_principal_is_krbtgt(context, r->server_princ))
+	sflags |= HDB_F_GET_KRBTGT;
+
     /*
      *
      */
@@ -1737,9 +1747,8 @@ _kdc_as_rep(kdc_request_t r,
      *
      */
 
-    ret = _kdc_db_fetch(context, config, r->client_princ,
-			HDB_F_GET_CLIENT | flags, NULL,
-			&r->clientdb, &r->client);
+    ret = _kdc_db_fetch(context, config, r->client_princ, cflags,
+			NULL, &r->clientdb, &r->client);
     if(ret == HDB_ERR_NOT_FOUND_HERE) {
 	kdc_log(context, config, 5, "client %s does not have secrets at this KDC, need to proxy",
 		r->client_name);
@@ -1776,8 +1785,7 @@ _kdc_as_rep(kdc_request_t r,
 	ret = KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN;
 	goto out;
     }
-    ret = _kdc_db_fetch(context, config, r->server_princ,
-			HDB_F_GET_SERVER|HDB_F_GET_KRBTGT | flags,
+    ret = _kdc_db_fetch(context, config, r->server_princ, sflags,
 			NULL, NULL, &r->server);
     if(ret == HDB_ERR_NOT_FOUND_HERE) {
 	kdc_log(context, config, 5, "target %s does not have secrets at this KDC, need to proxy",
@@ -1953,16 +1961,18 @@ _kdc_as_rep(kdc_request_t r,
     rep.pvno = 5;
     rep.msg_type = krb_as_rep;
 
+    if (r->client->entry.flags.force_canonicalize)
+	cflags |= HDB_F_CANON;
     if (_kdc_is_anonymous(context, r->client_princ)) {
 	Realm anon_realm=KRB5_ANON_REALM;
 	ret = copy_Realm(&anon_realm, &rep.crealm);
-    } else if (f.canonicalize || r->client->entry.flags.force_canonicalize)
+    } else if (cflags & HDB_F_CANON)
 	ret = copy_Realm(&r->client->entry.principal->realm, &rep.crealm);
     else
 	ret = copy_Realm(&r->client_princ->realm, &rep.crealm);
     if (ret)
 	goto out;
-    if (f.canonicalize || r->client->entry.flags.force_canonicalize)
+    if (cflags & HDB_F_CANON)
 	ret = _krb5_principal2principalname(&rep.cname, r->client->entry.principal);
     else
 	ret = _krb5_principal2principalname(&rep.cname, r->client_princ);
@@ -1970,13 +1980,15 @@ _kdc_as_rep(kdc_request_t r,
 	goto out;
 
     rep.ticket.tkt_vno = 5;
-    if (f.canonicalize || r->server->entry.flags.force_canonicalize)
+    if (r->server->entry.flags.force_canonicalize)
+	sflags |= HDB_F_CANON;
+    if (sflags & HDB_F_CANON)
 	ret = copy_Realm(&r->server->entry.principal->realm, &rep.ticket.realm);
     else
 	ret = copy_Realm(&r->server_princ->realm, &rep.ticket.realm);
     if (ret)
 	goto out;
-    if (f.canonicalize || r->server->entry.flags.force_canonicalize)
+    if (sflags & HDB_F_CANON)
 	_krb5_principal2principalname(&rep.ticket.sname,
 				      r->server->entry.principal);
     else

--- a/lib/hdb/common.c
+++ b/lib/hdb/common.c
@@ -155,19 +155,6 @@ _hdb_fetch_kvno(krb5_context context, HDB *db, krb5_const_principal principal,
 	    krb5_data_free(&value);
 	    return ret;
 	}
-
-	if ((flags & HDB_F_GET_ANY) && (flags & HDB_F_CANON) == 0) {
-	    krb5_principal tmp;
-
-	    /* "hard" alias: return the principal the client asked for */
-	    ret = krb5_copy_principal(context, principal, &tmp);
-	    if (ret) {
-		krb5_data_free(&value);
-		return ret;
-	    }
-	    krb5_free_principal(context, entry->entry.principal);
-	    entry->entry.principal = tmp;
-	}
     }
     krb5_data_free(&value);
     if ((flags & HDB_F_DECRYPT) && (flags & HDB_F_ALL_KVNOS)) {

--- a/lib/hdb/common.c
+++ b/lib/hdb/common.c
@@ -119,7 +119,6 @@ _hdb_fetch_kvno(krb5_context context, HDB *db, krb5_const_principal principal,
 	if (ret)
 	    return ret;
 	principal = enterprise_principal;
-	flags |= HDB_F_CANON; /* enterprise implies canonicalization */
     }
 
     hdb_principal2key(context, principal, &key);


### PR DESCRIPTION
Mirroring the logic recently introduced in the TGS, this patch modifies the KDC to perform client and server canonicalization itself rather than relying on the backend to do so. Per RFC 6806, the behavior is slightly different for the AS in that the setting of the canonicalize flag in the AS-REQ _does_ impact the returned names in the ticket. In order to support realm canonicalization or other custom behavior, we allow the backend to force the KDC to canonicalize by setting the `force-canonicalize` flag in the returned client or server entries.

Rationale: name canonicalization behavior should be as consistent as possible between the AS and TGS; naming logic does not belong in the HDB. (I'd also like to move `KRB5_NT_ENTERPRISE_PRINCIPAL` handling from HDB to the KDC, but I've left that for now.)