### PR TITLE
lib/ipc: client double close of socket file descriptor #431

### DIFF
--- a/lib/ipc/client.c
+++ b/lib/ipc/client.c
@@ -332,10 +332,8 @@ connect_unix(struct path_ctx *s)
 	return errno;
     rk_cloexec(s->fd);
 
-    if (connect(s->fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
-	close(s->fd);
+    if (connect(s->fd, (struct sockaddr *)&addr, sizeof(addr)) != 0)
 	return errno;
-    }
 
     return 0;
 }


### PR DESCRIPTION
When connect() fails in connect_unix() the path_ctx.fd is not
set to -1 after close().  When common_release() is executed due
to the error return from connect_unix() it calls close() a second
time.

There is no need to call close() from connect_unix(). Remove the
duplicate request.

This issue was reported by YASUOKA Masahiko.

Change-Id: I825e274cc7f12e50a8779a2b62ddb756817cdb52