### PR TITLE
Fixes #536 - Note that this can cause unexpected behavior with certain

### DIFF
--- a/kadmin/kadmin.1
+++ b/kadmin/kadmin.1
@@ -329,7 +329,13 @@ Run the password quality check function locally.
 You can run this on the host that is configured to run the kadmind
 process to verify that your configuration file is correct.
 The verification is done locally, if kadmin is run in remote mode,
-no rpc call is done to the server.
+no rpc call is done to the server. NOTE: if the environment has
+verify-password-quality configured to use a back-end that stores
+password history (such as heimdal-history), running
+verify-quality-password will cause an update to the password
+database meaning that merely verifying the quality of the password
+using verify-quality-password invalidates the use of that
+principal/password in the future.
 .Ed
 .Pp
 .Nm privileges


### PR DESCRIPTION
backends

When running with verify-password-quality and a back-end that stores
history (such as heimdal-history) this command can cause an update to
the database meaning the password can no longer be used with this
principal in the future