### PR TITLE
For https://github.com/heimdal/heimdal/issues/392

### DIFF
--- a/lib/hx509/data/gen-req.sh
+++ b/lib/hx509/data/gen-req.sh
@@ -16,7 +16,7 @@ fi
 
 gen_cert()
 {
-	keytype=${6:-rsa:1024}
+	keytype=${6:-rsa:4096}
 	${openssl} req \
 		-new \
 		-subj "$1" \
@@ -30,7 +30,7 @@ gen_cert()
         if [ "$3" = "ca" ] ; then
 	    ${openssl} x509 \
 		-req \
-		-days 3650 \
+		-days 182500 \
 		-in cert.req \
 		-extfile ${config} \
 		-extensions $4 \
@@ -46,7 +46,7 @@ gen_cert()
 	    ${openssl} x509 \
 		-req \
 		-in cert.req \
-		-days 3650 \
+		-days 182500 \
 		-out cert.crt \
 		-CA $2.crt \
 		-CAkey $2.key \
@@ -59,7 +59,7 @@ gen_cert()
 
 	    ${openssl} ca \
 		-name $4 \
-		-days 3650 \
+		-days 182500 \
 		-cert $2.crt \
 		-keyfile $2.key \
 		-in cert.req \

--- a/lib/hx509/data/mkcert.sh
+++ b/lib/hx509/data/mkcert.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-# For now, avoid going past the 2038 32-bit clock rollover
-DAYS=$(( ( 0x7fffffff - $(date +%s) ) / 86400 - 1 ))
+DAYS=182500
 
 key() {
     local key=$1; shift


### PR DESCRIPTION
Modern OpenSSL no longer has the 2038 year restriction.  Update the
certs to last 500 years rather than 10 years.

Modern crypto requirements suggest a stronger key strength than 1024.
Update to use a minimum of 4096.

Fix executable bit on gen-req.sh