### PR TITLE
make krb5_principal_is_anonymous public

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1613,7 +1613,7 @@ generate_pac(kdc_request_t r, Key *skey)
 krb5_boolean
 _kdc_is_anonymous(krb5_context context, krb5_const_principal principal)
 {
-    return _krb5_principal_is_anonymous(context, principal, KRB5_ANON_MATCH_ANY);
+    return krb5_principal_is_anonymous(context, principal, KRB5_ANON_MATCH_ANY);
 }
 
 static int

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -631,7 +631,7 @@ get_new_tickets(krb5_context context,
 	    goto out;
 	}
     } else if (pk_user_id || ent_user_id ||
-	       _krb5_principal_is_anonymous(context, principal, KRB5_ANON_MATCH_ANY)) {
+	       krb5_principal_is_anonymous(context, principal, KRB5_ANON_MATCH_ANY)) {
 
     } else if (!interactive && passwd[0] == '\0') {
 	static int already_warned = 0;

--- a/kuser/kuser_locl.h
+++ b/kuser/kuser_locl.h
@@ -72,7 +72,6 @@
 #include <parse_time.h>
 #include <err.h>
 #include <krb5.h>
-#include "krb5_locl.h"
 
 #if defined(HAVE_SYS_IOCTL_H) && SunOS != 40
 #include <sys/ioctl.h>

--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -954,6 +954,14 @@ typedef struct krb5_name_canon_iterator_data *krb5_name_canon_iterator;
 #define KRB5_GIC_OPT_PKINIT_NO_KDC_ANCHOR   16 /* do not authenticate KDC */
 
 /*
+ * _krb5_principal_is_anonymous() flags 
+ */
+#define KRB5_ANON_MATCH_AUTHENTICATED	1 /* authenticated with anon flag */
+#define KRB5_ANON_MATCH_UNAUTHENTICATED	2 /* anonymous PKINIT */
+#define KRB5_ANON_MATCH_ANY		( KRB5_ANON_MATCH_AUTHENTICATED | KRB5_ANON_MATCH_UNAUTHENTICATED )
+
+
+/*
  *
  */
 

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -498,6 +498,7 @@ EXPORTS
 	krb5_principal_get_num_comp
 	krb5_principal_get_realm
 	krb5_principal_get_type
+	krb5_principal_is_anonymous
 	krb5_principal_is_krbtgt
 	krb5_principal_match
 	krb5_principal_set_comp_string
@@ -776,7 +777,6 @@ EXPORTS
 	_krb5_pk_octetstring2key
 	_krb5_plugin_run_f
 	_krb5_enctype_requires_random_salt
-	_krb5_principal_is_anonymous
 	_krb5_principal2principalname
 	_krb5_principalname2krb5_principal
 	_krb5_put_int

--- a/lib/krb5/principal.c
+++ b/lib/krb5/principal.c
@@ -1253,8 +1253,8 @@ krb5_principal_is_root_krbtgt(krb5_context context, krb5_const_principal p)
  * @ingroup krb5_principal
  */
 
-krb5_boolean KRB5_LIB_FUNCTION
-_krb5_principal_is_anonymous(krb5_context context,
+KRB5_LIB_FUNCTION krb5_boolean KRB5_LIB_CALL
+krb5_principal_is_anonymous(krb5_context context,
 			     krb5_const_principal p,
 			     unsigned int flags)
 {

--- a/lib/krb5/ticket.c
+++ b/lib/krb5/ticket.c
@@ -539,7 +539,7 @@ check_client_mismatch(krb5_context context,
 		      krb5_keyblock const * key)
 {
     if (rep->enc_part.flags.anonymous) {
-	if (!_krb5_principal_is_anonymous(context, mapped, KRB5_ANON_MATCH_ANY)) {
+	if (!krb5_principal_is_anonymous(context, mapped, KRB5_ANON_MATCH_ANY)) {
 	    krb5_set_error_message(context, KRB5KRB_AP_ERR_MODIFIED,
 				   N_("Anonymous ticket does not contain anonymous "
 				      "principal", ""));

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -495,6 +495,7 @@ HEIMDAL_KRB5_2.0 {
 		krb5_principal_set_comp_string;
 		krb5_principal_set_realm;
 		krb5_principal_set_type;
+		krb5_principal_is_anonymous;
 		krb5_principal_is_krbtgt;
 		krb5_print_address;
 		krb5_program_setup;
@@ -767,7 +768,6 @@ HEIMDAL_KRB5_2.0 {
 		_krb5_pk_mk_ContentInfo;
 		_krb5_pk_octetstring2key;
 		_krb5_plugin_run_f;
-		_krb5_principal_is_anonymous;
 		_krb5_principal2principalname;
 		_krb5_principalname2krb5_principal;
 		_krb5_put_int;


### PR DESCRIPTION
_krb5_principal_is_anonymous() is used outside lib/krb5 and
therefore it needs to be properly exported and its flag macros
need to be in a public header: krb5.h not krb5_locl.h.

Including krb5_locl.h from within kuser_locl.h for instance
results in build failures on Solaris.

This change renames the function and makes it part of the public
api.

Change-Id: I130d1698b10bdbd150b95e8c7d32dfc362889ce6