### PR TITLE
kuser: allow kinit to renew anonymous PKINIT tickets

### DIFF
--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -737,9 +737,10 @@ fi
 if test "$pkinit" = yes -a "$rsa" = yes ; then
 
     echo "try anonymous pkinit"; > messages.log
-    ${kinit} -n @${R} || \
+    ${kinit} --renewable -n @${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
     ${kgetcred} ${server}@${R} || { ec=1 ; eval "${testfailed}"; }
+    ${kinit} --renew || { ec=1 ; eval "${testfailed}"; }
     ${kdestroy}
 
     for type in "" "--pk-use-enckey"; do


### PR DESCRIPTION
Anonymous PKINIT tickets discard the realm information used to locate the
issuing AS. Store the issuing realm in the credentials cache in order to locate
a KDC which can renew them.

(cherry picked from commit d89b5cb966c41015fad524027107dd2d241b44e8)