### PR TITLE
Windows: Make getaddrinfo-test work

### DIFF
--- a/lib/roken/NTMakefile
+++ b/lib/roken/NTMakefile
@@ -280,7 +280,7 @@ test-run:
 	-test-mini_inetd.exe
 	-dirent-test.exe
 	-base64-test.exe
-	-getaddrinfo-test.exe
+	-getaddrinfo-test.exe www.h5l.org http
 	-getifaddrs-test.exe
 	-hex-test.exe
 	-test-readenv.exe

--- a/lib/roken/getaddrinfo-test.c
+++ b/lib/roken/getaddrinfo-test.c
@@ -129,6 +129,8 @@ main(int argc, char **argv)
 	return 0;
     }
 
+    rk_SOCK_INIT();
+
     argc -= optidx;
     argv += optidx;
 
@@ -143,5 +145,6 @@ main(int argc, char **argv)
 
 	doit (nodename, argv[i+1]);
     }
+    rk_SOCK_EXIT();
     return 0;
 }


### PR DESCRIPTION
Before we call gettaddrinfo we have to call rx_SOCK_INIT

In order to exercise the test we have to supply parameters to the command line