### PR TITLE
krb5: check KDC supports anonymous if requested

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1551,7 +1551,7 @@ generate_pac(kdc_request_t r, Key *skey)
 krb5_boolean
 _kdc_is_anonymous(krb5_context context, krb5_const_principal principal)
 {
-    return _krb5_principal_is_anonymous(context, principal, KRB5_ANON_MATCH_ANY);
+    return krb5_principal_is_anonymous(context, principal, KRB5_ANON_MATCH_ANY);
 }
 
 static int

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -630,7 +630,7 @@ get_new_tickets(krb5_context context,
 	    goto out;
 	}
     } else if (pk_user_id || ent_user_id ||
-	       _krb5_principal_is_anonymous(context, principal, KRB5_ANON_MATCH_ANY)) {
+	       krb5_principal_is_anonymous(context, principal, KRB5_ANON_MATCH_ANY)) {
 
     } else if (!interactive && passwd[0] == '\0') {
 	static int already_warned = 0;

--- a/kuser/kuser_locl.h
+++ b/kuser/kuser_locl.h
@@ -72,7 +72,6 @@
 #include <parse_time.h>
 #include <err.h>
 #include <krb5.h>
-#include "krb5_locl.h"
 
 #if defined(HAVE_SYS_IOCTL_H) && SunOS != 40
 #include <sys/ioctl.h>

--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -560,6 +560,8 @@ get_cred_kdc(krb5_context context,
 	/* XXX should do better testing */
 	if (flags.b.constrained_delegation || impersonate_principal)
 	    eflags |= EXTRACT_TICKET_ALLOW_CNAME_MISMATCH;
+	if (flags.b.request_anonymous)
+	    eflags |= EXTRACT_TICKET_MATCH_ANON;
 
 	ret = _krb5_extract_ticket(context,
 				   &rep,

--- a/lib/krb5/get_in_tkt.c
+++ b/lib/krb5/get_in_tkt.c
@@ -492,7 +492,7 @@ krb5_get_in_cred(krb5_context context,
     {
 	unsigned flags = EXTRACT_TICKET_TIMESYNC;
 	if (opts.request_anonymous)
-	    flags |= EXTRACT_TICKET_ALLOW_SERVER_MISMATCH;
+	    flags |= EXTRACT_TICKET_ALLOW_SERVER_MISMATCH | EXTRACT_TICKET_MATCH_ANON;
 
 	ret = _krb5_extract_ticket(context,
 				   &rep,

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -2244,6 +2244,8 @@ krb5_init_creds_step(krb5_context context,
 	    }
 	    if (ctx->ic_flags & KRB5_INIT_CREDS_NO_C_CANON_CHECK)
 		eflags |= EXTRACT_TICKET_ALLOW_CNAME_MISMATCH;
+	    if (ctx->flags.request_anonymous)
+		eflags |= EXTRACT_TICKET_MATCH_ANON;
 
 	    ret = process_pa_data_to_key(context, ctx, &ctx->cred,
 					 &ctx->as_req, &rep.kdc_rep,

--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -951,6 +951,14 @@ typedef struct krb5_name_canon_iterator_data *krb5_name_canon_iterator;
 #define KRB5_GIC_OPT_PKINIT_NO_KDC_ANCHOR   16 /* do not authenticate KDC */
 
 /*
+ * _krb5_principal_is_anonymous() flags 
+ */
+#define KRB5_ANON_MATCH_AUTHENTICATED	1 /* authenticated with anon flag */
+#define KRB5_ANON_MATCH_UNAUTHENTICATED	2 /* anonymous PKINIT */
+#define KRB5_ANON_MATCH_ANY		( KRB5_ANON_MATCH_AUTHENTICATED | KRB5_ANON_MATCH_UNAUTHENTICATED )
+
+
+/*
  *
  */
 

--- a/lib/krb5/krb5_locl.h
+++ b/lib/krb5/krb5_locl.h
@@ -293,6 +293,7 @@ typedef struct krb5_context_data {
 #define EXTRACT_TICKET_MATCH_REALM			4
 #define EXTRACT_TICKET_AS_REQ				8
 #define EXTRACT_TICKET_TIMESYNC				16
+#define EXTRACT_TICKET_MATCH_ANON			32
 
 /*
  * Configurable options

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -497,6 +497,7 @@ EXPORTS
 	krb5_principal_get_num_comp
 	krb5_principal_get_realm
 	krb5_principal_get_type
+	krb5_principal_is_anonymous
 	krb5_principal_is_krbtgt
 	krb5_principal_match
 	krb5_principal_set_comp_string
@@ -762,7 +763,6 @@ EXPORTS
 	_krb5_pk_octetstring2key
 	_krb5_plugin_run_f
 	_krb5_enctype_requires_random_salt
-	_krb5_principal_is_anonymous
 	_krb5_principal2principalname
 	_krb5_principalname2krb5_principal
 	_krb5_put_int

--- a/lib/krb5/principal.c
+++ b/lib/krb5/principal.c
@@ -1253,8 +1253,8 @@ krb5_principal_is_root_krbtgt(krb5_context context, krb5_const_principal p)
  * @ingroup krb5_principal
  */
 
-krb5_boolean KRB5_LIB_FUNCTION
-_krb5_principal_is_anonymous(krb5_context context,
+KRB5_LIB_FUNCTION krb5_boolean KRB5_LIB_CALL
+krb5_principal_is_anonymous(krb5_context context,
 			     krb5_const_principal p,
 			     unsigned int flags)
 {

--- a/lib/krb5/ticket.c
+++ b/lib/krb5/ticket.c
@@ -539,7 +539,7 @@ check_client_mismatch(krb5_context context,
 		      krb5_keyblock const * key)
 {
     if (rep->enc_part.flags.anonymous) {
-	if (!_krb5_principal_is_anonymous(context, mapped, KRB5_ANON_MATCH_ANY)) {
+	if (!krb5_principal_is_anonymous(context, mapped, KRB5_ANON_MATCH_ANY)) {
 	    krb5_set_error_message(context, KRB5KRB_AP_ERR_MODIFIED,
 				   N_("Anonymous ticket does not contain anonymous "
 				      "principal", ""));

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -494,6 +494,7 @@ HEIMDAL_KRB5_2.0 {
 		krb5_principal_set_comp_string;
 		krb5_principal_set_realm;
 		krb5_principal_set_type;
+		krb5_principal_is_anonymous;
 		krb5_principal_is_krbtgt;
 		krb5_print_address;
 		krb5_program_setup;
@@ -757,7 +758,6 @@ HEIMDAL_KRB5_2.0 {
 		_krb5_plugin_find;
 		_krb5_plugin_free;
 		_krb5_plugin_run_f;
-		_krb5_principal_is_anonymous;
 		_krb5_principal2principalname;
 		_krb5_principalname2krb5_principal;
 		_krb5_put_int;


### PR DESCRIPTION
Verify the KDC recognized the request-anonymous flag by validating the returned
client principal name.

(cherry picked from commit 014e318d6bdefd8ecfcb99ca9928921f6a49d721)