### PR TITLE
Issue 619:

### DIFF
--- a/lib/hcrypto/ui.c
+++ b/lib/hcrypto/ui.c
@@ -125,7 +125,7 @@ read_string(const char *preprompt, const char *prompt,
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = 0;
     for(i = 1; i < sizeof(sigs) / sizeof(sigs[0]); i++)
-	if (i != SIGALRM)
+	if (i != SIGALRM && i != SIGWINCH)
 	    if (sigaction(i, &sa, &sigs[i]) == 0)
 		oksigs[i] = 1;
 

--- a/lib/hcrypto/ui.c
+++ b/lib/hcrypto/ui.c
@@ -125,7 +125,11 @@ read_string(const char *preprompt, const char *prompt,
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = 0;
     for(i = 1; i < sizeof(sigs) / sizeof(sigs[0]); i++)
-	if (i != SIGALRM && i != SIGWINCH)
+#if defined(SIGWINCH)
+    if (i != SIGALRM && i != SIGWINCH)
+#else
+    if (i != SIGALRM)
+#endif
 	    if (sigaction(i, &sa, &sigs[i]) == 0)
 		oksigs[i] = 1;
 

--- a/lib/hcrypto/ui.c
+++ b/lib/hcrypto/ui.c
@@ -126,9 +126,9 @@ read_string(const char *preprompt, const char *prompt,
     sa.sa_flags = 0;
     for(i = 1; i < sizeof(sigs) / sizeof(sigs[0]); i++)
 #if defined(SIGWINCH)
-	    if (i != SIGALRM && i != SIGWINCH)
+	if (i != SIGALRM && i != SIGWINCH)
 #else
-	    if (i != SIGALRM)
+	if (i != SIGALRM)
 #endif
 	    if (sigaction(i, &sa, &sigs[i]) == 0)
 		oksigs[i] = 1;

--- a/lib/hcrypto/ui.c
+++ b/lib/hcrypto/ui.c
@@ -126,9 +126,9 @@ read_string(const char *preprompt, const char *prompt,
     sa.sa_flags = 0;
     for(i = 1; i < sizeof(sigs) / sizeof(sigs[0]); i++)
 #if defined(SIGWINCH)
-    if (i != SIGALRM && i != SIGWINCH)
+	    if (i != SIGALRM && i != SIGWINCH)
 #else
-    if (i != SIGALRM)
+	    if (i != SIGALRM)
 #endif
 	    if (sigaction(i, &sa, &sigs[i]) == 0)
 		oksigs[i] = 1;


### PR DESCRIPTION
    Heimdal's read_string() does not restart I/O when interrupted by a
    signal, returning with an error code instead. We don't want this to
    happen when the user resizes the window triggering a SIGWINCH, so we
    skip installing a handler for it. The default action for this signal is
    "ignore", so the I/O won't be interrupted (no need to set SA_RESTART).