### PR TITLE
hcrypto: avoid hcrypto_validate race

### DIFF
--- a/lib/hcrypto/validate.c
+++ b/lib/hcrypto/validate.c
@@ -297,10 +297,10 @@ hcrypto_validate(void)
     /* its ok to run this twice, do don't check for races */
     if (validated)
 	return;
-    validated++;
 
     for (i = 0; i < sizeof(hc_tests) / sizeof(hc_tests[0]); i++)
 	test_cipher(&hc_tests[i]);
 
     check_hmac();
+    validated++;
 }


### PR DESCRIPTION
Do not increment 'validated' until after all of the validation
steps have been performed.  While its ok the validate more than
once we need to ensure that validation occurs at least once
before the cipher is used.

Change-Id: I6896c132ec2a7423c5166c1c074a2dedac54e00d