### PR TITLE
Windows:   Windows CRT doesn't support %k as format for strftime

### DIFF
--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -868,7 +868,7 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 #define HAVE_STRERROR 1
 
 /* Define if you have the function `strftime'. */
-#define HAVE_STRFTIME 1
+/* #define HAVE_STRFTIME 1 */
 
 /* Define to 1 if you have the <strings.h> header file. */
 /* #define HAVE_STRINGS_H 1 */

--- a/lib/roken/NTMakefile
+++ b/lib/roken/NTMakefile
@@ -99,6 +99,7 @@ libroken_la_OBJS =			\
 	$(OBJ)\sockstartup_w32.obj	\
 	$(OBJ)\strcollect.obj		\
 	$(OBJ)\strerror_r.obj		\
+	$(OBJ)\strftime.obj		\
 	$(OBJ)\strlcat.obj		\
 	$(OBJ)\strlcpy.obj		\
 	$(OBJ)\strndup.obj		\


### PR DESCRIPTION
The fix involves:
  - Removing HAVE_STRFTIME from config.h.w32
  - Adding strftime.c to the makefile
  - Defining timezone and tzname to their windows equivalent
    for the compile of this module