### PR TITLE
krb5: check KDC supports anonymous if requested

### DIFF
--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -560,6 +560,8 @@ get_cred_kdc(krb5_context context,
 	/* XXX should do better testing */
 	if (flags.b.constrained_delegation || impersonate_principal)
 	    eflags |= EXTRACT_TICKET_ALLOW_CNAME_MISMATCH;
+	if (flags.b.request_anonymous)
+	    eflags |= EXTRACT_TICKET_MATCH_ANON;
 
 	ret = _krb5_extract_ticket(context,
 				   &rep,

--- a/lib/krb5/get_in_tkt.c
+++ b/lib/krb5/get_in_tkt.c
@@ -489,7 +489,7 @@ krb5_get_in_cred(krb5_context context,
     {
 	unsigned flags = EXTRACT_TICKET_TIMESYNC;
 	if (opts.request_anonymous)
-	    flags |= EXTRACT_TICKET_ALLOW_SERVER_MISMATCH;
+	    flags |= EXTRACT_TICKET_ALLOW_SERVER_MISMATCH | EXTRACT_TICKET_MATCH_ANON;
 
 	ret = _krb5_extract_ticket(context,
 				   &rep,

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -2257,6 +2257,8 @@ krb5_init_creds_step(krb5_context context,
 	    }
 	    if (ctx->ic_flags & KRB5_INIT_CREDS_NO_C_CANON_CHECK)
 		eflags |= EXTRACT_TICKET_ALLOW_CNAME_MISMATCH;
+	    if (ctx->flags.request_anonymous)
+		eflags |= EXTRACT_TICKET_MATCH_ANON;
 
 	    ret = process_pa_data_to_key(context, ctx, &ctx->cred,
 					 &ctx->as_req, &rep.kdc_rep,

--- a/lib/krb5/krb5_locl.h
+++ b/lib/krb5/krb5_locl.h
@@ -310,6 +310,7 @@ typedef struct krb5_context_data {
 #define EXTRACT_TICKET_MATCH_REALM			4
 #define EXTRACT_TICKET_AS_REQ				8
 #define EXTRACT_TICKET_TIMESYNC				16
+#define EXTRACT_TICKET_MATCH_ANON			32
 
 /*
  * Configurable options


### PR DESCRIPTION
Verify the KDC recognized the request-anonymous flag by validating the returned client principal name.