### PR TITLE
hx509: replace time_t with int64_t for cert timestamps

### DIFF
--- a/lib/hx509/ca.c
+++ b/lib/hx509/ca.c
@@ -55,8 +55,8 @@ struct hx509_ca_tbs {
 	unsigned int domaincontroller:1;
 	unsigned int xUniqueID:1;
     } flags;
-    time_t notBefore;
-    time_t notAfter;
+    int64_t notBefore;
+    int64_t notAfter;
     int pathLenConstraint; /* both for CA and Proxy */
     CRLDistributionPoints crldp;
     heim_bit_string subjectUniqueID;
@@ -135,7 +135,7 @@ hx509_ca_tbs_free(hx509_ca_tbs *tbs)
 HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_notBefore(hx509_context context,
 			   hx509_ca_tbs tbs,
-			   time_t t)
+			   int64_t t)
 {
     tbs->notBefore = t;
     return 0;
@@ -156,7 +156,7 @@ hx509_ca_tbs_set_notBefore(hx509_context context,
 HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_notAfter(hx509_context context,
 			   hx509_ca_tbs tbs,
-			   time_t t)
+			   int64_t t)
 {
     tbs->notAfter = t;
     return 0;
@@ -177,7 +177,7 @@ hx509_ca_tbs_set_notAfter(hx509_context context,
 HX509_LIB_FUNCTION int HX509_LIB_CALL
 hx509_ca_tbs_set_notAfter_lifetime(hx509_context context,
 				   hx509_ca_tbs tbs,
-				   time_t delta)
+				   int64_t delta)
 {
     return hx509_ca_tbs_set_notAfter(context, tbs, time(NULL) + delta);
 }
@@ -991,7 +991,7 @@ static int
 build_proxy_prefix(hx509_context context, const Name *issuer, Name *subject)
 {
     char *tstr;
-    time_t t;
+    int64_t t;
     int ret;
 
     ret = copy_Name(issuer, subject);
@@ -1031,8 +1031,8 @@ ca_sign(hx509_context context,
     size_t size;
     int ret;
     const AlgorithmIdentifier *sigalg;
-    time_t notBefore;
-    time_t notAfter;
+    int64_t notBefore;
+    int64_t notAfter;
     unsigned key_usage;
 
     sigalg = tbs->sigalg;

--- a/lib/hx509/cms.c
+++ b/lib/hx509/cms.c
@@ -263,7 +263,7 @@ static int
 find_CMSIdentifier(hx509_context context,
 		   CMSIdentifier *client,
 		   hx509_certs certs,
-		   time_t time_now,
+		   int64_t time_now,
 		   hx509_cert *signer_cert,
 		   int match)
 {
@@ -356,7 +356,7 @@ hx509_cms_unenvelope(hx509_context context,
 		     const void *data,
 		     size_t length,
 		     const heim_octet_string *encryptedContent,
-		     time_t time_now,
+		     int64_t time_now,
 		     heim_oid *contentType,
 		     heim_octet_string *content)
 {

--- a/lib/hx509/hx_locl.h
+++ b/lib/hx509/hx_locl.h
@@ -158,7 +158,7 @@ struct hx509_query_data {
     int (*cmp_func)(hx509_context, hx509_cert, void *);
     void *cmp_func_ctx;
     heim_octet_string *keyhash_sha1;
-    time_t timenow;
+    int64_t timenow;
     heim_oid *eku;
     struct hx_expr *expr;
 };
@@ -292,7 +292,7 @@ struct signature_alg {
 
 #define RA_RSA_USES_DIGEST_INFO 0x1000000
 
-    time_t best_before; /* refuse signature made after best before date */
+    int64_t best_before; /* refuse signature made after best before date */
     const EVP_MD *(*evp_md)(void);
     int (*verify_signature)(hx509_context context,
 			    const struct signature_alg *,

--- a/lib/hx509/hxtool.c
+++ b/lib/hx509/hxtool.c
@@ -889,7 +889,7 @@ pcert_verify(struct verify_options *opt, int argc, char **argv)
     if (opt->time_string) {
 	const char *p;
 	struct tm tm;
-	time_t t;
+	int64_t t;
 
 	memset(&tm, 0, sizeof(tm));
 
@@ -1182,7 +1182,7 @@ static int HX509_LIB_CALL
 verify_o(hx509_context hxcontext, void *ctx, hx509_cert c)
 {
     heim_octet_string *os = ctx;
-    time_t expiration;
+    int64_t expiration;
     int ret;
 
     ret = hx509_ocsp_verify(context, 0, c, 0,

--- a/lib/hx509/print.c
+++ b/lib/hx509/print.c
@@ -64,12 +64,12 @@ struct cert_status {
 static int
 Time2string(const Time *T, char **str)
 {
-    time_t t;
+    int64_t t;
     char *s;
     struct tm *tm;
 
     *str = NULL;
-    t = _hx509_Time2time_t(T);
+    t = _hx509_Time2int64_t(T);
     tm = gmtime (&t);
     s = malloc(30);
     if (s == NULL)


### PR DESCRIPTION
On platforms with 32-bit time_t (e.g. Linux i386), certificates
with timestamps later than 03:14:07 UTC on 19 January 2038 fail
to be processed correctly.

Recent changes to include certificates in the test suite with
500 year lifetimes cause the test suite to fail on these platforms.

This change replaces all use of time_t with int64_t to permit
uniform processing of certificate timestamps on all platforms.

Change-Id: I8ada6392478f39862c62d5b6490682b026e49261