### PR TITLE
Define log levels in docs and change default to 0-3.

### DIFF
--- a/kdc/digest-service.c
+++ b/kdc/digest-service.c
@@ -67,7 +67,7 @@ ntlm_service(void *ctx, const heim_idata *req,
     int ret;
     const char *domain;
 
-    kdc_log(context, config, 1, "digest-request: uid=%d",
+    kdc_log(context, config, 4, "digest-request: uid=%d",
 	    (int)heim_ipc_cred_get_uid(cred));
 
     if (heim_ipc_cred_get_uid(cred) != 0) {
@@ -93,7 +93,7 @@ ntlm_service(void *ctx, const heim_idata *req,
 	goto failed;
     }
 
-    kdc_log(context, config, 1, "digest-request: user=%s/%s",
+    kdc_log(context, config, 4, "digest-request: user=%s/%s",
 	    ntq.loginUserName, domain);
 
     if (ntq.lmchallenge.length != 8)
@@ -126,7 +126,7 @@ ntlm_service(void *ctx, const heim_idata *req,
 	}
     }
 
-    kdc_log(context, config, 2,
+    kdc_log(context, config, 5,
 	    "digest-request: found user, processing ntlm request");
 
     if (ntq.ntChallengeResponce.length != 24) {
@@ -205,7 +205,7 @@ ntlm_service(void *ctx, const heim_idata *req,
 	abort();
 
   failed:
-    kdc_log(context, config, 1, "digest-request: %d", ret);
+    kdc_log(context, config, 4, "digest-request: %d", ret);
 
     (*complete)(cctx, ret, &rep);
 

--- a/kdc/digest.c
+++ b/kdc/digest.c
@@ -223,7 +223,7 @@ _kdc_do_digest(krb5_context context,
     krb5_data serverNonce;
 
     if(!config->enable_digest) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Rejected digest request (disabled) from %s", from);
 	return KRB5KDC_ERR_POLICY;
     }
@@ -236,7 +236,7 @@ _kdc_do_digest(krb5_context context,
     memset(&rep, 0, sizeof(rep));
     memset(&res, 0, sizeof(res));
 
-    kdc_log(context, config, 0, "Digest request from %s", from);
+    kdc_log(context, config, 3, "Digest request from %s", from);
 
     ret = krb5_kt_resolve(context, "HDBGET:", &id);
     if (ret) {
@@ -320,7 +320,7 @@ _kdc_do_digest(krb5_context context,
 	    goto out;
 
 	if (client->entry.flags.allow_digest == 0) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Client %s tried to use digest "
 		    "but is not allowed to",
 		    client_name);
@@ -364,7 +364,7 @@ _kdc_do_digest(krb5_context context,
 	goto out;
     }
 
-    kdc_log(context, config, 0, "Valid digest request from %s (%s)",
+    kdc_log(context, config, 3, "Valid digest request from %s (%s)",
 	    client_name, from);
 
     /*
@@ -498,7 +498,7 @@ _kdc_do_digest(krb5_context context,
 	    goto out;
 	}
 
-	kdc_log(context, config, 0, "Digest %s init request successful from %s",
+	kdc_log(context, config, 3, "Digest %s init request successful from %s",
 		ireq.u.init.type, from);
 
 	break;
@@ -622,7 +622,7 @@ _kdc_do_digest(krb5_context context,
 	    char idx;
 
 	    if ((config->digests_allowed & CHAP_MD5) == 0) {
-		kdc_log(context, config, 0, "Digest CHAP MD5 not allowed");
+		kdc_log(context, config, 2, "Digest CHAP MD5 not allowed");
 		goto out;
 	    }
 
@@ -669,7 +669,7 @@ _kdc_do_digest(krb5_context context,
 	    if (ret == 0) {
 		r.u.response.success = TRUE;
 	    } else {
-		kdc_log(context, config, 0,
+		kdc_log(context, config, 2,
 			"CHAP reply mismatch for %s",
 			ireq.u.digestRequest.username);
 		r.u.response.success = FALSE;
@@ -682,7 +682,7 @@ _kdc_do_digest(krb5_context context,
 	    char *A1, *A2;
 
 	    if ((config->digests_allowed & DIGEST_MD5) == 0) {
-		kdc_log(context, config, 0, "Digest SASL MD5 not allowed");
+		kdc_log(context, config, 2, "Digest SASL MD5 not allowed");
 		goto out;
 	    }
 
@@ -794,7 +794,7 @@ _kdc_do_digest(krb5_context context,
 	    if (ret == 0) {
 		r.u.response.success = TRUE;
 	    } else {
-		kdc_log(context, config, 0,
+		kdc_log(context, config, 2,
 			"DIGEST-MD5 reply mismatch for %s",
 			ireq.u.digestRequest.username);
 		r.u.response.success = FALSE;
@@ -810,7 +810,7 @@ _kdc_do_digest(krb5_context context,
 	    EVP_MD_CTX *ctp;
 
 	    if ((config->digests_allowed & MS_CHAP_V2) == 0) {
-		kdc_log(context, config, 0, "MS-CHAP-V2 not allowed");
+		kdc_log(context, config, 2, "MS-CHAP-V2 not allowed");
 		goto failed;
 	    }
 
@@ -917,7 +917,7 @@ _kdc_do_digest(krb5_context context,
 	    if (ret == 0) {
 		r.u.response.success = TRUE;
 	    } else {
-		kdc_log(context, config, 0,
+		kdc_log(context, config, 2,
 			"MS-CHAP-V2 hash mismatch for %s",
 			ireq.u.digestRequest.username);
 		r.u.response.success = FALSE;
@@ -1013,7 +1013,7 @@ _kdc_do_digest(krb5_context context,
 	    r.u.error.code = EINVAL;
 	}
 
-	kdc_log(context, config, 0, "Digest %s request successful %s",
+	kdc_log(context, config, 3, "Digest %s request successful %s",
 		ireq.u.digestRequest.type, ireq.u.digestRequest.username);
 
 	break;
@@ -1021,7 +1021,7 @@ _kdc_do_digest(krb5_context context,
     case choice_DigestReqInner_ntlmInit:
 
 	if ((config->digests_allowed & (NTLM_V1|NTLM_V1_SESSION|NTLM_V2)) == 0) {
-	    kdc_log(context, config, 0, "NTLM not allowed");
+	    kdc_log(context, config, 2, "NTLM not allowed");
 	    goto failed;
 	}
 
@@ -1030,14 +1030,14 @@ _kdc_do_digest(krb5_context context,
 	r.u.ntlmInitReply.flags = NTLM_NEG_UNICODE;
 
 	if ((ireq.u.ntlmInit.flags & NTLM_NEG_UNICODE) == 0) {
-	    kdc_log(context, config, 0, "NTLM client have no unicode");
+	    kdc_log(context, config, 2, "NTLM client have no unicode");
 	    goto failed;
 	}
 
 	if (ireq.u.ntlmInit.flags & NTLM_NEG_NTLM)
 	    r.u.ntlmInitReply.flags |= NTLM_NEG_NTLM;
 	else {
-	    kdc_log(context, config, 0, "NTLM client doesn't support NTLM");
+	    kdc_log(context, config, 2, "NTLM client doesn't support NTLM");
 	    goto failed;
 	}
 
@@ -1137,7 +1137,7 @@ _kdc_do_digest(krb5_context context,
 	if (ret)
 	    goto out;
 
-	kdc_log(context, config, 0, "NTLM init from %s", from);
+	kdc_log(context, config, 3, "NTLM init from %s", from);
 
 	break;
 
@@ -1181,7 +1181,7 @@ _kdc_do_digest(krb5_context context,
 	krb5_crypto_destroy(context, crypto);
 	crypto = NULL;
 	if (ret) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Failed to decrypt nonce from %s", from);
 	    goto failed;
 	}
@@ -1227,7 +1227,7 @@ _kdc_do_digest(krb5_context context,
 	    char *targetname;
 
 	    if ((config->digests_allowed & NTLM_V2) == 0) {
-		kdc_log(context, config, 0, "NTLM v2 not allowed");
+		kdc_log(context, config, 2, "NTLM v2 not allowed");
 		goto out;
 	    }
 
@@ -1273,7 +1273,7 @@ _kdc_do_digest(krb5_context context,
 		EVP_MD_CTX *ctx;
 
 		if ((config->digests_allowed & NTLM_V1_SESSION) == 0) {
-		    kdc_log(context, config, 0, "NTLM v1-session not allowed");
+		    kdc_log(context, config, 2, "NTLM v1-session not allowed");
 		    ret = EINVAL;
 		    goto failed;
 		}
@@ -1298,7 +1298,7 @@ _kdc_do_digest(krb5_context context,
 
 	    } else {
 		if ((config->digests_allowed & NTLM_V1) == 0) {
-		    kdc_log(context, config, 0, "NTLM v1 not allowed");
+		    kdc_log(context, config, 2, "NTLM v1 not allowed");
 		    goto failed;
 		}
 	    }
@@ -1389,7 +1389,7 @@ _kdc_do_digest(krb5_context context,
     }
     case choice_DigestReqInner_supportedMechs:
 
-	kdc_log(context, config, 0, "digest supportedMechs from %s", from);
+	kdc_log(context, config, 4, "digest supportedMechs from %s", from);
 
 	r.element = choice_DigestRepInner_supportedMechs;
 	memset(&r.u.supportedMechs, 0, sizeof(r.u.supportedMechs));
@@ -1421,7 +1421,7 @@ _kdc_do_digest(krb5_context context,
 	    goto out;
 	}
 
-	kdc_log(context, config, 0, "Digest failed with: %s", s);
+	kdc_log(context, config, 2, "Digest failed with: %s", s);
 
 	r.element = choice_DigestRepInner_error;
 	r.u.error.reason = strdup("unknown error");

--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -115,7 +115,7 @@ fast_parse_cookie(kdc_request_t r, const PA_DATA *pa)
 	goto out;
 
     if (r->fast.expiration < kdc_time) {
-	kdc_log(r->context, r->config, 0, "fast cookie expired");
+	kdc_log(r->context, r->config, 2, "fast cookie expired");
 	ret = KRB5KDC_ERR_POLICY;
 	goto out;
     }
@@ -298,7 +298,7 @@ _kdc_fast_mk_error(krb5_context context,
 				  KRB5_PADATA_FX_COOKIE,
 				  NULL, 0);
 	if (ret) {
-	    kdc_log(r->context, r->config, 0, "failed to add fast cookie with: %d", ret);
+	    kdc_log(r->context, r->config, 1, "failed to add fast cookie with: %d", ret);
 	    free_METHOD_DATA(error_method);
 	    return ret;
 	}
@@ -388,7 +388,7 @@ _kdc_fast_unwrap_request(kdc_request_t r)
     }
 
     if (fxreq.element != choice_PA_FX_FAST_REQUEST_armored_data) {
-	kdc_log(r->context, r->config, 0,
+	kdc_log(r->context, r->config, 2,
 		"AS-REQ FAST contain unknown type: %d", (int)fxreq.element);
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;
 	goto out;
@@ -396,14 +396,14 @@ _kdc_fast_unwrap_request(kdc_request_t r)
 
     /* pull out armor key */
     if (fxreq.u.armored_data.armor == NULL) {
-	kdc_log(r->context, r->config, 0,
+	kdc_log(r->context, r->config, 2,
 		"AS-REQ armor missing");
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;
 	goto out;
     }
 
     if (fxreq.u.armored_data.armor->armor_type != 1) {
-	kdc_log(r->context, r->config, 0,
+	kdc_log(r->context, r->config, 2,
 		"AS-REQ armor type not ap-req");
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;
 	goto out;
@@ -413,7 +413,7 @@ _kdc_fast_unwrap_request(kdc_request_t r)
 			     &fxreq.u.armored_data.armor->armor_value,
 			     &ap_req);
     if(ret) {
-	kdc_log(r->context, r->config, 0, "AP-REQ decode failed");
+	kdc_log(r->context, r->config, 2, "AP-REQ decode failed");
 	goto out;
     }
 
@@ -462,7 +462,7 @@ _kdc_fast_unwrap_request(kdc_request_t r)
 
     if (ac->remote_subkey == NULL) {
 	krb5_auth_con_free(r->context, ac);
-	kdc_log(r->context, r->config, 0,
+	kdc_log(r->context, r->config, 2,
 		"FAST AP-REQ remote subkey missing");
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;
 	goto out;
@@ -495,7 +495,7 @@ _kdc_fast_unwrap_request(kdc_request_t r)
 			       buf, len, 
 			       &fxreq.u.armored_data.req_checksum);
     if (ret) {
-	kdc_log(r->context, r->config, 0,
+	kdc_log(r->context, r->config, 2,
 		"FAST request have a bad checksum");
 	goto out;
     }
@@ -505,7 +505,7 @@ _kdc_fast_unwrap_request(kdc_request_t r)
 				     &fxreq.u.armored_data.enc_fast_req,
 				     &data);
     if (ret) {
-	kdc_log(r->context, r->config, 0,
+	kdc_log(r->context, r->config, 2,
 		"Failed to decrypt FAST request");
 	goto out;
     }
@@ -529,7 +529,7 @@ _kdc_fast_unwrap_request(kdc_request_t r)
 	    
     /* check for unsupported mandatory options */
     if (FastOptions2int(fastreq.fast_options) & 0xfffc) {
-	kdc_log(r->context, r->config, 0,
+	kdc_log(r->context, r->config, 2,
 		"FAST unsupported mandatory option set");
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;
 	goto out;

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -337,7 +337,7 @@ _kdc_log_timestamp(krb5_context context,
     else
 	strlcpy(renewtime_str, "unset", sizeof(renewtime_str));
 
-    kdc_log(context, config, 5,
+    kdc_log(context, config, 3,
 	    "%s authtime: %s starttime: %s endtime: %s renew till: %s",
 	    type, authtime_str, starttime_str, endtime_str, renewtime_str);
 }
@@ -358,7 +358,7 @@ pa_pkinit_validate(kdc_request_t r, const PA_DATA *pa)
     ret = _kdc_pk_rd_padata(r->context, r->config, &r->req, pa, r->client, &pkp);
     if (ret || pkp == NULL) {
 	ret = KRB5KRB_AP_ERR_BAD_INTEGRITY;
-	_kdc_r_log(r, 5, "Failed to decode PKINIT PA-DATA -- %s",
+	_kdc_r_log(r, 2, "Failed to decode PKINIT PA-DATA -- %s",
 		   r->client_name);
 	goto out;
     }
@@ -375,7 +375,7 @@ pa_pkinit_validate(kdc_request_t r, const PA_DATA *pa)
 	goto out;
     }
 
-    _kdc_r_log(r, 0, "PKINIT pre-authentication succeeded -- %s using %s",
+    _kdc_r_log(r, 3, "PKINIT pre-authentication succeeded -- %s using %s",
 	       r->client_name, client_cert);
     free(client_cert);
 
@@ -466,7 +466,7 @@ pa_enc_chal_validate(kdc_request_t r, const PA_DATA *pa)
     
     if (_kdc_is_anon_request(&r->req)) {
 	ret = KRB5KRB_AP_ERR_BAD_INTEGRITY;
-	kdc_log(r->context, r->config, 0, "ENC-CHALL doesn't support anon");
+	kdc_log(r->context, r->config, 2, "ENC-CHALL doesn't support anon");
 	return ret;
     }
 
@@ -476,7 +476,7 @@ pa_enc_chal_validate(kdc_request_t r, const PA_DATA *pa)
 			       &size);
     if (ret) {
 	ret = KRB5KRB_AP_ERR_BAD_INTEGRITY;
-	_kdc_r_log(r, 5, "Failed to decode PA-DATA -- %s",
+	_kdc_r_log(r, 2, "Failed to decode PA-DATA -- %s",
 		   r->client_name);
 	return ret;
     }
@@ -525,7 +525,7 @@ pa_enc_chal_validate(kdc_request_t r, const PA_DATA *pa)
 	    ret2 = krb5_enctype_to_string(r->context, k->key.keytype, &str);
 	    if (ret2)
 		str = NULL;
-	    _kdc_r_log(r, 5, "Failed to decrypt ENC-CHAL -- %s "
+	    _kdc_r_log(r, 2, "Failed to decrypt ENC-CHAL -- %s "
 		       "(enctype %s) error %s",
 		       r->client_name, str ? str : "unknown enctype", msg);
 	    krb5_free_error_message(r->context, msg);
@@ -542,7 +542,7 @@ pa_enc_chal_validate(kdc_request_t r, const PA_DATA *pa)
 	if(ret){
 	    krb5_crypto_destroy(r->context, challangecrypto);
 	    ret = KRB5KDC_ERR_PREAUTH_FAILED;
-	    _kdc_r_log(r, 5, "Failed to decode PA-ENC-TS_ENC -- %s",
+	    _kdc_r_log(r, 2, "Failed to decode PA-ENC-TS_ENC -- %s",
 		       r->client_name);
 	    continue;
 	}
@@ -556,7 +556,7 @@ pa_enc_chal_validate(kdc_request_t r, const PA_DATA *pa)
 			     client_time, sizeof(client_time), TRUE);
 
 	    ret = KRB5KRB_AP_ERR_SKEW;
-	    _kdc_r_log(r, 0, "Too large time skew, "
+	    _kdc_r_log(r, 2, "Too large time skew, "
 		       "client time %s is out by %u > %u seconds -- %s",
 		       client_time,
 		       (unsigned)labs(kdc_time - p.patimestamp),
@@ -619,7 +619,7 @@ pa_enc_ts_validate(kdc_request_t r, const PA_DATA *pa)
 			       &len);
     if (ret) {
 	ret = KRB5KRB_AP_ERR_BAD_INTEGRITY;
-	_kdc_r_log(r, 5, "Failed to decode PA-DATA -- %s",
+	_kdc_r_log(r, 2, "Failed to decode PA-DATA -- %s",
 		   r->client_name);
 	goto out;
     }
@@ -633,11 +633,11 @@ pa_enc_ts_validate(kdc_request_t r, const PA_DATA *pa)
 	if(krb5_enctype_to_string(r->context, enc_data.etype, &estr))
 	    estr = NULL;
 	if(estr == NULL)
-	    _kdc_r_log(r, 5,
+	    _kdc_r_log(r, 2,
 		       "No client key matching pa-data (%d) -- %s",
 		       enc_data.etype, r->client_name);
 	else
-	    _kdc_r_log(r, 5,
+	    _kdc_r_log(r, 2,
 		       "No client key matching pa-data (%s) -- %s",
 		       estr, r->client_name);
 	free(estr);
@@ -649,7 +649,7 @@ pa_enc_ts_validate(kdc_request_t r, const PA_DATA *pa)
     ret = krb5_crypto_init(r->context, &pa_key->key, 0, &crypto);
     if (ret) {
 	const char *msg = krb5_get_error_message(r->context, ret);
-	_kdc_r_log(r, 0, "krb5_crypto_init failed: %s", msg);
+	_kdc_r_log(r, 1, "krb5_crypto_init failed: %s", msg);
 	krb5_free_error_message(r->context, msg);
 	free_EncryptedData(&enc_data);
 	goto out;
@@ -674,7 +674,7 @@ pa_enc_ts_validate(kdc_request_t r, const PA_DATA *pa)
 				      pa_key->key.keytype, &str);
 	if (ret2)
 	    str = NULL;
-	_kdc_r_log(r, 5, "Failed to decrypt PA-DATA -- %s "
+	_kdc_r_log(r, 2, "Failed to decrypt PA-DATA -- %s "
 		   "(enctype %s) error %s",
 		   r->client_name, str ? str : "unknown enctype", msg);
 	krb5_free_error_message(r->context, msg);
@@ -701,7 +701,7 @@ pa_enc_ts_validate(kdc_request_t r, const PA_DATA *pa)
     krb5_data_free(&ts_data);
     if(ret){
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;
-	_kdc_r_log(r, 5, "Failed to decode PA-ENC-TS_ENC -- %s",
+	_kdc_r_log(r, 2, "Failed to decode PA-ENC-TS_ENC -- %s",
 		   r->client_name);
 	goto out;
     }
@@ -712,7 +712,7 @@ pa_enc_ts_validate(kdc_request_t r, const PA_DATA *pa)
 			 client_time, sizeof(client_time), TRUE);
 
 	ret = KRB5KRB_AP_ERR_SKEW;
-	_kdc_r_log(r, 0, "Too large time skew, "
+	_kdc_r_log(r, 2, "Too large time skew, "
 		   "client time %s is out by %u > %u seconds -- %s",
 		   client_time,
 		   (unsigned)labs(kdc_time - p.patimestamp),
@@ -739,7 +739,7 @@ pa_enc_ts_validate(kdc_request_t r, const PA_DATA *pa)
     ret = krb5_enctype_to_string(r->context, pa_key->key.keytype, &str);
     if (ret)
 	str = NULL;
-    _kdc_r_log(r, 2, "ENC-TS Pre-authentication succeeded -- %s using %s",
+    _kdc_r_log(r, 3, "ENC-TS Pre-authentication succeeded -- %s using %s",
 	       r->client_name, str ? str : "unknown enctype");
     free(str);
 
@@ -816,7 +816,7 @@ log_patypes(krb5_context context,
 	if (p && n + 1 < padata->len)
 	    p = rk_strpoolprintf(p, ", ");
 	if (p == NULL) {
-	    kdc_log(context, config, 0, "out of memory");
+	    kdc_log(context, config, 1, "out of memory");
 	    return;
 	}
     }
@@ -824,7 +824,7 @@ log_patypes(krb5_context context,
 	p = rk_strpoolprintf(p, "none");
 
     str = rk_strpoolcollect(p);
-    kdc_log(context, config, 0, "Client sent patypes: %s", str);
+    kdc_log(context, config, 4, "Client sent patypes: %s", str);
     free(str);
 }
 
@@ -853,7 +853,7 @@ _kdc_encode_reply(krb5_context context,
     ASN1_MALLOC_ENCODE(EncTicketPart, buf, buf_size, et, &len, ret);
     if(ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "Failed to encode ticket: %s", msg);
+	kdc_log(context, config, 1, "Failed to encode ticket: %s", msg);
 	krb5_free_error_message(context, msg);
 	return ret;
     }
@@ -863,7 +863,7 @@ _kdc_encode_reply(krb5_context context,
     ret = krb5_crypto_init(context, skey, etype, &crypto);
     if (ret) {
         const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "krb5_crypto_init failed: %s", msg);
+	kdc_log(context, config, 1, "krb5_crypto_init failed: %s", msg);
 	krb5_free_error_message(context, msg);
 	free(buf);
 	return ret;
@@ -880,7 +880,7 @@ _kdc_encode_reply(krb5_context context,
     krb5_crypto_destroy(context, crypto);
     if(ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "Failed to encrypt data: %s", msg);
+	kdc_log(context, config, 1, "Failed to encrypt data: %s", msg);
 	krb5_free_error_message(context, msg);
 	return ret;
     }
@@ -890,7 +890,7 @@ _kdc_encode_reply(krb5_context context,
 	krb5_keyblock *strengthen_key = NULL;
 	KrbFastFinished finished;
 
-	kdc_log(context, config, 0, "FAST armor protection");
+	kdc_log(context, config, 4, "FAST armor protection");
 
 	memset(&finished, 0, sizeof(finished));
 	krb5_data_zero(&data);
@@ -954,13 +954,13 @@ _kdc_encode_reply(krb5_context context,
 	ASN1_MALLOC_ENCODE(EncTGSRepPart, buf, buf_size, ek, &len, ret);
     if(ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "Failed to encode KDC-REP: %s", msg);
+	kdc_log(context, config, 1, "Failed to encode KDC-REP: %s", msg);
 	krb5_free_error_message(context, msg);
 	return ret;
     }
     if(buf_size != len) {
 	free(buf);
-	kdc_log(context, config, 0, "Internal error in ASN.1 encoder");
+	kdc_log(context, config, 1, "Internal error in ASN.1 encoder");
 	*e_text = "KDC internal error";
 	return KRB5KRB_ERR_GENERIC;
     }
@@ -968,7 +968,7 @@ _kdc_encode_reply(krb5_context context,
     if (ret) {
 	const char *msg = krb5_get_error_message(context, ret);
 	free(buf);
-	kdc_log(context, config, 0, "krb5_crypto_init failed: %s", msg);
+	kdc_log(context, config, 1, "krb5_crypto_init failed: %s", msg);
 	krb5_free_error_message(context, msg);
 	return ret;
     }
@@ -996,13 +996,13 @@ _kdc_encode_reply(krb5_context context,
     krb5_crypto_destroy(context, crypto);
     if(ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "Failed to encode KDC-REP: %s", msg);
+	kdc_log(context, config, 1, "Failed to encode KDC-REP: %s", msg);
 	krb5_free_error_message(context, msg);
 	return ret;
     }
     if(buf_size != len) {
 	free(buf);
-	kdc_log(context, config, 0, "Internal error in ASN.1 encoder");
+	kdc_log(context, config, 1, "Internal error in ASN.1 encoder");
 	*e_text = "KDC internal error";
 	return KRB5KRB_ERR_GENERIC;
     }
@@ -1059,7 +1059,7 @@ make_etype_info_entry(krb5_context context,
 	else if(key->salt->type == hdb_afs3_salt)
 	    *ent->salttype = 2;
 	else {
-	    kdc_log(context, config, 0, "unknown salt-type: %d",
+	    kdc_log(context, config, 2, "unknown salt-type: %d",
 		    key->salt->type);
 	    return KRB5KRB_ERR_GENERIC;
 	}
@@ -1333,7 +1333,7 @@ log_as_req(krb5_context context,
 	if (p && i + 1 < b->etype.len)
 	    p = rk_strpoolprintf(p, ", ");
 	if (p == NULL) {
-	    kdc_log(context, config, 0, "out of memory");
+	    kdc_log(context, config, 1, "out of memory");
 	    return;
 	}
     }
@@ -1359,7 +1359,7 @@ log_as_req(krb5_context context,
     }
 
     str = rk_strpoolcollect(p);
-    kdc_log(context, config, 0, "%s", str);
+    kdc_log(context, config, 3, "%s", str);
     free(str);
 
     {
@@ -1367,7 +1367,7 @@ log_as_req(krb5_context context,
 	unparse_flags(KDCOptions2int(b->kdc_options), asn1_KDCOptions_units(),
 		      fixedstr, sizeof(fixedstr));
 	if(*fixedstr)
-	    kdc_log(context, config, 0, "Requested flags: %s", fixedstr);
+	    kdc_log(context, config, 3, "Requested flags: %s", fixedstr);
     }
 }
 
@@ -1389,19 +1389,19 @@ kdc_check_flags(krb5_context context,
 
 	/* check client */
 	if (client->flags.locked_out) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Client (%s) is locked out", client_name);
 	    return KRB5KDC_ERR_POLICY;
 	}
 
 	if (client->flags.invalid) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Client (%s) has invalid bit set", client_name);
 	    return KRB5KDC_ERR_POLICY;
 	}
 
 	if(!client->flags.client){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Principal may not act as client -- %s", client_name);
 	    return KRB5KDC_ERR_POLICY;
 	}
@@ -1410,7 +1410,7 @@ kdc_check_flags(krb5_context context,
 	    char starttime_str[100];
 	    krb5_format_time(context, *client->valid_start,
 			     starttime_str, sizeof(starttime_str), TRUE);
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Client not yet valid until %s -- %s",
 		    starttime_str, client_name);
 	    return KRB5KDC_ERR_CLIENT_NOTYET;
@@ -1420,7 +1420,7 @@ kdc_check_flags(krb5_context context,
 	    char endtime_str[100];
 	    krb5_format_time(context, *client->valid_end,
 			     endtime_str, sizeof(endtime_str), TRUE);
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Client expired at %s -- %s",
 		    endtime_str, client_name);
 	    return KRB5KDC_ERR_NAME_EXP;
@@ -1428,7 +1428,7 @@ kdc_check_flags(krb5_context context,
 
 	if (client->flags.require_pwchange &&
 	    (server_ex == NULL || !server_ex->entry.flags.change_pw)) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Client's key must be changed -- %s", client_name);
 	    return KRB5KDC_ERR_KEY_EXPIRED;
 	}
@@ -1438,7 +1438,7 @@ kdc_check_flags(krb5_context context,
 	    char pwend_str[100];
 	    krb5_format_time(context, *client->pw_end,
 			     pwend_str, sizeof(pwend_str), TRUE);
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Client's key has expired at %s -- %s",
 		    pwend_str, client_name);
 	    return KRB5KDC_ERR_KEY_EXPIRED;
@@ -1451,24 +1451,24 @@ kdc_check_flags(krb5_context context,
 	hdb_entry *server = &server_ex->entry;
 
 	if (server->flags.locked_out) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Server locked out -- %s", server_name);
 	    return KRB5KDC_ERR_POLICY;
 	}
 	if (server->flags.invalid) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Server has invalid flag set -- %s", server_name);
 	    return KRB5KDC_ERR_POLICY;
 	}
 
 	if(!server->flags.server){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Principal may not act as server -- %s", server_name);
 	    return KRB5KDC_ERR_POLICY;
 	}
 
 	if(!is_as_req && server->flags.initial) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "AS-REQ is required for server -- %s", server_name);
 	    return KRB5KDC_ERR_POLICY;
 	}
@@ -1477,7 +1477,7 @@ kdc_check_flags(krb5_context context,
 	    char starttime_str[100];
 	    krb5_format_time(context, *server->valid_start,
 			     starttime_str, sizeof(starttime_str), TRUE);
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Server not yet valid until %s -- %s",
 		    starttime_str, server_name);
 	    return KRB5KDC_ERR_SERVICE_NOTYET;
@@ -1487,7 +1487,7 @@ kdc_check_flags(krb5_context context,
 	    char endtime_str[100];
 	    krb5_format_time(context, *server->valid_end,
 			     endtime_str, sizeof(endtime_str), TRUE);
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Server expired at %s -- %s",
 		    endtime_str, server_name);
 	    return KRB5KDC_ERR_SERVICE_EXP;
@@ -1497,7 +1497,7 @@ kdc_check_flags(krb5_context context,
 	    char pwend_str[100];
 	    krb5_format_time(context, *server->pw_end,
 			     pwend_str, sizeof(pwend_str), TRUE);
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Server's key has expired at %s -- %s",
 		    pwend_str, server_name);
 	    return KRB5KDC_ERR_KEY_EXPIRED;
@@ -1563,7 +1563,7 @@ _kdc_check_anon_policy (krb5_context context,
 			hdb_entry_ex *server)
 {
     if (!config->allow_anonymous){
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Request for anonymous ticket denied by local policy");
 	return KRB5KDC_ERR_POLICY;
     }
@@ -1613,7 +1613,7 @@ generate_pac(kdc_request_t r, Key *skey)
 
     ret = _kdc_pac_generate(r->context, r->client, &p);
     if (ret) {
-	_kdc_r_log(r, 0, "PAC generation failed for -- %s",
+	_kdc_r_log(r, 1, "PAC generation failed for -- %s",
 		   r->client_name);
 	return ret;
     }
@@ -1627,7 +1627,7 @@ generate_pac(kdc_request_t r, Key *skey)
 			 &data);
     krb5_pac_free(r->context, p);
     if (ret) {
-	_kdc_r_log(r, 0, "PAC signing failed for -- %s",
+	_kdc_r_log(r, 1, "PAC signing failed for -- %s",
 		   r->client_name);
 	return ret;
     }
@@ -1740,7 +1740,7 @@ _kdc_as_rep(kdc_request_t r,
      */
     ret = _kdc_fast_unwrap_request(r);
     if (ret) {
-	_kdc_r_log(r, 0, "FAST unwrap request from %s failed: %d", from, ret);
+	_kdc_r_log(r, 1, "FAST unwrap request from %s failed: %d", from, ret);
 	goto out;
     }
 
@@ -1762,7 +1762,7 @@ _kdc_as_rep(kdc_request_t r,
 	    ret = krb5_unparse_name(context, r->server_princ, &r->server_name);
     }
     if (ret) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"AS-REQ malformed server name from %s", from);
 	goto out;
     }
@@ -1780,12 +1780,12 @@ _kdc_as_rep(kdc_request_t r,
 	ret = krb5_unparse_name(context, r->client_princ, &r->client_name);
     }
     if (ret) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"AS-REQ malformed client name from %s", from);
 	goto out;
     }
 
-    kdc_log(context, config, 0, "AS-REQ %s from %s for %s",
+    kdc_log(context, config, 3, "AS-REQ %s from %s for %s",
 	    r->client_name, from, r->server_name);
 
     is_tgs = krb5_principal_is_krbtgt(context, r->server_princ);
@@ -1796,7 +1796,7 @@ _kdc_as_rep(kdc_request_t r,
 
     if (_kdc_is_anonymous(context, r->client_princ) &&
 	!_kdc_is_anon_request(&r->req)) {
-	kdc_log(context, config, 0, "Anonymous client w/o anonymous flag");
+	kdc_log(context, config, 2, "Anonymous client w/o anonymous flag");
 	ret = KRB5KDC_ERR_BADOPTION;
 	goto out;
     }
@@ -1821,7 +1821,7 @@ _kdc_as_rep(kdc_request_t r,
 	    goto out;
 	}
 
-	kdc_log(context, config, 0, "WRONG_REALM - %s -> %s",
+	kdc_log(context, config, 2, "WRONG_REALM - %s -> %s",
 		r->client_name, fixed_client_name);
 	free(fixed_client_name);
 
@@ -1839,7 +1839,7 @@ _kdc_as_rep(kdc_request_t r,
 	goto out;
     } else if(ret){
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "UNKNOWN -- %s: %s", r->client_name, msg);
+	kdc_log(context, config, 2, "UNKNOWN -- %s: %s", r->client_name, msg);
 	krb5_free_error_message(context, msg);
 	ret = KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN;
 	goto out;
@@ -1853,7 +1853,7 @@ _kdc_as_rep(kdc_request_t r,
 	goto out;
     } else if(ret){
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "UNKNOWN -- %s: %s", r->server_name, msg);
+	kdc_log(context, config, 2, "UNKNOWN -- %s: %s", r->server_name, msg);
 	krb5_free_error_message(context, msg);
 	ret = KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN;
 	goto out;
@@ -1877,7 +1877,7 @@ _kdc_as_rep(kdc_request_t r,
 			  b->etype.val, b->etype.len,
 			  &r->sessionetype, NULL, NULL);
     if (ret) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Client (%s) from %s has no common enctypes with KDC "
 		"to use for the session key",
 		r->client_name, from);
@@ -1927,7 +1927,7 @@ _kdc_as_rep(kdc_request_t r,
 		    }
 		    goto out;
 		}
-		kdc_log(context, config, 0,
+		kdc_log(context, config, 3,
 			"%s pre-authentication succeeded -- %s",
 			pat[n].name, r->client_name);
 		found_pa = 1;
@@ -2318,7 +2318,7 @@ _kdc_as_rep(kdc_request_t r,
 	ret = add_enc_pa_rep(r);
 	if (ret) {
 	    const char *msg = krb5_get_error_message(r->context, ret);
-	    _kdc_r_log(r, 0, "add_enc_pa_rep failed: %s: %d", msg, ret);
+	    _kdc_r_log(r, 1, "add_enc_pa_rep failed: %s: %d", msg, ret);
 	    krb5_free_error_message(r->context, msg);
 	    goto out;
 	}

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -243,7 +243,7 @@ check_KRB5SignedPath(krb5_context context,
 	free(data.data);
 	if (ret) {
 	    free_KRB5SignedPath(&sp);
-	    kdc_log(context, config, 5,
+	    kdc_log(context, config, 2,
 		    "KRB5SignedPath not signed correctly, not marking as signed");
 	    return 0;
 	}
@@ -400,26 +400,26 @@ check_tgs_flags(krb5_context context,
 
     if(f.validate){
 	if(!tgt->flags.invalid || tgt->starttime == NULL){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Bad request to validate ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	if(*tgt->starttime > kdc_time){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Early request to validate ticket");
 	    return KRB5KRB_AP_ERR_TKT_NYV;
 	}
 	/* XXX  tkt = tgt */
 	et->flags.invalid = 0;
     }else if(tgt->flags.invalid){
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Ticket-granting ticket has INVALID flag set");
 	return KRB5KRB_AP_ERR_TKT_INVALID;
     }
 
     if(f.forwardable){
 	if(!tgt->flags.forwardable){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Bad request for forwardable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
@@ -427,7 +427,7 @@ check_tgs_flags(krb5_context context,
     }
     if(f.forwarded){
 	if(!tgt->flags.forwardable){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Request to forward non-forwardable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
@@ -439,7 +439,7 @@ check_tgs_flags(krb5_context context,
 
     if(f.proxiable){
 	if(!tgt->flags.proxiable){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Bad request for proxiable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
@@ -447,7 +447,7 @@ check_tgs_flags(krb5_context context,
     }
     if(f.proxy){
 	if(!tgt->flags.proxiable){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Request to proxy non-proxiable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
@@ -459,7 +459,7 @@ check_tgs_flags(krb5_context context,
 
     if(f.allow_postdate){
 	if(!tgt->flags.may_postdate){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Bad request for post-datable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
@@ -467,7 +467,7 @@ check_tgs_flags(krb5_context context,
     }
     if(f.postdated){
 	if(!tgt->flags.may_postdate){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Bad request for postdated ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
@@ -482,7 +482,7 @@ check_tgs_flags(krb5_context context,
 
     if(f.renewable){
 	if(!tgt->flags.renewable || tgt->renew_till == NULL){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Bad request for renewable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
@@ -494,7 +494,7 @@ check_tgs_flags(krb5_context context,
     if(f.renew){
 	time_t old_life;
 	if(!tgt->flags.renewable || tgt->renew_till == NULL){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Request to renew non-renewable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
@@ -514,7 +514,7 @@ check_tgs_flags(krb5_context context,
      */
     if (tgt->flags.anonymous &&
 	!_kdc_is_anonymous(context, tgt_name)) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Anonymous ticket flag set without anonymous principal");
 	return KRB5KDC_ERR_BADOPTION;
     }
@@ -554,7 +554,7 @@ check_constrained_delegation(krb5_context context,
      */
     if(!krb5_realm_compare(context, client->entry.principal, server->entry.principal)) {
 	ret = KRB5KDC_ERR_BADOPTION;
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 	    "Bad request for constrained delegation");
 	return ret;
     }
@@ -582,7 +582,7 @@ check_constrained_delegation(krb5_context context,
 	}
 	ret = KRB5KDC_ERR_BADOPTION;
     }
-    kdc_log(context, config, 0,
+    kdc_log(context, config, 2,
 	    "Bad request for constrained delegation");
     return ret;
 }
@@ -628,11 +628,11 @@ verify_flags (krb5_context context,
 	      const char *pstr)
 {
     if(et->endtime < kdc_time){
-	kdc_log(context, config, 0, "Ticket expired (%s)", pstr);
+	kdc_log(context, config, 2, "Ticket expired (%s)", pstr);
 	return KRB5KRB_AP_ERR_TKT_EXPIRED;
     }
     if(et->flags.invalid){
-	kdc_log(context, config, 0, "Ticket not valid (%s)", pstr);
+	kdc_log(context, config, 2, "Ticket not valid (%s)", pstr);
 	return KRB5KRB_AP_ERR_TKT_NYV;
     }
     return 0;
@@ -667,11 +667,11 @@ fix_transited_encoding(krb5_context context,
 	 */
 	if (tr->contents.length == 0)
 	    break;
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Transited type 0 with non empty content");
 	return KRB5KDC_ERR_TRTYPE_NOSUPP;
     default:
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Unknown transited type: %u", tr->tr_type);
 	return KRB5KDC_ERR_TRTYPE_NOSUPP;
     }
@@ -712,7 +712,7 @@ fix_transited_encoding(krb5_context context,
     }
     if(num_realms == 0) {
 	if(strcmp(client_realm, server_realm))
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 4,
 		    "cross-realm %s -> %s", client_realm, server_realm);
     } else {
 	size_t l = 0;
@@ -727,7 +727,7 @@ fix_transited_encoding(krb5_context context,
 		    strlcat(rs, ", ", l);
 		strlcat(rs, realms[i], l);
 	    }
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 4,
 		    "cross-realm %s -> %s via [%s]",
 		    client_realm, server_realm, rs);
 	    free(rs);
@@ -1080,7 +1080,7 @@ tgs_check_authenticator(krb5_context context,
 
     krb5_auth_con_getauthenticator(context, ac, &auth);
     if(auth->cksum == NULL){
-	kdc_log(context, config, 0, "No authenticator in request");
+	kdc_log(context, config, 2, "No authenticator in request");
 	ret = KRB5KRB_AP_ERR_INAPP_CKSUM;
 	goto out;
     }
@@ -1094,7 +1094,7 @@ tgs_check_authenticator(krb5_context context,
 	||
 #endif
  !krb5_checksum_is_collision_proof(context, auth->cksum->cksumtype)) {
-	kdc_log(context, config, 0, "Bad checksum type in authenticator: %d",
+	kdc_log(context, config, 2, "Bad checksum type in authenticator: %d",
 		auth->cksum->cksumtype);
 	ret =  KRB5KRB_AP_ERR_INAPP_CKSUM;
 	goto out;
@@ -1104,13 +1104,13 @@ tgs_check_authenticator(krb5_context context,
     ASN1_MALLOC_ENCODE(KDC_REQ_BODY, buf, buf_size, b, &len, ret);
     if(ret){
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "Failed to encode KDC-REQ-BODY: %s", msg);
+	kdc_log(context, config, 1, "Failed to encode KDC-REQ-BODY: %s", msg);
 	krb5_free_error_message(context, msg);
 	goto out;
     }
     if(buf_size != len) {
 	free(buf);
-	kdc_log(context, config, 0, "Internal error in ASN.1 encoder");
+	kdc_log(context, config, 1, "Internal error in ASN.1 encoder");
 	*e_text = "KDC internal error";
 	ret = KRB5KRB_ERR_GENERIC;
 	goto out;
@@ -1119,7 +1119,7 @@ tgs_check_authenticator(krb5_context context,
     if (ret) {
 	const char *msg = krb5_get_error_message(context, ret);
 	free(buf);
-	kdc_log(context, config, 0, "krb5_crypto_init failed: %s", msg);
+	kdc_log(context, config, 1, "krb5_crypto_init failed: %s", msg);
 	krb5_free_error_message(context, msg);
 	goto out;
     }
@@ -1133,7 +1133,7 @@ tgs_check_authenticator(krb5_context context,
     krb5_crypto_destroy(context, crypto);
     if(ret){
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Failed to verify authenticator checksum: %s", msg);
 	krb5_free_error_message(context, msg);
     }
@@ -1162,7 +1162,7 @@ need_referral(krb5_context context, krb5_kdc_configuration *config,
 	  SPN form, which is used for inter-domain communication in AD
 	 */
 	name = server->name.name_string.val[2];
-	kdc_log(context, config, 0, "Giving 3 part referral for %s", name);
+	kdc_log(context, config, 4, "Giving 3 part referral for %s", name);
 	*realms = malloc(sizeof(char *)*2);
 	if (*realms == NULL) {
 	    krb5_set_error_message(context, ENOMEM, N_("malloc: out of memory", ""));
@@ -1176,7 +1176,7 @@ need_referral(krb5_context context, krb5_kdc_configuration *config,
     else
 	return FALSE;
 
-    kdc_log(context, config, 0, "Searching referral for %s", name);
+    kdc_log(context, config, 5, "Searching referral for %s", name);
 
     return _krb5_get_host_realm_int(context, name, FALSE, realms) == 0;
 }
@@ -1223,14 +1223,14 @@ tgs_parse_request(krb5_context context,
     ret = krb5_decode_ap_req(context, &tgs_req->padata_value, &ap_req);
     if(ret){
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "Failed to decode AP-REQ: %s", msg);
+	kdc_log(context, config, 2, "Failed to decode AP-REQ: %s", msg);
 	krb5_free_error_message(context, msg);
 	goto out;
     }
 
     if(!get_krbtgt_realm(&ap_req.ticket.sname)){
 	/* XXX check for ticket.sname == req.sname */
-	kdc_log(context, config, 0, "PA-DATA is not a ticket-granting ticket");
+	kdc_log(context, config, 2, "PA-DATA is not a ticket-granting ticket");
 	ret = KRB5KDC_ERR_POLICY; /* ? */
 	goto out;
     }
@@ -1290,7 +1290,7 @@ tgs_parse_request(krb5_context context,
 	ret = krb5_unparse_name(context, princ, &p);
 	if (ret != 0)
 	    p = failed;
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 1,
 		"Ticket-granting ticket %s not found in database: %s", p, msg);
 	krb5_free_principal(context, princ);
 	krb5_free_error_message(context, msg);
@@ -1316,7 +1316,7 @@ next_kvno:
 
 	krb5_enctype_to_string(context, ap_req.ticket.enc_part.etype, &str);
 	krb5_unparse_name(context, princ, &p);
- 	kdc_log(context, config, 0,
+ 	kdc_log(context, config, 2,
 		"No server key with enctype %s found for %s",
 		str ? str : "<unknown enctype>",
 		p ? p : "<unparse_name failed>");
@@ -1349,7 +1349,7 @@ next_kvno:
     krb5_free_principal(context, princ);
     if(ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "Failed to verify AP-REQ: %s", msg);
+	kdc_log(context, config, 2, "Failed to verify AP-REQ: %s", msg);
 	krb5_free_error_message(context, msg);
 	goto out;
     }
@@ -1362,14 +1362,14 @@ next_kvno:
 	    *csec   = malloc(sizeof(**csec));
 	    if (*csec == NULL) {
 		krb5_free_authenticator(context, &auth);
-		kdc_log(context, config, 0, "malloc failed");
+		kdc_log(context, config, 1, "malloc failed");
 		goto out;
 	    }
 	    **csec  = auth->ctime;
 	    *cusec  = malloc(sizeof(**cusec));
 	    if (*cusec == NULL) {
 		krb5_free_authenticator(context, &auth);
-		kdc_log(context, config, 0, "malloc failed");
+		kdc_log(context, config, 1, "malloc failed");
 		goto out;
 	    }
 	    **cusec  = auth->cusec;
@@ -1391,7 +1391,7 @@ next_kvno:
     if(ret){
 	const char *msg = krb5_get_error_message(context, ret);
 	krb5_auth_con_free(context, ac);
-	kdc_log(context, config, 0, "Failed to get remote subkey: %s", msg);
+	kdc_log(context, config, 1, "Failed to get remote subkey: %s", msg);
 	krb5_free_error_message(context, msg);
 	goto out;
     }
@@ -1403,14 +1403,14 @@ next_kvno:
 	if(ret) {
 	    const char *msg = krb5_get_error_message(context, ret);
 	    krb5_auth_con_free(context, ac);
-	    kdc_log(context, config, 0, "Failed to get session key: %s", msg);
+	    kdc_log(context, config, 1, "Failed to get session key: %s", msg);
 	    krb5_free_error_message(context, msg);
 	    goto out;
 	}
     }
     if(subkey == NULL){
 	krb5_auth_con_free(context, ac);
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 1,
 		"Failed to get key for enc-authorization-data");
 	ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
 	goto out;
@@ -1425,7 +1425,7 @@ next_kvno:
 	if (ret) {
 	    const char *msg = krb5_get_error_message(context, ret);
 	    krb5_auth_con_free(context, ac);
-	    kdc_log(context, config, 0, "krb5_crypto_init failed: %s", msg);
+	    kdc_log(context, config, 1, "krb5_crypto_init failed: %s", msg);
 	    krb5_free_error_message(context, msg);
 	    goto out;
 	}
@@ -1437,7 +1437,7 @@ next_kvno:
 	krb5_crypto_destroy(context, crypto);
 	if(ret){
 	    krb5_auth_con_free(context, ac);
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Failed to decrypt enc-authorization-data");
 	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
 	    goto out;
@@ -1453,7 +1453,7 @@ next_kvno:
 	    krb5_auth_con_free(context, ac);
 	    free(*auth_data);
 	    *auth_data = NULL;
-	    kdc_log(context, config, 0, "Failed to decode authorization data");
+	    kdc_log(context, config, 2, "Failed to decode authorization data");
 	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
 	    goto out;
 	}
@@ -1621,13 +1621,13 @@ tgs_build_reply(krb5_context context,
 	if(b->additional_tickets == NULL ||
 	   b->additional_tickets->len == 0){
 	    ret = KRB5KDC_ERR_BADOPTION; /* ? */
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "No second ticket present in request");
 	    goto out;
 	}
 	t = &b->additional_tickets->val[0];
 	if(!get_krbtgt_realm(&t->sname)){
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Additional ticket is not a ticket-granting ticket");
 	    ret = KRB5KDC_ERR_POLICY;
 	    goto out;
@@ -1678,11 +1678,11 @@ tgs_build_reply(krb5_context context,
 		   asn1_KDCOptions_units(),
 		   opt_str, sizeof(opt_str));
     if(*opt_str)
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 3,
 		"TGS-REQ %s from %s for %s [%s]",
 		cpn, from, spn, opt_str);
     else
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 3,
 		"TGS-REQ %s from %s for %s", cpn, from, spn);
 
     /*
@@ -1704,7 +1704,7 @@ server_lookup:
 	    goto out;
 	}
 
-	kdc_log(context, config, 5,
+	kdc_log(context, config, 4,
 		"Returning a referral to realm %s for "
 		"server %s.",
 		ref_realm, spn);
@@ -1762,7 +1762,7 @@ server_lookup:
             }
 	} else if (need_referral(context, config, &b->kdc_options, sp, &realms)) {
 	    if (strcmp(realms[0], sp->realm) != 0) {
-		kdc_log(context, config, 5,
+		kdc_log(context, config, 4,
 			"Returning a referral to realm %s for "
 			"server %s that was not found",
 			realms[0], spn);
@@ -1787,7 +1787,7 @@ server_lookup:
 	    krb5_free_host_realm(context, realms);
 	}
 	msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Server not found in database: %s: %s", spn, msg);
 	krb5_free_error_message(context, msg);
 	if (ret == HDB_ERR_NOENTRY)
@@ -1821,7 +1821,7 @@ server_lookup:
 		if (b->etype.val[i] == adtkt.key.keytype)
 		    break;
 	    if(i == b->etype.len) {
-		kdc_log(context, config, 0,
+		kdc_log(context, config, 2,
 			"Addition ticket have not matching etypes");
 		krb5_clear_error_message(context);
 		ret = KRB5KDC_ERR_ETYPE_NOSUPP;
@@ -1841,14 +1841,14 @@ server_lookup:
 				  NULL,
 				  NULL);
 	    if(ret) {
-		kdc_log(context, config, 0,
+		kdc_log(context, config, 2,
 			"Server (%s) has no support for etypes", spn);
 		goto out;
 	    }
 	    ret = _kdc_get_preferred_key(context, config, server, spn,
 					 NULL, &skey);
 	    if(ret) {
-		kdc_log(context, config, 0,
+		kdc_log(context, config, 2,
 			"Server (%s) has no supported etypes", spn);
 		goto out;
 	    }
@@ -1874,7 +1874,7 @@ server_lookup:
     ret = hdb_enctype2key(context, &krbtgt->entry, NULL, /* XXX use the right kvno! */
 			  krbtgt_etype, &tkey_check);
     if(ret) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		    "Failed to find key for krbtgt PAC check");
 	goto out;
     }
@@ -1892,14 +1892,14 @@ server_lookup:
                               our_realm,
                               NULL);
     if (ret) {
-        kdc_log(context, config, 0,
+        kdc_log(context, config, 1,
                 "Failed to make krbtgt principal name object for "
                 "authz-data signatures");
         goto out;
     }
     ret = krb5_unparse_name(context, krbtgt_out_principal, &krbtgt_out_n);
     if (ret) {
-        kdc_log(context, config, 0,
+        kdc_log(context, config, 1,
                 "Failed to make krbtgt principal name object for "
                 "authz-data signatures");
         goto out;
@@ -1910,7 +1910,7 @@ server_lookup:
     if (ret) {
 	char *ktpn = NULL;
 	ret = krb5_unparse_name(context, krbtgt->entry.principal, &ktpn);
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"No such principal %s (needed for authz-data signature keys) "
 		"while processing TGS-REQ for service %s with krbtg %s",
 		krbtgt_out_n, spn, (ret == 0) ? ktpn : "<unknown>");
@@ -1930,7 +1930,7 @@ server_lookup:
 	       krb5_principal_get_realm(context, krbtgt_out->entry.principal)) != 0) {
 	char *ktpn;
 	ret = krb5_unparse_name(context, krbtgt_out->entry.principal, &ktpn);
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Request with wrong krbtgt: %s",
 		(ret == 0) ? ktpn : "<unknown>");
 	if(ret == 0)
@@ -1942,14 +1942,14 @@ server_lookup:
     ret = _kdc_get_preferred_key(context, config, krbtgt_out, krbtgt_out_n,
 				 NULL, &tkey_sign);
     if (ret) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		    "Failed to find key for krbtgt PAC signature");
 	goto out;
     }
     ret = hdb_enctype2key(context, &krbtgt_out->entry, NULL,
 			  tkey_sign->key.keytype, &tkey_sign);
     if(ret) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		    "Failed to find key for krbtgt PAC signature");
 	goto out;
     }
@@ -1974,13 +1974,13 @@ server_lookup:
 	if(strcmp(krb5_principal_get_realm(context, cp), krbtgt_realm) == 0) {
 	    if (ret == HDB_ERR_NOENTRY)
 		ret = KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN;
-	    kdc_log(context, config, 1, "Client no longer in database: %s",
+	    kdc_log(context, config, 2, "Client no longer in database: %s",
 		    cpn);
 	    goto out;
 	}
 
 	msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 1, "Client not found in database: %s", msg);
+	kdc_log(context, config, 2, "Client not found in database: %s", msg);
 	krb5_free_error_message(context, msg);
     }
 
@@ -1991,7 +1991,7 @@ server_lookup:
 		    tgt, &rspac, &signedpath);
     if (ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Verify PAC failed for %s (%s) from %s with %s",
 		spn, cpn, from, msg);
 	krb5_free_error_message(context, msg);
@@ -2008,7 +2008,7 @@ server_lookup:
 			       &signedpath);
     if (ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"KRB5SignedPath check failed for %s (%s) from %s with %s",
 		spn, cpn, from, msg);
 	krb5_free_error_message(context, msg);
@@ -2038,13 +2038,13 @@ server_lookup:
 				     sdata->padata_value.length,
 				     &self, NULL);
 	    if (ret) {
-		kdc_log(context, config, 0, "Failed to decode PA-S4U2Self");
+		kdc_log(context, config, 2, "Failed to decode PA-S4U2Self");
 		goto out;
 	    }
 
 	    if (!krb5_checksum_is_keyed(context, self.cksum.cksumtype)) {
 		free_PA_S4U2Self(&self);
-		kdc_log(context, config, 0, "Reject PA-S4U2Self with unkeyed checksum");
+		kdc_log(context, config, 2, "Reject PA-S4U2Self with unkeyed checksum");
 		ret = KRB5KRB_AP_ERR_INAPP_CKSUM;
 		goto out;
 	    }
@@ -2058,7 +2058,7 @@ server_lookup:
 		const char *msg = krb5_get_error_message(context, ret);
 		free_PA_S4U2Self(&self);
 		krb5_data_free(&datack);
-		kdc_log(context, config, 0, "krb5_crypto_init failed: %s", msg);
+		kdc_log(context, config, 2, "krb5_crypto_init failed: %s", msg);
 		krb5_free_error_message(context, msg);
 		goto out;
 	    }
@@ -2096,7 +2096,7 @@ server_lookup:
 	    if (ret) {
 		const char *msg = krb5_get_error_message(context, ret);
 		free_PA_S4U2Self(&self);
-		kdc_log(context, config, 0,
+		kdc_log(context, config, 2,
 			"krb5_verify_checksum failed for S4U2Self: %s", msg);
 		krb5_free_error_message(context, msg);
 		goto out;
@@ -2132,7 +2132,7 @@ server_lookup:
 		    if (ret == HDB_ERR_NOENTRY)
 			ret = KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN;
 		    msg = krb5_get_error_message(context, ret);
-		    kdc_log(context, config, 1,
+		    kdc_log(context, config, 2,
 			    "S4U2Self principal to impersonate %s not found in database: %s",
 			    tpn, msg);
 		    krb5_free_error_message(context, msg);
@@ -2140,7 +2140,7 @@ server_lookup:
 		}
 		ret = _kdc_pac_generate(context, s4u2self_impersonated_client, &p);
 		if (ret) {
-		    kdc_log(context, config, 0, "PAC generation failed for -- %s",
+		    kdc_log(context, config, 2, "PAC generation failed for -- %s",
 			    tpn);
 		    goto out;
 		}
@@ -2151,7 +2151,7 @@ server_lookup:
 					 &rspac);
 		    krb5_pac_free(context, p);
 		    if (ret) {
-			kdc_log(context, config, 0, "PAC signing failed for -- %s",
+			kdc_log(context, config, 2, "PAC signing failed for -- %s",
 				tpn);
 			goto out;
 		    }
@@ -2164,7 +2164,7 @@ server_lookup:
 	     */
 	    ret = check_s4u2self(context, config, clientdb, client, sp);
 	    if (ret) {
-		kdc_log(context, config, 0, "S4U2Self: %s is not allowed "
+		kdc_log(context, config, 2, "S4U2Self: %s is not allowed "
 			"to impersonate to service "
 			"(tried for user %s to service %s)",
 			cpn, tpn, spn);
@@ -2182,7 +2182,7 @@ server_lookup:
 		b->kdc_options.forwardable = 0;
 		str = "";
 	    }
-	    kdc_log(context, config, 0, "s4u2self %s impersonating %s to "
+	    kdc_log(context, config, 3, "s4u2self %s impersonating %s to "
 		    "service %s %s", cpn, tpn, spn, str);
 	}
     }
@@ -2207,7 +2207,7 @@ server_lookup:
 	 */
 	if (!signedpath) {
 	    ret = KRB5KDC_ERR_BADOPTION;
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Constrained delegation done on service ticket %s/%s",
 		    cpn, spn);
 	    goto out;
@@ -2226,7 +2226,7 @@ server_lookup:
 
 	ret = krb5_decrypt_ticket(context, t, &clientkey->key, &adtkt, 0);
 	if (ret) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "failed to decrypt ticket for "
 		    "constrained delegation from %s to %s ", cpn, spn);
 	    goto out;
@@ -2256,7 +2256,7 @@ server_lookup:
 
 	/* check that ticket is valid */
 	if (adtkt.flags.forwardable == 0) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Missing forwardable flag on ticket for "
 		    "constrained delegation from %s (%s) as %s to %s ",
 		    cpn, dpn, tpn, spn);
@@ -2267,7 +2267,7 @@ server_lookup:
 	ret = check_constrained_delegation(context, config, clientdb,
 					   client, server, sp);
 	if (ret) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "constrained delegation from %s (%s) as %s to %s not allowed",
 		    cpn, dpn, tpn, spn);
 	    goto out;
@@ -2293,7 +2293,7 @@ server_lookup:
 			&adtkt, &rspac, &ad_signedpath);
 	if (ret) {
 	    const char *msg = krb5_get_error_message(context, ret);
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Verify delegated PAC failed to %s for client"
 		    "%s (%s) as %s from %s with %s",
 		    spn, cpn, dpn, tpn, from, msg);
@@ -2313,7 +2313,7 @@ server_lookup:
 				   &ad_signedpath);
 	if (ret) {
 	    const char *msg = krb5_get_error_message(context, ret);
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "KRB5SignedPath check from service %s failed "
 		    "for delegation to %s for client %s (%s)"
 		    "from %s failed with %s",
@@ -2324,7 +2324,7 @@ server_lookup:
 
 	if (!ad_signedpath) {
 	    ret = KRB5KDC_ERR_BADOPTION;
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 2,
 		    "Ticket not signed with PAC nor SignedPath service %s failed "
 		    "for delegation to %s for client %s (%s)"
 		    "from %s",
@@ -2332,7 +2332,7 @@ server_lookup:
 	    goto out;
 	}
 
-	kdc_log(context, config, 0, "constrained delegation for %s "
+	kdc_log(context, config, 3, "constrained delegation for %s "
 		"from %s (%s) to %s", tpn, cpn, dpn, spn);
     }
 
@@ -2351,7 +2351,7 @@ server_lookup:
        !krb5_principal_compare(context,
 			       krbtgt->entry.principal,
 			       server->entry.principal)){
-	kdc_log(context, config, 0, "Inconsistent request.");
+	kdc_log(context, config, 2, "Inconsistent request.");
 	ret = KRB5KDC_ERR_SERVER_NOMATCH;
 	goto out;
     }
@@ -2359,7 +2359,7 @@ server_lookup:
     /* check for valid set of addresses */
     if(!_kdc_check_addresses(context, config, tgt->caddr, from_addr)) {
 	ret = KRB5KRB_AP_ERR_BADADDR;
-	kdc_log(context, config, 0, "Request from wrong address");
+	kdc_log(context, config, 2, "Request from wrong address");
 	goto out;
     }
 
@@ -2378,7 +2378,7 @@ server_lookup:
 	PA_DATA pa;
 	krb5_crypto crypto;
 
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 4,
 		"Adding server referral to %s", ref_realm);
 
 	ret = krb5_crypto_init(context, &sessionkey, 0, &crypto);
@@ -2389,7 +2389,7 @@ server_lookup:
 				    NULL, s, &pa.padata_value);
 	krb5_crypto_destroy(context, crypto);
 	if (ret) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 1,
 		    "Failed building server referral");
 	    goto out;
 	}
@@ -2398,7 +2398,7 @@ server_lookup:
 	ret = add_METHOD_DATA(&enc_pa_data, &pa);
 	krb5_data_free(&pa.padata_value);
 	if (ret) {
-	    kdc_log(context, config, 0,
+	    kdc_log(context, config, 4,
 		    "Add server referral METHOD-DATA failed");
 	    goto out;
 	}
@@ -2497,7 +2497,7 @@ _kdc_tgs_rep(krb5_context context,
 
     if(req->padata == NULL){
 	ret = KRB5KDC_ERR_PREAUTH_REQUIRED; /* XXX ??? */
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"TGS-REQ from %s without PA-DATA", from);
 	goto out;
     }
@@ -2507,7 +2507,7 @@ _kdc_tgs_rep(krb5_context context,
     if(tgs_req == NULL){
 	ret = KRB5KDC_ERR_PADATA_TYPE_NOSUPP;
 
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"TGS-REQ from %s without PA-TGS-REQ", from);
 	goto out;
     }
@@ -2527,7 +2527,7 @@ _kdc_tgs_rep(krb5_context context,
 	goto out;
     }
     if (ret) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 2,
 		"Failed parsing TGS-REQ from %s", from);
 	goto out;
     }
@@ -2535,7 +2535,7 @@ _kdc_tgs_rep(krb5_context context,
     {
 	const PA_DATA *pa = _kdc_find_padata(req, &i, KRB5_PADATA_FX_FAST);
 	if (pa)
-	    kdc_log(context, config, 10, "Got TGS FAST request"); 
+	    kdc_log(context, config, 5, "Got TGS FAST request"); 
     }
 
 
@@ -2554,7 +2554,7 @@ _kdc_tgs_rep(krb5_context context,
 			  &auth_data,
 			  from_addr);
     if (ret) {
-	kdc_log(context, config, 0,
+	kdc_log(context, config, 1,
 		"Failed building TGS-REP to %s", from);
 	goto out;
     }
@@ -2575,7 +2575,7 @@ out:
 	METHOD_DATA error_method = { 0, NULL };
 	
 
-	kdc_log(context, config, 10, "tgs-req: sending error: %d to client", ret);
+	kdc_log(context, config, 5, "tgs-req: sending error: %d to client", ret);
 	ret = _kdc_fast_mk_error(context, NULL,
 				 &error_method,
 				 NULL,

--- a/kdc/kx509.c
+++ b/kdc/kx509.c
@@ -413,13 +413,13 @@ get_template(krb5_context context,
                                                     "kx509_templates",
                                                     config_label, comp0, NULL);
         if (kx509_template == NULL) {
-            kdc_log(context, reqctx->config, 0, "kx509 template not found for %s",
+            kdc_log(context, reqctx->config, 2, "kx509 template not found for %s",
                     princ);
             ret = KRB5KDC_ERR_POLICY;
             goto out;
         }
     } else {
-        kdc_log(context, reqctx->config, 0, "kx509 client %s has too many components!",
+        kdc_log(context, reqctx->config, 2, "kx509 client %s has too many components!",
                 princ);
         ret = KRB5KDC_ERR_POLICY;
     }
@@ -538,7 +538,7 @@ build_certificate(krb5_context context,
         goto out;
     }
 
-    kdc_log(context, reqctx->config, 0, "Issuing kx509 certificate to %s "
+    kdc_log(context, reqctx->config, 3, "Issuing kx509 certificate to %s "
             "using template %s", princ, kx509_template);
 
     /*
@@ -747,7 +747,7 @@ kdc_kx509_verify_service_principal(krb5_context context,
                KRB5_TGS_NAME) == 0) {
         const char *r = krb5_principal_get_comp_string(context, sprincipal, 1);
         if ((ret = is_local_realm(context, reqctx, r)))
-            kx509_log(context, reqctx, 0, "client used wrong krbtgt for kx509");
+            kx509_log(context, reqctx, 2, "client used wrong krbtgt for kx509");
         goto out;
     }
 
@@ -775,7 +775,7 @@ err:
 	goto out;
 
     ret = KRB5KDC_ERR_SERVER_NOMATCH;
-    kx509_log(context, reqctx, 0, "client used wrong kx509 service principal "
+    kx509_log(context, reqctx, 2, "client used wrong kx509 service principal "
               "(expected %s)", expected);
 
 out:
@@ -798,7 +798,7 @@ encode_reply(krb5_context context,
     reqctx->reply->length = 0;
     ASN1_MALLOC_ENCODE(Kx509Response, data.data, data.length, r, &size, ret);
     if (ret) {
-        kdc_log(context, reqctx->config, 0, "Failed to encode kx509 reply");
+        kdc_log(context, reqctx->config, 1, "Failed to encode kx509 reply");
         return ret;
     }
     if (size != data.length)
@@ -860,7 +860,7 @@ mk_error_response(krb5_context context,
         msg = freeme1;
     }
 
-    kdc_log(context, reqctx->config, 0, "%s", msg);
+    kdc_log(context, reqctx->config, 1, "%s", msg);
 
     rep.hash = NULL;
     rep.certificate = NULL;
@@ -969,7 +969,7 @@ update_csr(krb5_context context, kx509_req_context reqctx, Extensions *exts)
         }
     }
     if (ret)
-        kx509_log(context, reqctx, 0,
+        kx509_log(context, reqctx, 2,
                   "request has bad desired certificate extensions");
     return ret;
 }
@@ -998,7 +998,7 @@ get_csr(krb5_context context, kx509_req_context reqctx)
         ret = hx509_request_parse_der(context->hx509ctx, &reqctx->csr_plus.csr,
                                       &reqctx->csr);
         if (ret)
-            kx509_log(context, reqctx, 0, "invalid CSR");
+            kx509_log(context, reqctx, 2, "invalid CSR");
 
         /*
          * Handle any additional Certificate Extensions requested out of band
@@ -1025,7 +1025,7 @@ get_csr(krb5_context context, kx509_req_context reqctx)
 
     /* Not an RSAPublicKey or garbage follows it */
     if (ret == 0)
-        kx509_log(context, reqctx, 0, "request has garbage after key");
+        kx509_log(context, reqctx, 2, "request has garbage after key");
     return mk_error_response(context, reqctx, KRB5KDC_ERR_NULL_KEY,
                              "Could not decode CSR or RSA subject public key");
 }
@@ -1094,7 +1094,7 @@ _kdc_do_kx509(krb5_context context,
          * possibly change the error code and message.
          */
         is_probe = 1;
-        kx509_log(context, &reqctx, 0, "unauthenticated probe request");
+        kx509_log(context, &reqctx, 4, "unauthenticated probe request");
         ret = mk_error_response(context, &reqctx, KRB5KDC_ERR_NULL_KEY,
                                 "kx509 service is available");
         goto out;
@@ -1229,13 +1229,13 @@ _kdc_do_kx509(krb5_context context,
     ret = encode_reply(context, &reqctx, &rep);
     if (ret)
         /* Can't send an error message either in this case, surely */
-        kx509_log(context, &reqctx, 0, "Could not encode response");
+        kx509_log(context, &reqctx, 1, "Could not encode response");
 
 out:
     if (ret == 0 && !is_probe)
-        kx509_log(context, &reqctx, 0, "Issued certificate");
+        kx509_log(context, &reqctx, 3, "Issued certificate");
     else
-        kx509_log(context, &reqctx, 0, "Did not issue certificate");
+        kx509_log(context, &reqctx, 2, "Did not issue certificate");
     if (reqctx.ac)
 	krb5_auth_con_free(context, reqctx.ac);
     if (ticket)

--- a/kdc/misc.c
+++ b/kdc/misc.c
@@ -58,7 +58,7 @@ log_princ(krb5_context context, krb5_kdc_configuration *config, int lvl,
 
     ret = krb5_unparse_name(context, princ, &princstr);
     if (ret) {
-	kdc_log(context, config, 0, "log_princ: ENOMEM");
+	kdc_log(context, config, 1, "log_princ: ENOMEM");
 	return;
     }
     kdc_log(context, config, lvl, fmt, princstr);
@@ -121,7 +121,7 @@ _derive_the_keys(krb5_context context, krb5_kdc_configuration *config,
 bail:
     if (ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "%s: %s", errmsg, msg);
+	kdc_log(context, config, 1, "%s: %s", errmsg, msg);
 	krb5_free_error_message(context, msg);
     }
     if (crypto)

--- a/kdc/set_dbinfo.c
+++ b/kdc/set_dbinfo.c
@@ -85,13 +85,13 @@ krb5_kdc_set_dbinfo(krb5_context context, struct krb5_kdc_configuration *c)
 	if (ret)
 	    goto out;
 
-	kdc_log(context, c, 0, "label: %s",
+	kdc_log(context, c, 3, "label: %s",
 		hdb_dbinfo_get_label(context, d));
-	kdc_log(context, c, 0, "\tdbname: %s",
+	kdc_log(context, c, 3, "\tdbname: %s",
 		hdb_dbinfo_get_dbname(context, d));
-	kdc_log(context, c, 0, "\tmkey_file: %s",
+	kdc_log(context, c, 3, "\tmkey_file: %s",
 		hdb_dbinfo_get_mkey_file(context, d));
-	kdc_log(context, c, 0, "\tacl_file: %s",
+	kdc_log(context, c, 3, "\tacl_file: %s",
 		hdb_dbinfo_get_acl_file(context, d));
     }
     hdb_free_dbinfo(context, &info);

--- a/lib/krb5/krb5_openlog.3
+++ b/lib/krb5/krb5_openlog.3
@@ -203,9 +203,29 @@ parameter to
 .Fn krb5_log
 is within this range (inclusive) the message gets logged to this
 destination, otherwise not. Either of the min and max valued may be
-omitted, in this case min is assumed to be zero, and max is assumed to be
-infinity.  If you don't include a dash, both min and max gets set to the
-specified value. If no range is specified, all messages gets logged.
+omitted, in this case min is assumed to be 0, and max is assumed to
+be 3.
+If you don't include a dash, both min and max get set to the
+specified value.
+.Ss Levels
+Each log message has a level as follows:
+.Bl -tag -width "xxx" -offset indent
+.It 0
+Critical conditions.
+This is a condition that should be corrected immediately, such as a
+corrupted Kerberos database.
+.It 1
+Errors.
+These are errors that occur in the normal processing of requests.
+.It 2
+Warning messages.
+On the KDC, this includes malformed requests and requests that
+are out of policy.
+.It 3
+Informational messages.
+.It 4-9
+Debugging messages with increasing obscurity as the level rises.
+.El
 .Sh EXAMPLES
 .Bd -literal -offset indent
 [logging]

--- a/lib/krb5/log.c
+++ b/lib/krb5/log.c
@@ -268,7 +268,7 @@ KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_addlog_dest(krb5_context context, krb5_log_facility *f, const char *orig)
 {
     krb5_error_code ret = 0;
-    int min = 0, max = -1, n;
+    int min = 0, max = 3, n;
     char c;
     const char *p = orig;
 #ifdef _WIN32
@@ -285,6 +285,8 @@ krb5_addlog_dest(krb5_context context, krb5_log_facility *f, const char *orig)
 		max = min;
 	    }
 	}
+	if (c == '-')
+	    max = -1;
     }
     if(n){
 #ifdef _WIN32


### PR DESCRIPTION
We define the meaning of the various log levels in the man page
for krb5_openlog(3).  If logging configured and levels are not
specified, we change the default levels to 0-3 which should exclude
debugging messages which are generally only desired in exceptional
circumstances.

We also go through the KDC and adjust the levels to be appropriate.