### PR TITLE
Fix (OTP) build with no external database support

### DIFF
--- a/cf/db.m4
+++ b/cf/db.m4
@@ -148,6 +148,8 @@ for db_type in unknown $db_type_preference; do
     db_type=unknown
 done
 
+dnl Note that these lines can only do anything if the user explicitly passed
+dnl --with-db-type-preference and did not include sqlite at all.
 AS_IF([test "x$have_db3" = xyes -a "$db_type" = unknown], db_type=db3, db_type="$db_type")
 AS_IF([test "x$have_db1" = xyes -a "$db_type" = unknown], db_type=db1, db_type="$db_type")
 AS_IF([test "x$have_lmdb" = xyes -a "$db_type" = unknown], db_type=lmdb, db_type="$db_type")

--- a/cf/otp.m4
+++ b/cf/otp.m4
@@ -6,11 +6,13 @@ AC_DEFUN([rk_OTP],[
 AC_REQUIRE([rk_DB])dnl
 AC_ARG_ENABLE(otp,
 	AS_HELP_STRING([--disable-otp],[if you don't want OTP support]))
-if test "$enable_otp" = yes -a "$db_type" = unknown; then
+AS_IF([test "$db_type" = unknown -o "$db_type" = sqlite -o "$db_type" = lmdb],
+	[dbm_compat=no], [dbm_compat=yes])
+if test "$enable_otp" = yes -a "$dbm_compat" = no; then
 	AC_MSG_ERROR([OTP requires a NDBM/DB compatible library])
 fi
 if test "$enable_otp" != no; then
-	if test "$db_type" != unknown; then
+	if test "$dbm_compat" != no; then
 		enable_otp=yes
 	else
 		enable_otp=no

--- a/configure.ac
+++ b/configure.ac
@@ -735,12 +735,13 @@ else
             User=${USER:-${LOGNAME:-`id -nu`}}
         fi
         if test -d "$srcdir/.git"; then
-            GitCommit=`git rev-parse HEAD`
-            GitBranch=`git rev-parse --abbrev-ref HEAD`
+            GitCommit=`cd $srcdir && git rev-parse HEAD`
+            GitBranch=`cd $srcdir && git rev-parse --abbrev-ref HEAD`
             if test "x$GitBranch" = master; then
-                GitDesc=`git describe --all --dirty`
+                GitDesc=`cd $srcdir && git describe --all --dirty`
             else
-                GitDesc=`git describe --tags --match 'heimdal-*' --dirty`
+                GitDesc=`cd $srcdir && \
+			 git describe --tags --match 'heimdal-*' --dirty`
             fi
         else
             GitCommit='<commit-unknown>'


### PR DESCRIPTION
On a fairly minimal debian sid system, my builds fail in libotp trying to link otptest due to missing symbols (e.g., __roken_dbm_open); it turns out that this is not due to failing to link libroken, but rather that these symbols are not in libroken at all! Though ```ndbm_wrap.c``` is in lib/roken, the sources are used directly in lib/otp/Makefile.am; however, these wrappers are only built when HAVE_DB3 or HAVE_DB1 is defined; otherwise we try to use NDBMLIB for the DBM support (as set by the routines in cf/db.m4).
However, ```otp_db.c``` includes ```ndbm_wrap.h``` when ```!defined(HAVE_NDBM) && !defined(HAVE_DB_NDBM)```, but the roken version seems to require a "real" DB*N* for some *N*.

As far as I can tell, this means that we just can't use libotp in such a minimal environment, hence the proposed change to configure to disable otp in these cases.  (But of course the details of when exactly to do such disabling may not be correct, as I don't have an exhaustive test matrix to try it on.)

Please try to double-check the notes in the commit message about the commits where sqlite/lmdb were introduced, as I'm not 100% confident in them.

I'm also a bit confused at how the ```$db_type``` configure variable seems to be used both for what the HDB format is and what kind of db*N* we have available (for libotp's purposes), but did not try to investigate down that path.

One final side note from my investigation's results: ```ndbm_wrap.c``` includes db.h if ```HAVE_DBHEADER``` and then has an elif chain, with the else clause also being to include db.h.  I didn't fully read up on when we set HAVE_DBHEADER, but maybe this is trying to include the thing that we already checked wasn't available?