### PR TITLE
draft: Fix KRB5SignedPath when evidence ticket is not acquired via protocol-transition

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1000,7 +1000,7 @@ tgs_make_reply(krb5_context context,
 					  config,
 					  krbtgt,
 					  krbtgt_etype,
-					  client_principal,
+					  tgt_name,
 					  NULL,
 					  spp,
 					  &et);
@@ -2307,7 +2307,7 @@ server_lookup:
 	ret = check_KRB5SignedPath(context,
 				   config,
 				   krbtgt,
-				   cp,
+				   tp,
 				   &adtkt,
 				   NULL,
 				   &ad_signedpath);

--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -805,8 +805,29 @@ echo "  negative check"
 ${kgetcred_imp} --impersonate=bar@${R} foo@${R} 2>/dev/null && \
 	{ ec=1 ; eval "${testfailed}"; }
 
-echo "test constrained delegation"; > messages.log
+echo "test constrained delegation (evidence from impersonation)"; > messages.log
 ${kgetcred_imp} --forward --impersonate=bar@${R} ${ps} || \
+	{ ec=1 ; eval "${testfailed}"; }
+${kgetcred} \
+	--out-cache=${o2cache} \
+	--delegation-credential-cache=${ocache} \
+	${server}@${R} || \
+	{ ec=1 ; eval "${testfailed}"; }
+echo "  try using the credential"
+${test_ap_req} ${server}@${R} ${keytab} ${o2cache} || \
+	{ ec=1 ; eval "${testfailed}"; }
+echo "  negative check"
+${kgetcred} \
+	--out-cache=${o2cache} \
+	--delegation-credential-cache=${ocache} \
+	bar@${R} 2>/dev/null && \
+	{ ec=1 ; eval "${testfailed}"; }
+
+echo "test constrained delegation evidence (evidence from TGS)"; > messages.log
+echo bar > ${objdir}/barpassword
+${kinit} --cache=${icache} --forwardable --password-file=${objdir}/barpassword bar@${R} || \
+        { ec=1 ; eval "${testfailed}"; }
+${kgetcred} --cache=${icache} --out-cache=${ocache} ${ps} || \
 	{ ec=1 ; eval "${testfailed}"; }
 ${kgetcred} \
 	--out-cache=${o2cache} \

--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -844,6 +844,24 @@ ${kgetcred} \
 	bar@${R} 2>/dev/null && \
 	{ ec=1 ; eval "${testfailed}"; }
 
+echo "test constrained delegation evidence (evidence from AS)"; > messages.log
+${kinit} --cache=${ocache} --forwardable --password-file=${objdir}/barpassword --server=${ps} bar@${R} || \
+        { ec=1 ; eval "${testfailed}"; }
+${kgetcred} \
+	--out-cache=${o2cache} \
+	--delegation-credential-cache=${ocache} \
+	${server}@${R} || \
+	{ ec=1 ; eval "${testfailed}"; }
+echo "  try using the credential"
+${test_ap_req} ${server}@${R} ${keytab} ${o2cache} || \
+	{ ec=1 ; eval "${testfailed}"; }
+echo "  negative check"
+${kgetcred} \
+	--out-cache=${o2cache} \
+	--delegation-credential-cache=${ocache} \
+	bar@${R} 2>/dev/null && \
+	{ ec=1 ; eval "${testfailed}"; }
+
 echo "test constrained delegation impersonation (non forward)"; > messages.log
 rm -f ocache.krb5
 ${kimpersonate} -s ${ps} -c bar@${R} -t ${aesenctype} || \


### PR DESCRIPTION
Follow up to #598.
- Fix check of KRB5SignedPath in constrained-delegation to match on impersonated client.
- Fix signing of KRB5SignedPath in protocol-transition to sign with impersonated client.
- Fix PAC and KRB5SignedPath KDC signatures in case of non krbtgt server requested via AS-RRQ to use local TGS key instead of the server key.