### PR TITLE
Fix broken return from _krb5_erase_file on missing file.

### DIFF
--- a/lib/krb5/fcache.c
+++ b/lib/krb5/fcache.c
@@ -254,8 +254,12 @@ _krb5_erase_file(krb5_context context, const char *filename)
     int ret;
 
     ret = lstat (filename, &sb1);
-    if (ret < 0)
-	return errno;
+    if (ret < 0) {
+	if(errno == ENOENT)
+	    return 0;
+	else
+	    return errno;
+    }
 
     fd = open(filename, O_RDWR | O_BINARY | O_CLOEXEC | O_NOFOLLOW);
     if(fd < 0) {


### PR DESCRIPTION
The return of lstat should be handled like the "open" if errno = ENOENT.