### PR TITLE
Support builds as non-logged-in root

### DIFF
--- a/lib/kadm5/init_c.c
+++ b/lib/kadm5/init_c.c
@@ -370,10 +370,13 @@ _kadm5_c_get_cred_cache(krb5_context context,
 	     * determine the client from a credentials cache.
 	     */
             char userbuf[128];
-	    const char *user;
+	    const char *user = NULL;
 
-	    user = roken_get_username(userbuf, sizeof(userbuf));
-	    if(user == NULL) {
+            if (geteuid() == 0)
+                user = roken_get_loginname(userbuf, sizeof(userbuf));
+            if (user == NULL)
+                user = roken_get_username(userbuf, sizeof(userbuf));
+	    if (user == NULL) {
 		krb5_set_error_message(context, KADM5_FAILURE, "Unable to find local user name");
 		return KADM5_FAILURE;
 	    }

--- a/lib/krb5/expand_path.c
+++ b/lib/krb5/expand_path.c
@@ -329,6 +329,26 @@ _expand_username(krb5_context context, PTYPE param, const char *postfix, char **
     return 0;
 }
 
+static krb5_error_code
+_expand_loginname(krb5_context context, PTYPE param, const char *postfix, char **str)
+{
+    char user[128];
+    const char *username = roken_get_loginname(user, sizeof(user));
+
+    if (username == NULL) {
+	krb5_set_error_message(context, ENOTTY,
+			       N_("unable to figure out current principal",
+			       ""));
+	return ENOTTY; /* XXX */
+    }
+
+    *str = strdup(username);
+    if (*str == NULL)
+	return krb5_enomem(context);
+
+    return 0;
+}
+
 /**
  * Expand an extra token
  */
@@ -389,11 +409,14 @@ static const struct {
     {"LIBEXEC", SPECIAL(_expand_bin_dir)},
     {"SBINDIR", SPECIAL(_expand_bin_dir)},
 #else
+    {"LOCALSTATEDIR", FTYPE_SPECIAL, 0, LOCALSTATEDIR, _expand_path},
     {"LIBDIR", FTYPE_SPECIAL, 0, LIBDIR, _expand_path},
     {"BINDIR", FTYPE_SPECIAL, 0, BINDIR, _expand_path},
     {"LIBEXEC", FTYPE_SPECIAL, 0, LIBEXECDIR, _expand_path},
     {"SBINDIR", FTYPE_SPECIAL, 0, SBINDIR, _expand_path},
     {"euid", SPECIAL(_expand_euid)},
+    {"ruid", SPECIAL(_expand_userid)},
+    {"loginname", SPECIAL(_expand_loginname)},
 #endif
     {"username", SPECIAL(_expand_username)},
     {"TEMP", SPECIAL(_expand_temp_folder)},

--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -87,7 +87,8 @@ path: STRING
 .Li STRINGs
 consists of one or more non-whitespace characters.
 .Pp
-Files and directories may be included by absolute path.  Including a
+Files and directories may be included by absolute path, with percent
+token expansion (see the TOKEN EXPANSION section).  Including a
 directory causes all files in the directory to be included as if each
 file had been included separately, but only files whose names consist of
 alphanumeric, hyphen, and underscore are included, though they may also
@@ -193,10 +194,8 @@ sets the default credentials type.
 the default credentials cache name.
 If you want to change the type only use
 .Li default_cc_type .
-The string can contain variables that are expanded on runtime.
-The Only supported variable currently is
-.Li %{uid}
-which expands to the current user id.
+The string can contain variables that are expanded at runtime. See the TOKEN
+EXPANSION section.
 .It Li default_etypes = Va etypes ...
 A list of default encryption types to use. (Default: all enctypes if
 allow_weak_crypto = TRUE, else all enctypes except single DES enctypes.)
@@ -211,6 +210,11 @@ A list of default encryption types to use when requesting a DES credential.
 .It Li default_keytab_name = Va keytab
 The keytab to use if no other is specified, default is
 .Dq FILE:/etc/krb5.keytab .
+.It Li default_client_keytab_name = Va keytab
+The keytab to use for client credential acquisition if no other is
+specified, default is
+.Dq FILE:%{LOCALSTATEDIR}/user/%{euid}/client.keytab .
+See the TOKEN EXPANSION section.
 .It Li dns_lookup_kdc = Va boolean
 Use DNS SRV records to lookup KDC services location.
 .It Li dns_lookup_realm = Va boolean
@@ -277,7 +281,8 @@ this is very useful when the GSS-API server input the
 wrong server name into the gss_accept_sec_context call.
 .It Li k5login_directory = Va directory
 Alternative location for user .k5login files. This option is provided
-for compatibility with MIT krb5 configuration files.
+for compatibility with MIT krb5 configuration files. This path is
+subject to percent token expansion (see TOKEN EXPANSION).
 .It Li k5login_authoritative = Va boolean
 If true then if a principal is not found in k5login files then
 .Xr krb5_userok 3
@@ -796,6 +801,60 @@ List of policy names to apply to the password. Builtin policies are
 among other minimum-length, character-class, external-check.
 .El
 .El
+.El
+.Sh TOKEN EXPANSION
+The values of some parameters are subject to percent token expansion.
+Expansions supported on all platforms:
+.Bl -tag -width "xxx" -offset indent
+.It %{LIBDIR}
+The install location of Heimdal libraries.
+.It %{BINDIR}
+The install location of Heimdal user programs.
+.It %{LIBEXEC}
+The install location of Heimdal services.
+.It %{SBINDIR}
+The install location of Heimdal admin programs.
+.It %{username}
+The current username.
+.It %{TEMP}
+A temporary directory.
+.It %{USERID}
+The current user's SID (Windows) or effective user ID (POSIX).
+.It %{uid}
+The current user's SID (Windows) or real user ID (POSIX).  On POSIX it is best
+to use the
+.Va %{euid}
+token instead (see below).
+.It %{null}
+The empty string.
+.El
+.Pp
+Expansions supported on POSIX-like platforms:
+.Bl -tag -width "xxx" -offset indent
+.It %{euid}
+The current effective user ID.
+.It %{loginname}
+The username of the logged-in user for this terminal.
+.It %{LOCALSTATEDIR}
+The install location of Heimdal databases.
+.El
+.Pp
+On Windows, several additional tokens can also be expanded:
+.Bl -tag -width "xxx" -offset indent
+.It %{APPDATA}
+Roaming application data (for current user).
+.It %{COMMON_APPDATA}
+Application data (all users).
+.It %{LOCAL_APPDATA}
+Local application data (for current user).
+.It %{SYSTEM}
+Windows System folder.
+.It %{WINDOWS}
+Windows folder.
+.It %{USERCONFIG}
+Per user Heimdal configuration file path.
+.It %{COMMONCONFIG}
+Common Heimdal configuration file path.
 .El
 .Sh ENVIRONMENT
 .Ev KRB5_CONFIG

--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -1036,6 +1036,8 @@ roken_get_appdatadir(char *, size_t);
 ROKEN_LIB_FUNCTION char * ROKEN_LIB_CALL
 roken_get_username(char *, size_t);
 ROKEN_LIB_FUNCTION char * ROKEN_LIB_CALL
+roken_get_loginname(char *, size_t);
+ROKEN_LIB_FUNCTION char * ROKEN_LIB_CALL
 roken_get_shell(char *, size_t);
 
 #ifndef HAVE_STRFTIME

--- a/lib/roken/test-getuserinfo.c
+++ b/lib/roken/test-getuserinfo.c
@@ -69,6 +69,7 @@ main(void)
     }
 #endif
     printf("Username:\t%s\n", roken_get_username(buf, sizeof(buf)));
+    printf("Loginname:\t%s\n", roken_get_loginname(buf, sizeof(buf)));
     printf("Home:\t\t%s\n", roken_get_homedir(buf, sizeof(buf)));
     printf("Appdatadir:\t%s\n", roken_get_appdatadir(buf, sizeof(buf)));
     printf("Shell:\t\t%s\n", roken_get_shell(buf, sizeof(buf)));

--- a/lib/roken/version-script.map
+++ b/lib/roken/version-script.map
@@ -182,6 +182,7 @@ HEIMDAL_ROKEN_2.0 {
 		roken_get_homedir;
 		roken_get_shell;
 		roken_get_username;
+		roken_get_loginname;
 		roken_mconcat;
 		roken_vconcat;
 		roken_vmconcat;


### PR DESCRIPTION
We add a new `%{loginname}` to mean "that which is returned by `getlogin_r()`", and make `%{username}` mean only whatever `$USER`, or `$LOGNAME`, or `getpwuid_r()` say.  And we make sure that the default principal name, and the principal name `kadmin` defaults to, are based on the former when running as root and the latter otherwise.