### PR TITLE
ASN.1: Support wider bit sets (fix #514)

### DIFF
--- a/lib/asn1/asn1_gen.c
+++ b/lib/asn1/asn1_gen.c
@@ -141,7 +141,8 @@ doit(const char *fn)
     }
     printf("line: eof offset: %lu\n", (unsigned long)offset);
 
-    fclose(fout);
+    if (fclose(fout) == EOF)
+        err(1, "writes to file %s failed", fnout);
     fclose(f);
     return 0;
 }

--- a/lib/asn1/gen.c
+++ b/lib/asn1/gen.c
@@ -288,15 +288,16 @@ close_generate (void)
 {
     fprintf (headerfile, "#endif /* __%s_h__ */\n", headerbase);
 
-    if (headerfile)
-        fclose (headerfile);
-    if (privheaderfile)
-        fclose (privheaderfile);
-    if (templatefile)
-        fclose (templatefile);
+    if (headerfile && fclose(headerfile) == EOF)
+        err(1, "writes to public header file failed");
+    if (privheaderfile && fclose(privheaderfile) == EOF)
+        err(1, "writes to private header file failed");
+    if (templatefile && fclose(templatefile) == EOF)
+        err(1, "writes to template file failed");
     if (logfile) {
-        fprintf (logfile, "\n");
-        fclose (logfile);
+        fprintf(logfile, "\n");
+        if (fclose(logfile) == EOF)
+            err(1, "writes to log file failed");
     }
 }
 
@@ -399,7 +400,8 @@ close_codefile(void)
     if (codefile == NULL)
 	abort();
 
-    fclose(codefile);
+    if (fclose(codefile) == EOF)
+        err(1, "writes to source code file failed");
     codefile = NULL;
 }
 

--- a/lib/asn1/gen_decode.c
+++ b/lib/asn1/gen_decode.c
@@ -354,7 +354,7 @@ decode_type (const char *name, const Type *t, int optional,
 	    break;
 
 	fprintf(codefile, "{\n");
-	fprintf(codefile, "unsigned int members = 0;\n");
+	fprintf(codefile, "uint64_t members = 0;\n");
 	fprintf(codefile, "while(len > 0) {\n");
 	fprintf(codefile,
 		"Der_class class;\n"
@@ -384,7 +384,7 @@ decode_type (const char *name, const Type *t, int optional,
 	    decode_type (s, m->type, 0, forwstr, m->gen_name, NULL, depth + 1);
 	    free (s);
 
-	    fprintf(codefile, "members |= (1 << %d);\n", memno);
+	    fprintf(codefile, "members |= (1LU << %u);\n", memno);
 	    memno++;
 	    fprintf(codefile, "break;\n");
 	}
@@ -400,7 +400,7 @@ decode_type (const char *name, const Type *t, int optional,
 
 	    if (asprintf (&s, "%s->%s", name, m->gen_name) < 0 || s == NULL)
 		errx(1, "malloc");
-	    fprintf(codefile, "if((members & (1 << %d)) == 0)\n", memno);
+	    fprintf(codefile, "if((members & (1LU << %u)) == 0)\n", memno);
 	    if(m->optional)
 		fprintf(codefile, "%s = NULL;\n", s);
 	    else if(m->defval)

--- a/lib/asn1/test.asn1
+++ b/lib/asn1/test.asn1
@@ -188,6 +188,21 @@ TESTBitString ::= BIT STRING {
 	      thirtyone(31)
 }
 
+TESTBitString64 ::= BIT STRING {
+	      zero(0),
+	      eight(8),
+	      thirtyone(31),
+	      thirtytwo(32),
+	      sixtythree(63)
+}
+
+TESTLargeBitString ::= BIT STRING {
+	      zero(0),
+	      eight(8),
+	      thirtyone(31),
+	      onehundredtwenty(120)
+}
+
 TESTMechType::= OBJECT IDENTIFIER
 TESTMechTypeList ::= SEQUENCE OF TESTMechType
 

--- a/lib/roken/parse_units.h
+++ b/lib/roken/parse_units.h
@@ -51,7 +51,7 @@
 
 struct units {
     const char *name;
-    unsigned mult;
+    unsigned long long mult;
 };
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL


### PR DESCRIPTION
Wait for builds and tests before reviewing.  Also: need to add a test.

The ASN.1 compiler now uses `uint64_t` for `BIT STRING` bitsets with between 33 and 64 members.

For `BIT STRING` bitsets with more than 64 members, no `<type>2int()` nor `int2<type>()` functions are generated, and the application can then only encode/decode.