### PR TITLE
Make common plugin api public

### DIFF
--- a/lib/krb5/Makefile.am
+++ b/lib/krb5/Makefile.am
@@ -125,8 +125,10 @@ dist_libkrb5_la_SOURCES =			\
 	build_ap_req.c				\
 	build_auth.c				\
 	cache.c					\
+	ccache_plugin.h				\
 	changepw.c				\
 	codec.c					\
+	common_plugin.h				\
 	config_file.c				\
 	convert_creds.c				\
 	constants.c				\
@@ -387,7 +389,7 @@ nodist_include_HEADERS = krb5_err.h heim_err.h k524_err.h k5e1_err.h
 
 # XXX use nobase_include_HEADERS = krb5/locate_plugin.h
 krb5dir = $(includedir)/krb5
-krb5_HEADERS = locate_plugin.h send_to_kdc_plugin.h ccache_plugin.h an2ln_plugin.h db_plugin.h
+krb5_HEADERS = common_plugin.h locate_plugin.h send_to_kdc_plugin.h ccache_plugin.h an2ln_plugin.h db_plugin.h
 
 build_HEADERZ = \
 	$(krb5_HEADERS) \

--- a/lib/krb5/NTMakefile
+++ b/lib/krb5/NTMakefile
@@ -182,7 +182,14 @@ INCFILES=			\
 	$(INCDIR)\krb5-protos.h	\
 	$(INCDIR)\krb5-private.h	\
 	$(INCDIR)\krb5-v4compat.h	\
-	$(INCDIR)\crypto.h
+	$(INCDIR)\crypto.h \
+	$(INCDIR)\an2ln_plugin.h \
+	$(INCDIR)\ccache_plugin.h \
+	$(INCDIR)\common_plugin.h \
+	$(INCDIR)\db_plugin.h \
+	$(INCDIR)\kuserok_plugin.h \
+	$(INCDIR)\locate_plugin.h \
+	$(INCDIR)\send_to_kdc_plugin.h
 
 all:: $(INCFILES)
 

--- a/lib/krb5/ccache_plugin.h
+++ b/lib/krb5/ccache_plugin.h
@@ -33,7 +33,14 @@
 #define HEIMDAL_KRB5_CCACHE_PLUGIN_H 1
 
 #include <krb5.h>
+#include <common_plugin.h>
 
 #define KRB5_PLUGIN_CCACHE "ccache_ops"
+
+krb5_error_code KRB5_CALLCONV
+ccache_ops_plugin_load(krb5_context context,
+		       krb5_get_instance_func_t *func,
+		       size_t *n_ftables,
+		       const krb5_plugin_common_ftable *const **ftables);
 
 #endif /* HEIMDAL_KRB5_CCACHE_PLUGIN_H */

--- a/lib/krb5/ccache_plugin.h
+++ b/lib/krb5/ccache_plugin.h
@@ -41,6 +41,6 @@ krb5_error_code KRB5_CALLCONV
 ccache_ops_plugin_load(krb5_context context,
 		       krb5_get_instance_func_t *func,
 		       size_t *n_ftables,
-		       const krb5_plugin_common_ftable *const **ftables);
+		       krb5_plugin_common_ftable_p **ftables);
 
 #endif /* HEIMDAL_KRB5_CCACHE_PLUGIN_H */

--- a/lib/krb5/common_plugin.h
+++ b/lib/krb5/common_plugin.h
@@ -39,11 +39,14 @@
 /*
  * All plugin function tables extend the following structure.
  */
-typedef struct krb5_plugin_common_ftable_desc {
+struct krb5_plugin_common_ftable_desc {
     int			version;
     krb5_error_code	(KRB5_LIB_CALL *init)(krb5_context, void **);
     void		(KRB5_LIB_CALL *fini)(void *);
-} krb5_plugin_common_ftable;
+};
+typedef struct krb5_plugin_common_ftable_desc krb5_plugin_common_ftable;
+typedef struct krb5_plugin_common_ftable_desc *krb5_plugin_common_ftable_p;
+typedef struct krb5_plugin_common_ftable_desc * const krb5_plugin_common_ftable_cp;
 
 /*
  * All plugins must export a function named "<type>_plugin_load" with

--- a/lib/krb5/common_plugin.h
+++ b/lib/krb5/common_plugin.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2006 - 2007 Kungliga Tekniska Högskolan
+ * (Royal Institute of Technology, Stockholm, Sweden).
+ * All rights reserved.
+ *
+ * Portions Copyright (c) 2018 AuriStor, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef HEIMDAL_KRB5_COMMON_PLUGIN_H
+#define HEIMDAL_KRB5_COMMON_PLUGIN_H
+
+/*
+ * All plugin function tables extend the following structure.
+ */
+typedef struct krb5_plugin_common_ftable_desc {
+    int			version;
+    krb5_error_code	(KRB5_LIB_CALL *init)(krb5_context, void **);
+    void		(KRB5_LIB_CALL *fini)(void *);
+} krb5_plugin_common_ftable;
+
+/*
+ * All plugins must export a function named "<type>_plugin_load" with
+ * a signature of:
+ *
+ * krb5_error_code KRB5_CALLCONV
+ * <type>_plugin_load(krb5_context context,
+ *	              krb5_get_instance_func_t *func,
+ *		      size_t *n_ftables,
+ *		      const krb5_plugin_common_ftable *const **ftables);
+ */
+#endif /* HEIMDAL_KRB5_COMMON_PLUGIN_H */

