### PR TITLE
Fix sendto_kdc on Windows

### DIFF
--- a/lib/krb5/send_to_kdc.c
+++ b/lib/krb5/send_to_kdc.c
@@ -994,7 +994,7 @@ wait_setup(heim_object_t obj, void *iter_ctx, int *stop)
 	debug_host(wait_ctx->context, 5, h, "invalid sendto host state");
 	heim_abort("invalid sendto host state");
     }
-    if (h->fd > wait_ctx->max_fd)
+    if (h->fd > wait_ctx->max_fd || wait_ctx->max_fd == rk_INVALID_SOCKET)
 	wait_ctx->max_fd = h->fd;
 }
 


### PR DESCRIPTION
The combination of 8740528b2477f872147998ca19a66d2fae12631b
("Windows-compatible sentinel socket type and value") and
d497d7e4a796c6bda153e7f10fe9478724b855ab ("krb5_sendto_kdc:
failover for multiple AAAA/A RRs on one domain") broke
all the send to kdc loop on Windows.  rk_socket_t is
a HANDLE and rk_INVALID_SOCKET is the max value.  Therefore,
no valid socket will be larger and all communications
will fail.

Change-Id: I3464f78d67b19f14050ad7a01738fb32bac99385