### PR TITLE
Fixes #550 - Note that encrypt is the default option

### DIFF
--- a/kdc/hprop.8
+++ b/kdc/hprop.8
@@ -115,7 +115,8 @@ The encryption keys in the database can either be in clear, or
 encrypted with a master key. This option transmits the database with
 unencrypted keys.
 .It Fl E , Fl Fl encrypt
-This option transmits the database with encrypted keys.
+This option transmits the database with encrypted keys. This is the
+default if no option is supplied.
 .It Fl n , Fl Fl stdout
 Dump the database on stdout, in a format that can be fed to hpropd.
 .El


### PR DESCRIPTION
There are two options to hprop.  It's important to note that the default
behavior is to transmit the database with encrypted keys.