### PR TITLE
Fix to 7.6.0 release for Solaris and Windows

### DIFF
--- a/lib/hcrypto/evp-pkcs11.c
+++ b/lib/hcrypto/evp-pkcs11.c
@@ -100,6 +100,8 @@ p11_module_load(CK_FUNCTION_LIST_PTR_PTR ppFunctionList)
 {
     CK_RV rv;
     CK_RV (*C_GetFunctionList_fn)(CK_FUNCTION_LIST_PTR_PTR);
+	
+	*ppFunctionList = NULL;
 
     if (!issuid()) {
         char *pkcs11ModulePath = getenv("PKCS11_MODULE_PATH");

--- a/lib/krb5/send_to_kdc.c
+++ b/lib/krb5/send_to_kdc.c
@@ -979,7 +979,7 @@ wait_setup(heim_object_t obj, void *iter_ctx, int *stop)
 	debug_host(wait_ctx->context, 5, h, "invalid sendto host state");
 	heim_abort("invalid sendto host state");
     }
-    if (h->fd > wait_ctx->max_fd)
+    if (h->fd > wait_ctx->max_fd || wait_ctx->max_fd == rk_INVALID_SOCKET)
 	wait_ctx->max_fd = h->fd;
 }
 


### PR DESCRIPTION
The cherry pick of 934d5e09bf3ba0774d303da53446e5ff94daae01 dropped
the initialization of p11_module_load() *ppFunctionList to NULL.

Change-Id: I0b07315c040340c7ca95ff87fd985c6c7e865aeb