### PR TITLE
Export krb5_crypto_prfplus() from libkrb5

### DIFF
--- a/lib/krb5/crypto.c
+++ b/lib/krb5/crypto.c
@@ -2990,7 +2990,7 @@ krb5_crypto_prf(krb5_context context,
     return (*et->prf)(context, crypto, input, output);
 }
 
-static krb5_error_code
+KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_crypto_prfplus(krb5_context context,
 		    const krb5_crypto crypto,
 		    const krb5_data *input,

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -187,6 +187,7 @@ EXPORTS
 	krb5_crypto_init
 	krb5_crypto_overhead
 	krb5_crypto_prf
+	krb5_crypto_prfplus
 	krb5_crypto_prf_length
 	krb5_crypto_length
 	krb5_crypto_length_iov

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -183,6 +183,7 @@ HEIMDAL_KRB5_2.0 {
 		krb5_crypto_init;
 		krb5_crypto_overhead;
 		krb5_crypto_prf;
+		krb5_crypto_prfplus;
 		krb5_crypto_prf_length;
 		krb5_crypto_length;
 		krb5_crypto_length_iov;


### PR DESCRIPTION
This function is quite useful for a project on which I am working. We _may_ want to rename it or update the usage in some fashion before we export it?