### PR TITLE
kdc: history of request_anonymous vs cname-in-addl-tkt confusion

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -123,11 +123,11 @@ is_anon_as_request_p(kdc_request_t r)
     KDC_REQ_BODY *b = &r->req.req_body;
 
     /*
-     * Some versions of heimdal use bit 14 instead of 16 for
-     * request_anonymous, as indicated in the anonymous draft prior to
-     * version 11. Bit 14 is assigned to S4U2Proxy, but S4U2Proxy requests
-     * are only sent to the TGS and, in any case, would have an additional
-     * ticket present.
+     * Versions of Heimdal from 0.9rc1 through 1.50 use bit 14 instead
+     * of 16 for request_anonymous, as indicated in the anonymous draft
+     * prior to version 11. Bit 14 is assigned to S4U2Proxy, but S4U2Proxy
+     * requests are only sent to the TGS and, in any case, would have an
+     * additional ticket present.
      */
     return b->kdc_options.request_anonymous ||
 	   (b->kdc_options.cname_in_addl_tkt && !b->additional_tickets);

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -373,7 +373,7 @@ is_anon_tgs_request_p(const KDC_REQ_BODY *b,
     KDCOptions f = b->kdc_options;
 
     /*
-     * Earlier (pre-7.6) versions of Heimdal would send both the
+     * Versions of Heimdal from 1.0 to 7.6, inclusive, send both the
      * request-anonymous and cname-in-addl-tkt flags for constrained
      * delegation requests. A true anonymous TGS request will only
      * have the request-anonymous flag set. (A corollary of this is


### PR DESCRIPTION
Drafts 0 through 10 of the Kerberos anonymity draft specified the
TicketFlags.anonymous flag as bit 14.  This was changed to bit 16
after it was discovered that Microsoft used bit 14 for S4U2Proxy.

d5bb7a7c566841d52662b230248f06522bfa64ad ("(krb5_get_creds): if
KRB5_GC_CONSTRAINED_DELEGATION is set, set both") set both the
anonymous and constrained_delegation TicketFlags when issuing a
S4U2Proxy request.  The setting of the anonymous TicketFlag was
removed by ea7615ade3af28843f358e715703226b760db73b("Do not set
anonymous flag in S4U2Proxy request").

014e318d6bdefd8ecfcb99ca9928921f6a49d721 ("krb5: check KDC
supports anonymous if requested") introduced a client side check
to ensure that an anonymous request is responded to with an
anonymized ticket.  The combination of setting the anonymous
TicketFlag and the anonymized ticket validation broke S4U2Proxy
requests to Windows KDCs because they ignore the anonymous TicketFlag
when constrained_delegation is requested.

The Heimdal KDC includes fallback logic to handle Heimdal clients
that set the anonymous TicketFlag as bit 14 in _kdc_is_anon_request().
However, it failed to adjust the kdc_options flags when it
determined that the request came from an old Heimdal client.

This change clears the constrained_delegation flag and sets the
request_anonymous flag when an old Heimdal client is detected.
It also clears the request_anonymous flag if both bit 14 and 16
are set.

Change-Id: If57b6f9fe95fdba0109c4450dba5548b4ae6eba9