### PR TITLE
Fixes heimdal#535 - verify-password-quality

### DIFF
--- a/kadmin/kadmin.1
+++ b/kadmin/kadmin.1
@@ -321,7 +321,7 @@ The
 behavior is the default if none of these are given.
 .Ed
 .Pp
-.Nm password-quality
+.Nm verify-password-quality
 .Ar principal
 .Ar password
 .Bd -ragged -offset indent


### PR DESCRIPTION
At one point in time, the configuration option was named
"password-quality" but this was later changed to
"verify-password-quality".  Update the kadmin(1) man page to reflect
this change.