### PR TITLE
Do not set anonymous flag in S4U2Proxy request

### DIFF
--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -1644,10 +1644,8 @@ next_rule:
 	flags.b.forwardable = 1;
     if (options & KRB5_GC_NO_TRANSIT_CHECK)
 	flags.b.disable_transited_check = 1;
-    if (options & KRB5_GC_CONSTRAINED_DELEGATION) {
-	flags.b.request_anonymous = 1; /* XXX ARGH confusion */
+    if (options & KRB5_GC_CONSTRAINED_DELEGATION)
 	flags.b.constrained_delegation = 1;
-    }
     if (options & KRB5_GC_ANONYMOUS)
 	flags.b.request_anonymous = 1;
 


### PR DESCRIPTION
CC @lhoward 

Constrained delegation fails on master, after commit: 014e318d
I get BADOPTION at: https://github.com/heimdal/heimdal/blob/014e318d6bdefd8ecfcb99ca9928921f6a49d721/lib/krb5/ticket.c#L727
Any idea why is S4U2Proxy automatically set to anonymous? I didn't see a mention of it elsewhere.
If I remove the anonymous flag as in this patch then it works okay.

To reproduce:
$ echo pwd | kinit -f impersonator@REALM
$ kgetcred --out-cache=evidence --impersonate=user@REALM impersonator@REALM
$ kgetcred --debug --delegation-credential-cache=evidence --out-cache=out -H HTTP/apache.realm@REALM
$ KRB5CCNAME=out curl --negotiate -u: http://apache.realm/whoami.aspx