### PR TITLE
Fixes #532 - Note that all does not include get-keys

### DIFF
--- a/kadmin/kadmind.8
+++ b/kadmin/kadmind.8
@@ -109,7 +109,7 @@ get
 .It
 get-keys
 .It
-all
+all (everything except get-keys)
 .El
 .Pp
 And the optional


### PR DESCRIPTION
Update the kadmind(8) man page to note that the "all" option for ACLs
does not include the "get-keys" option.