--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -56,8 +56,10 @@
 
 #ifdef _WIN32
 #define KRB5_CALLCONV __stdcall
+#define KRB5_LIB_CALL __stdcall
 #else
 #define KRB5_CALLCONV
+#define KRB5_LIB_CALL
 #endif
 
 /* simple constants */

--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -883,7 +883,7 @@ enum krb5_plugin_type {
 #define KRB5_PLUGIN_INVOKE_ALL  1
 
 typedef uintptr_t
-(KRB5_CALLCONV *krb5_get_instance_func_t)(const char *);
+(KRB5_LIB_CALL *krb5_get_instance_func_t)(const char *);
 
 struct credentials; /* this is to keep the compiler happy */
 struct getargs;

--- a/lib/krb5/plugin.c
+++ b/lib/krb5/plugin.c
@@ -154,8 +154,8 @@ copy_internal_dso(const char *name)
  */
 typedef struct common_plugin_ftable_desc {
     int			version;
-    krb5_error_code	(*init)(krb5_context, void **);
-    void		(*fini)(void *);
+    krb5_error_code	(KRB5_LIB_CALL *init)(krb5_context, void **);
+    void		(KRB5_LIB_CALL *fini)(void *);
 } common_plugin_ftable;
 
 struct krb5_plugin {

--- a/lib/krb5/plugin.c
+++ b/lib/krb5/plugin.c
@@ -34,6 +34,7 @@
  */
 
 #include "krb5_locl.h"
+#include "common_plugin.h"
 
 /*
  * Definitions:
@@ -149,17 +150,8 @@ copy_internal_dso(const char *name)
     return dso;
 }
 
-/*
- * All plugin function tables extend the following structure.
- */
-typedef struct common_plugin_ftable_desc {
-    int			version;
-    krb5_error_code	(KRB5_LIB_CALL *init)(krb5_context, void **);
-    void		(KRB5_LIB_CALL *fini)(void *);
-} common_plugin_ftable;
-
 struct krb5_plugin {
-    common_plugin_ftable *ftable;
+    krb5_plugin_common_ftable *ftable;
     void *ctx;
 };
 
@@ -490,7 +482,7 @@ add_dso_plugin_struct(krb5_context context,
 		      const char *name)
 {
     krb5_error_code ret;
-    common_plugin_ftable *cpm;
+    krb5_plugin_common_ftable *cpm;
     struct krb5_plugin *pl;
     heim_array_t plugins;
 
@@ -526,7 +518,7 @@ typedef krb5_error_code
 (KRB5_CALLCONV *krb5_plugin_load_t)(krb5_context context,
 				    krb5_get_instance_func_t *func,
 				    size_t *n_ftables,
-				    const common_plugin_ftable *const **ftables);
+				    const krb5_plugin_common_ftable *const **ftables);
 
 static krb5_boolean
 validate_plugin_deps(krb5_context context,
@@ -583,7 +575,7 @@ add_dso_plugins_load_fn(krb5_context context,
     size_t i;
     krb5_get_instance_func_t get_instance;
     size_t n_ftables;
-    const common_plugin_ftable *const *ftables;
+    const krb5_plugin_common_ftable *const *ftables;
 
     if (asprintf(&sym, "%s_plugin_load", caller->name) == -1)
 	return NULL;
@@ -609,7 +601,7 @@ add_dso_plugins_load_fn(krb5_context context,
     plugins = heim_array_create();
 
     for (i = 0; i < n_ftables; i++) {
-	const common_plugin_ftable *const cpm = ftables[i];
+	const krb5_plugin_common_ftable *const cpm = ftables[i];
 	struct krb5_plugin *pl;
 
 	pl = heim_alloc(sizeof(*pl), "krb5-plugin", plugin_free);

--- a/lib/krb5/plugin.c
+++ b/lib/krb5/plugin.c
@@ -597,7 +597,10 @@ add_dso_plugins_load_fn(krb5_context context,
     ret = load_fn(context, &get_instance, &n_ftables, &ftables);
     if (ret) {
 	krb5_warn(context, ret, "plugin %s failed to load", dsopath);
-	return NULL;
+
+	/* fallback to loading structure directly */
+	return add_dso_plugin_struct(context, dsopath,
+				     dsohandle, caller->name);
     }
 
     if (!validate_plugin_deps(context, caller, dsopath, get_instance))
@@ -651,11 +654,6 @@ search_modules(heim_object_t key, heim_object_t value, void *ctx)
 					  s->caller,
 					  path,
 					  p->dsohandle);
-	if (plugins == NULL) {
-	    /* fallback to loading structure directly */
-	    plugins = add_dso_plugin_struct(s->context, path,
-					    p->dsohandle, s->caller->name);
-	}
 	if (plugins) {
 	    heim_dict_set_value(p->plugins_by_name, s->n, plugins);
 	    _krb5_debug(s->context, 5, "Loaded %zu %s %s plugin%s from %s",


### PR DESCRIPTION
This series fixes build issues on Windows related to the new common plugin api and makes the common plugin interface public for consumption by third party plugins.
