### PR TITLE
Delegate destination TGT support

### DIFF
--- a/cf/make-proto.pl
+++ b/cf/make-proto.pl
@@ -95,6 +95,13 @@ while(<>) {
     } elsif ($doxygen) { $funcdoc .= $_; next;
     } elsif ($comment) { next; }
 
+    # Handle CPP #define's
+    $define = 1		if /^\s*\#\s*define/;
+    if ($define) {
+	$define = 0	if ! /\\$/;
+	next;
+    }
+
     if(/^\#if 0/) {
 	$if_0 = 1;
     }

--- a/kuser/kinit.1
+++ b/kuser/kinit.1
@@ -115,10 +115,18 @@ like
 .It Fl p , Fl Fl proxiable
 Request tickets with the proxiable flag set.
 .It Fl R , Fl Fl renew
-Try to renew ticket.
+Try to renew a ticket.
 The ticket must have the
 .Sq renewable
-flag set, and must not be expired.
+flag set, and must not be expired. If the
+.Oo Fl S Ar principal Oc
+option is specified, the ticket for the indicated service is renewed.
+If no service is explicitly specified, an attempt is made to renew the
+TGT for the client realm.  If no TGT for the client realm is found in the
+credential cache, an attempt is made to renew the TGT for the defaualt
+realm (if that is found in the credential cache), or else the first
+TGT found.  This makes it easier for users to renew forwarded tickets
+that are not issued by the origin realm.
 .It Fl Fl renewable
 The same as
 .Fl Fl renewable-life ,

--- a/lib/krb5/Makefile.am
+++ b/lib/krb5/Makefile.am
@@ -195,6 +195,7 @@ dist_libkrb5_la_SOURCES =			\
 	log.c					\
 	mcache.c				\
 	misc.c					\
+	mk_cred.c				\
 	mk_error.c				\
 	mk_priv.c				\
 	mk_rep.c				\

--- a/lib/krb5/NTMakefile
+++ b/lib/krb5/NTMakefile
@@ -108,6 +108,7 @@ libkrb5_OBJS =			\
 	$(OBJ)\mcache.obj		    \
 	$(OBJ)\misc.obj			    \
 	$(OBJ)\mit_glue.obj		    \
+	$(OBJ)\mk_cred.obj		    \
 	$(OBJ)\mk_error.obj		    \
 	$(OBJ)\mk_priv.obj		    \
 	$(OBJ)\mk_rep.obj		    \
@@ -274,6 +275,7 @@ dist_libkrb5_la_SOURCES =			\
 	log.c					\
 	mcache.c				\
 	misc.c					\
+	mk_cred.c				\
 	mk_error.c				\
 	mk_priv.c				\
 	mk_rep.c				\

--- a/lib/krb5/addr_families.c
+++ b/lib/krb5/addr_families.c
@@ -1481,6 +1481,8 @@ krb5_make_addrport (krb5_context context,
     size_t len = addr->address.length + 2 + 4 * 4;
     u_char *p;
 
+    /* XXX Make this assume port == 0 -> port is absent */
+
     *res = malloc (sizeof(**res));
     if (*res == NULL)
 	return krb5_enomem(context);

--- a/lib/krb5/get_for_creds.c
+++ b/lib/krb5/get_for_creds.c
@@ -33,6 +33,14 @@
 
 #include "krb5_locl.h"
 
+static krb5_error_code set_tgs_creds(krb5_context, krb5_ccache,
+                                     krb5_const_principal,
+                                     krb5_const_principal, krb5_creds *);
+static krb5_error_code get_cred(krb5_context, krb5_ccache, krb5_creds *,
+                                krb5_flags, const char *, krb5_creds **);
+static krb5_error_code get_addresses(krb5_context, krb5_ccache, krb5_creds *,
+                                     const char *, krb5_addresses *);
+
 static krb5_error_code
 add_addrs(krb5_context context,
 	  krb5_addresses *addr,
@@ -81,9 +89,15 @@ fail:
 }
 
 /**
- * Forward credentials for client to host hostname , making them
+ * Forward credentials for client to host hostname, making them
  * forwardable if forwardable, and returning the blob of data to sent
  * in out_data.  If hostname == NULL, pick it from server.
+ *
+ * If the server's realm is configured for delegation of destination
+ * TGTs, forward a TGT for the server realm, rather than the client
+ * realm. This works better with destinations on the far side of a
+ * firewall. We also forward the destination TGT when the client
+ * TGT is not available (we may have just the destination TGT).
  *
  * @param context A kerberos 5 context.
  * @param auth_context the auth context with the key to encrypt the out_data.
@@ -100,19 +114,18 @@ fail:
  */
 
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
-krb5_fwd_tgt_creds (krb5_context	context,
-		    krb5_auth_context	auth_context,
-		    const char		*hostname,
-		    krb5_principal	client,
-		    krb5_principal	server,
-		    krb5_ccache		ccache,
-		    int			forwardable,
-		    krb5_data		*out_data)
+krb5_fwd_tgt_creds(krb5_context	context,
+		   krb5_auth_context	auth_context,
+		   const char		*hostname,
+		   krb5_const_principal	client,
+		   krb5_const_principal	server,
+		   krb5_ccache		ccache,
+		   int			forwardable,
+		   krb5_data		*out_data)
 {
     krb5_flags flags = 0;
     krb5_creds creds;
     krb5_error_code ret;
-    krb5_const_realm client_realm;
 
     flags |= KDC_OPT_FORWARDED;
 
@@ -131,17 +144,11 @@ krb5_fwd_tgt_creds (krb5_context	context,
 	    hostname = host;
     }
 
-    client_realm = krb5_principal_get_realm(context, client);
-
-    memset (&creds, 0, sizeof(creds));
-    creds.client = client;
-
-    ret = krb5_make_principal(context,
-			      &creds.server,
-			      client_realm,
-			      KRB5_TGS_NAME,
-			      client_realm,
-			      NULL);
+    /*
+     * Fill-in the request creds, the server principal will be the TGS
+     * of either the client's or the server's realm.
+     */
+    ret = set_tgs_creds(context, ccache, client, server, &creds);
     if (ret)
 	return ret;
 
@@ -152,6 +159,8 @@ krb5_fwd_tgt_creds (krb5_context	context,
 				    hostname,
 				    &creds,
 				    out_data);
+
+    krb5_free_cred_contents(context, &creds);
     return ret;
 }
 
@@ -192,273 +201,167 @@ krb5_get_forwarded_creds (krb5_context	    context,
 			  krb5_data         *out_data)
 {
     krb5_error_code ret;
-    krb5_creds *out_creds;
-    krb5_addresses addrs, *paddrs;
-    KRB_CRED cred;
-    KrbCredInfo *krb_cred_info;
-    EncKrbCredPart enc_krb_cred_part;
-    size_t len;
-    unsigned char *buf;
-    size_t buf_size;
-    krb5_kdc_flags kdc_flags;
-    krb5_crypto crypto;
-    struct addrinfo *ai;
-    krb5_creds *ticket;
+    krb5_creds *creds;
 
-    paddrs = NULL;
+    /* Obtain the requested TGT */
+    ret = get_cred(context, ccache, in_creds, flags, hostname, &creds);
+    if (ret)
+        return ret;
+
+    /* Forward obtained creds */
+    ret = _krb5_mk_1cred(context, auth_context, creds, out_data, NULL);
+    krb5_free_creds(context, creds);
+    return ret;
+}
+
+/*
+ * Get a TGT for forwarding to hostname. If the client TGT is
+ * addressless, the forwarded ticket will also be addressless.
+ *
+ * If the TGT has any addresses, hostname will be used to determine
+ * the address to forward the ticket to. Thus, since this might use DNS,
+ * it's insecure and also may not capture all the addresses of the host.
+ * In general addressless tickets are more robust, be it at a small
+ * security penalty.
+ *
+ * @param context A kerberos 5 context.
+ * @param ccache The credential cache to use
+ * @param creds Creds with client and server principals
+ * @param flags The flags to control the resulting ticket flags
+ * @param hostname The hostname of server
+ * @param out_creds The resulting credential
+ *
+ * @return Return an error code or 0.
+ */
+
+static krb5_error_code
+get_cred(krb5_context      context,
+	 krb5_ccache       ccache,
+	 krb5_creds	   *creds,
+	 krb5_flags        flags,
+	 const char        *hostname,
+	 krb5_creds        **out_creds)
+{
+    krb5_error_code ret;
+    krb5_kdc_flags kdc_flags;
+    krb5_addresses addrs;
+
     addrs.len = 0;
     addrs.val = NULL;
+    ret = get_addresses(context, ccache, creds, hostname, &addrs);
+    if (ret)
+	return ret;
 
-    ret = krb5_get_credentials(context, 0, ccache, in_creds, &ticket);
-    if(ret == 0) {
-	if (ticket->addresses.len)
-	    paddrs = &addrs;
-	krb5_free_creds (context, ticket);
-    } else {
-	krb5_boolean noaddr;
-	krb5_appdefault_boolean(context, NULL,
-				krb5_principal_get_realm(context,
-							 in_creds->client),
-				"no-addresses", KRB5_ADDRESSLESS_DEFAULT,
-				&noaddr);
-	if (!noaddr)
-	    paddrs = &addrs;
+    kdc_flags.b = int2KDCOptions(flags);
+    ret = krb5_get_kdc_cred(context, ccache, kdc_flags, &addrs, NULL,
+			    creds, out_creds);
+
+    krb5_free_addresses(context, &addrs);
+    return ret;
+}
+
+static krb5_error_code
+set_tgs_creds(krb5_context		context,
+	      krb5_ccache		ccache,
+	      krb5_const_principal	client,
+	      krb5_const_principal	server,
+	      krb5_creds		*creds)
+{
+    krb5_error_code ret;
+    krb5_const_realm client_realm;
+    krb5_const_realm server_realm;
+    krb5_boolean fwd_dest_tgt;
+    krb5_creds *client_tgt;
+
+    client_realm = krb5_principal_get_realm(context, client);
+    server_realm = krb5_principal_get_realm(context, server);
+
+    memset (creds, 0, sizeof(*creds));
+    ret = krb5_copy_principal(context, client, &creds->client);
+    if (ret)
+	return ret;
+    ret = krb5_make_principal(context, &creds->server, client_realm,
+			      KRB5_TGS_NAME, client_realm, NULL);
+    if (ret) {
+	krb5_free_principal(context, creds->client);
+	return ret;
     }
 
     /*
-     * If tickets have addresses, get the address of the remote host.
+     * Optionally delegate a TGT for the server's realm, rather than
+     * the client's. Do this also when we don't have a client realm TGT.
+     *
+     * XXX: Note, when we have a start-realm, and delegate-destination-tgt
+     * is not set, we must use the start-realm.
      */
+    krb5_appdefault_boolean(context, NULL, server_realm,
+			    "delegate-destination-tgt", FALSE, &fwd_dest_tgt);
 
-    if (paddrs != NULL) {
-
-	ret = getaddrinfo (hostname, NULL, NULL, &ai);
-	if (ret) {
-	    krb5_error_code ret2 = krb5_eai_to_heim_errno(ret, errno);
-	    krb5_set_error_message(context, ret2,
-				   N_("resolving host %s failed: %s",
-				      "hostname, error"),
-				  hostname, gai_strerror(ret));
-	    return ret2;
-	}
-
-	ret = add_addrs (context, &addrs, ai);
-	freeaddrinfo (ai);
-	if (ret)
+    if (!fwd_dest_tgt) {
+	ret = krb5_get_credentials(context, KRB5_GC_CACHED, ccache, creds,
+				   &client_tgt);
+	if (ret == 0) {
+	    krb5_free_creds(context, client_tgt);
 	    return ret;
-    }
-
-    kdc_flags.b = int2KDCOptions(flags);
-
-    ret = krb5_get_kdc_cred (context,
-			     ccache,
-			     kdc_flags,
-			     paddrs,
-			     NULL,
-			     in_creds,
-			     &out_creds);
-    krb5_free_addresses (context, &addrs);
-    if (ret)
-	return ret;
-
-    memset (&cred, 0, sizeof(cred));
-    cred.pvno = 5;
-    cred.msg_type = krb_cred;
-    ALLOC_SEQ(&cred.tickets, 1);
-    if (cred.tickets.val == NULL) {
-	ret = krb5_enomem(context);
-	goto out2;
-    }
-    ret = decode_Ticket(out_creds->ticket.data,
-			out_creds->ticket.length,
-			cred.tickets.val, &len);
-    if (ret)
-	goto out3;
-
-    memset (&enc_krb_cred_part, 0, sizeof(enc_krb_cred_part));
-    ALLOC_SEQ(&enc_krb_cred_part.ticket_info, 1);
-    if (enc_krb_cred_part.ticket_info.val == NULL) {
-	ret = krb5_enomem(context);
-	goto out4;
-    }
-
-    if (auth_context->flags & KRB5_AUTH_CONTEXT_DO_TIME) {
-	krb5_timestamp sec;
-	int32_t usec;
-
-	krb5_us_timeofday (context, &sec, &usec);
-
-	ALLOC(enc_krb_cred_part.timestamp, 1);
-	if (enc_krb_cred_part.timestamp == NULL) {
-	    ret = krb5_enomem(context);
-	    goto out4;
-	}
-	*enc_krb_cred_part.timestamp = sec;
-	ALLOC(enc_krb_cred_part.usec, 1);
-	if (enc_krb_cred_part.usec == NULL) {
-	    ret = krb5_enomem(context);
-	    goto out4;
-	}
-	*enc_krb_cred_part.usec      = usec;
-    } else {
-	enc_krb_cred_part.timestamp = NULL;
-	enc_krb_cred_part.usec = NULL;
-    }
-
-    if (auth_context->local_address && auth_context->local_port && paddrs) {
-
-	ret = krb5_make_addrport (context,
-				  &enc_krb_cred_part.s_address,
-				  auth_context->local_address,
-				  auth_context->local_port);
-	if (ret)
-	    goto out4;
-    }
-
-    if (auth_context->remote_address) {
-	if (auth_context->remote_port) {
-	    krb5_boolean noaddr;
-	    krb5_const_realm srealm;
-
-	    srealm = krb5_principal_get_realm(context, out_creds->server);
-	    /* Is this correct, and should we use the paddrs == NULL
-               trick here as well? Having an address-less ticket may
-               indicate that we don't know our own global address, but
-               it does not necessary mean that we don't know the
-               server's. */
-	    krb5_appdefault_boolean(context, NULL, srealm, "no-addresses",
-				    FALSE, &noaddr);
-	    if (!noaddr) {
-		ret = krb5_make_addrport (context,
-					  &enc_krb_cred_part.r_address,
-					  auth_context->remote_address,
-					  auth_context->remote_port);
-		if (ret)
-		    goto out4;
-	    }
-	} else {
-	    ALLOC(enc_krb_cred_part.r_address, 1);
-	    if (enc_krb_cred_part.r_address == NULL) {
-		ret = krb5_enomem(context);
-		goto out4;
-	    }
-
-	    ret = krb5_copy_address (context, auth_context->remote_address,
-				     enc_krb_cred_part.r_address);
-	    if (ret)
-		goto out4;
 	}
     }
 
-    /* fill ticket_info.val[0] */
-
-    enc_krb_cred_part.ticket_info.len = 1;
-
-    krb_cred_info = enc_krb_cred_part.ticket_info.val;
-
-    ret = copy_EncryptionKey (&out_creds->session, &krb_cred_info->key);
-    if (ret)
-	goto out4;
-    ALLOC(krb_cred_info->prealm, 1);
-    ret = copy_Realm (&out_creds->client->realm, krb_cred_info->prealm);
-    if (ret)
-	goto out4;
-    ALLOC(krb_cred_info->pname, 1);
-    ret = copy_PrincipalName(&out_creds->client->name, krb_cred_info->pname);
-    if (ret)
-	goto out4;
-    ALLOC(krb_cred_info->flags, 1);
-    *krb_cred_info->flags          = out_creds->flags.b;
-    ALLOC(krb_cred_info->authtime, 1);
-    *krb_cred_info->authtime       = out_creds->times.authtime;
-    ALLOC(krb_cred_info->starttime, 1);
-    *krb_cred_info->starttime      = out_creds->times.starttime;
-    ALLOC(krb_cred_info->endtime, 1);
-    *krb_cred_info->endtime        = out_creds->times.endtime;
-    ALLOC(krb_cred_info->renew_till, 1);
-    *krb_cred_info->renew_till = out_creds->times.renew_till;
-    ALLOC(krb_cred_info->srealm, 1);
-    ret = copy_Realm (&out_creds->server->realm, krb_cred_info->srealm);
-    if (ret)
-	goto out4;
-    ALLOC(krb_cred_info->sname, 1);
-    ret = copy_PrincipalName (&out_creds->server->name, krb_cred_info->sname);
-    if (ret)
-	goto out4;
-    ALLOC(krb_cred_info->caddr, 1);
-    ret = copy_HostAddresses (&out_creds->addresses, krb_cred_info->caddr);
-    if (ret)
-	goto out4;
-
-    krb5_free_creds (context, out_creds);
-
-    /* encode EncKrbCredPart */
-
-    ASN1_MALLOC_ENCODE(EncKrbCredPart, buf, buf_size,
-		       &enc_krb_cred_part, &len, ret);
-    free_EncKrbCredPart (&enc_krb_cred_part);
-    if (ret) {
-	free_KRB_CRED(&cred);
-	return ret;
-    }
-    if(buf_size != len)
-	krb5_abortx(context, "internal error in ASN.1 encoder");
-
-    /**
-     * Some older of the MIT gssapi library used clear-text tickets
-     * (warped inside AP-REQ encryption), use the krb5_auth_context
-     * flag KRB5_AUTH_CONTEXT_CLEAR_FORWARDED_CRED to support those
-     * tickets. The session key is used otherwise to encrypt the
-     * forwarded ticket.
+    /*
+     * Client TGT inapplicable or unavailable
      */
+    krb5_free_principal(context, creds->server);
+    creds->server = 0;
+    return krb5_make_principal(context, &creds->server, server_realm,
+			       KRB5_TGS_NAME, server_realm, NULL);
+}
 
-    if (auth_context->flags & KRB5_AUTH_CONTEXT_CLEAR_FORWARDED_CRED) {
-	cred.enc_part.etype = KRB5_ENCTYPE_NULL;
-	cred.enc_part.kvno = NULL;
-	cred.enc_part.cipher.data = buf;
-	cred.enc_part.cipher.length = buf_size;
+/*
+ * Obtain address list for hostname if server realm policy is not addressless.
+ */
+static krb5_error_code
+get_addresses(krb5_context      context,
+	      krb5_ccache       ccache,
+	      krb5_creds        *creds,
+	      const char        *hostname,
+	      krb5_addresses    *addrs)
+{
+    krb5_error_code ret;
+    krb5_creds *ticket;
+    krb5_const_realm realm;
+    krb5_boolean noaddr;
+    struct addrinfo *ai;
+    int eai;
+
+    if (hostname == 0)
+	return 0;
+
+    ret = krb5_get_credentials(context, 0, ccache, creds, &ticket);
+    if (ret == 0) {
+        noaddr = (ticket->addresses.len == 0) ? TRUE : FALSE;
+	krb5_free_creds(context, ticket);
     } else {
-	/*
-	 * Here older versions then 0.7.2 of Heimdal used the local or
-	 * remote subkey. That is wrong, the session key should be
-	 * used. Heimdal 0.7.2 and newer have code to try both in the
-	 * receiving end.
-	 */
-
-	ret = krb5_crypto_init(context, auth_context->keyblock, 0, &crypto);
-	if (ret) {
-	    free(buf);
-	    free_KRB_CRED(&cred);
-	    return ret;
-	}
-	ret = krb5_encrypt_EncryptedData (context,
-					  crypto,
-					  KRB5_KU_KRB_CRED,
-					  buf,
-					  len,
-					  0,
-					  &cred.enc_part);
-	free(buf);
-	krb5_crypto_destroy(context, crypto);
-	if (ret) {
-	    free_KRB_CRED(&cred);
-	    return ret;
-	}
+	realm = krb5_principal_get_realm(context, creds->server);
+	krb5_appdefault_boolean(context, NULL, realm, "no-addresses",
+				KRB5_ADDRESSLESS_DEFAULT, &noaddr);
     }
 
-    ASN1_MALLOC_ENCODE(KRB_CRED, buf, buf_size, &cred, &len, ret);
-    free_KRB_CRED (&cred);
-    if (ret)
+    if (noaddr)
+	return 0;
+
+    /* Need addresses, get the address of the remote host. */
+
+    eai = getaddrinfo (hostname, NULL, NULL, &ai);
+    if (eai) {
+	ret = krb5_eai_to_heim_errno(eai, errno);
+	krb5_set_error_message(context, ret,
+			       N_("resolving host %s failed: %s",
+				  "hostname, error"),
+			       hostname, gai_strerror(eai));
 	return ret;
-    if(buf_size != len)
-	krb5_abortx(context, "internal error in ASN.1 encoder");
-    out_data->length = len;
-    out_data->data   = buf;
-    return 0;
- out4:
-    free_EncKrbCredPart(&enc_krb_cred_part);
- out3:
-    free_KRB_CRED(&cred);
- out2:
-    krb5_free_creds (context, out_creds);
+    }
+
+    ret = add_addrs(context, addrs, ai);
+    freeaddrinfo(ai);
+
     return ret;
 }

--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -162,6 +162,19 @@ If a principal argument is specified, it is used as an explicit realm name for
 anonymous pkinit even without an
 .Li @
 prefix.
+.It Li delegate-destination-tgt = Va boolean
+When forwarding credentials to a remote host, forward a TGT for the
+realm of the destination host rather than a TGT for the user's realm.
+This is useful when hosts in the remote realm should not or cannot
+(e.g. firewalled from user realm's KDC) obtain tickets for services
+in the user's realm. When the user's realm and the host's realm are
+the same, this parameter has no effect.  The setting can be applied
+to a single realm as follows:
+.Bd -literal -offset indent
+EXAMPLE.COM = {
+	delegate-destination-tgt = true
+}
+.Ed
 .El
 .It Li [libdefaults]
 .Bl -tag -width "xxx" -offset indent

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -462,8 +462,10 @@ EXPORTS
 	krb5_make_addrport
 	krb5_make_principal
 	krb5_max_sockaddr_size
+	krb5_mk_1cred
 	krb5_mk_error
 	krb5_mk_error_ext
+	krb5_mk_ncred
 	krb5_mk_priv
 	krb5_mk_rep
 	krb5_mk_req

--- a/lib/krb5/mk_cred.c
+++ b/lib/krb5/mk_cred.c
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 1997 - 2004 Kungliga Tekniska Högskolan
+ * (Royal Institute of Technology, Stockholm, Sweden).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "krb5_locl.h"
+
+#define CHECKED_ALLOC(dst) do {                                 \
+            if ((ALLOC(dst, 1)) == NULL) {                      \
+                ret = krb5_enomem(context);                     \
+                goto out;                                       \
+            }                                                   \
+        } while (0)
+
+#define CHECKED_COPY(cp_func, dst, src) do {                    \
+            if (cp_func(src, dst)) {                            \
+                ret = krb5_enomem(context);                     \
+                goto out;                                       \
+            }                                                   \
+        } while (0)
+#define CHECKED_COPY_PPC2KCI(cp_func, dst, src)                 \
+        CHECKED_COPY(cp_func, krb_cred_info->dst, &ppcreds[i]->src)
+
+#define CHECKED_ALLOC_ASSIGN(dst, src) do {                     \
+            if ((ALLOC(dst, 1)) == NULL) {                      \
+                ret = krb5_enomem(context);                     \
+                goto out;                                       \
+            } else                                              \
+                *dst = src;                                     \
+        } while (0)
+#define CHECKED_ALLOC_ASSIGN_PPC2KCI(dst, src)                  \
+        CHECKED_ALLOC_ASSIGN(krb_cred_info->dst, ppcreds[i]->src)
+
+#define CHECKED_ALLOC_COPY(cp_func, dst, src) do {              \
+            if ((ALLOC(dst, 1)) == NULL || cp_func(src, dst)) { \
+                ret = krb5_enomem(context);                     \
+                goto out;                                       \
+            }                                                   \
+        } while (0)
+#define CHECKED_ALLOC_COPY_PPC2KCI(cp_func, dst, src)           \
+        CHECKED_ALLOC_COPY(cp_func, krb_cred_info->dst, &ppcreds[i]->src)
+
+/**
+ * Make a KRB-CRED PDU with N credentials.
+ *
+ * @param context A kerberos 5 context.
+ * @param auth_context The auth context with the key to encrypt the out_data.
+ * @param ppcreds A null-terminated array of credentials to forward.
+ * @param ppdata The output KRB-CRED (to be freed by caller).
+ * @param replay_data (unused).
+ *
+ * @return Return an error code or 0.
+ *
+ * @ingroup krb5_credential
+ */
+
+/* ARGSUSED */
+KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+krb5_mk_ncred(krb5_context context, krb5_auth_context auth_context,
+              krb5_creds **ppcreds, krb5_data **ppdata,
+              krb5_replay_data *replay_data)
+{
+    krb5_error_code ret;
+    krb5_data out_data;
+
+    ret = _krb5_mk_ncred(context, auth_context, ppcreds, &out_data,
+        replay_data);
+    if (ret == 0) {
+        /*
+         * MIT allocates the return structure for no good reason. We do
+         * likewise as, in this case, incompatibility is the greater evil.
+         */
+        *ppdata = calloc(1, sizeof (*ppdata));
+        if (*ppdata) {
+            **ppdata = out_data;
+        } else {
+            krb5_data_free(&out_data);
+            ret = krb5_enomem(context);
+        }
+    }
+
+    return ret;
+}
+
+/* ARGSUSED */
+KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+_krb5_mk_ncred(krb5_context context,
+               krb5_auth_context auth_context,
+               krb5_creds **ppcreds,
+               krb5_data *out_data,
+               krb5_replay_data *replay_data)
+{
+    krb5_error_code ret;
+    EncKrbCredPart enc_krb_cred_part;
+    KrbCredInfo *krb_cred_info;
+    krb5_crypto crypto;
+    KRB_CRED cred;
+    unsigned char *buf = NULL;
+    size_t ncreds, i;
+    size_t buf_size;
+    size_t len;
+
+    /*
+     * The ownership of 'buf' is re-assigned to a containing structure
+     * multiple times. We enforce an invariant, either buf is non-zero
+     * and we own it, or buf is zero and it is freed or some structure
+     * owns any storage previously allocated as 'buf'.
+     */
+#define CHOWN_BUF(x, buf) do { (x) = (buf); (buf) = 0; } while (0)
+#define DISOWN_BUF(buf) do { free(buf); (buf) = 0; } while (0)
+
+    for (ncreds = 0; ppcreds[ncreds]; ncreds++)
+        ;
+
+    memset (&cred, 0, sizeof(cred));
+    cred.pvno = 5;
+    cred.msg_type = krb_cred;
+    ALLOC_SEQ(&cred.tickets, ncreds);
+    if (cred.tickets.val == NULL) {
+        ret = krb5_enomem(context);
+        goto out;
+    }
+    memset (&enc_krb_cred_part, 0, sizeof(enc_krb_cred_part));
+    ALLOC_SEQ(&enc_krb_cred_part.ticket_info, ncreds);
+    if (enc_krb_cred_part.ticket_info.val == NULL) {
+        ret = krb5_enomem(context);
+        goto out;
+    }
+
+    for (i = 0; i < ncreds; i++) {
+        ret = decode_Ticket(ppcreds[i]->ticket.data,
+                            ppcreds[i]->ticket.length,
+                            &cred.tickets.val[i],
+                            &len);/* don't care about len */
+        if (ret)
+           goto out;
+
+        /* fill ticket_info.val[i] */
+        krb_cred_info = &enc_krb_cred_part.ticket_info.val[i];
+
+        CHECKED_COPY(copy_EncryptionKey,
+                     &krb_cred_info->key, &ppcreds[i]->session);
+        CHECKED_ALLOC_COPY_PPC2KCI(copy_Realm, prealm, client->realm);
+        CHECKED_ALLOC_COPY_PPC2KCI(copy_PrincipalName, pname, client->name);
+        CHECKED_ALLOC_ASSIGN_PPC2KCI(flags, flags.b);
+        CHECKED_ALLOC_ASSIGN_PPC2KCI(authtime, times.authtime);
+        CHECKED_ALLOC_ASSIGN_PPC2KCI(starttime, times.starttime);
+        CHECKED_ALLOC_ASSIGN_PPC2KCI(endtime, times.endtime);
+        CHECKED_ALLOC_ASSIGN_PPC2KCI(renew_till, times.renew_till);
+        CHECKED_ALLOC_COPY_PPC2KCI(copy_Realm, srealm, server->realm);
+        CHECKED_ALLOC_COPY_PPC2KCI(copy_PrincipalName, sname, server->name);
+        CHECKED_ALLOC_COPY_PPC2KCI(copy_HostAddresses, caddr, addresses);
+    }
+
+    if (auth_context->flags & KRB5_AUTH_CONTEXT_DO_TIME) {
+        krb5_timestamp sec;
+        int32_t usec;
+
+        krb5_us_timeofday (context, &sec, &usec);
+
+        CHECKED_ALLOC_ASSIGN(enc_krb_cred_part.timestamp, sec);
+        CHECKED_ALLOC_ASSIGN(enc_krb_cred_part.usec, usec);
+    } else {
+        enc_krb_cred_part.timestamp = NULL;
+        enc_krb_cred_part.usec = NULL;
+        /* XXX Er, shouldn't we set the seq nums?? */
+    }
+
+    /* XXX: Is this needed? */
+    if (auth_context->local_address && auth_context->local_port) {
+        ret = krb5_make_addrport(context,
+                                 &enc_krb_cred_part.s_address,
+                                 auth_context->local_address,
+                                 auth_context->local_port);
+        if (ret)
+            goto out;
+    }
+
+    /* XXX: Is this needed? */
+    if (auth_context->remote_address) {
+        if (auth_context->remote_port) {
+            /*
+             * XXX: Should we be checking "no-addresses" for
+             * the receiving realm?
+             */
+            ret = krb5_make_addrport(context,
+                                     &enc_krb_cred_part.r_address,
+                                     auth_context->remote_address,
+                                     auth_context->remote_port);
+            if (ret)
+                goto out;
+        } else {
+            /*
+             * XXX Ugly, make krb5_make_addrport() handle missing port
+             * number (i.e., port == 0), then remove this else.
+             */
+            CHECKED_ALLOC(enc_krb_cred_part.r_address);
+            ret = krb5_copy_address(context, auth_context->remote_address,
+                                    enc_krb_cred_part.r_address);
+            if (ret)
+                goto out;
+        }
+    }
+
+    /* encode EncKrbCredPart */
+    ASN1_MALLOC_ENCODE(EncKrbCredPart, buf, buf_size,
+                       &enc_krb_cred_part, &len, ret);
+    if (ret)
+        goto out;
+
+    /**
+     * Some older of the MIT gssapi library used clear-text tickets
+     * (warped inside AP-REQ encryption), use the krb5_auth_context
+     * flag KRB5_AUTH_CONTEXT_CLEAR_FORWARDED_CRED to support those
+     * tickets. The session key is used otherwise to encrypt the
+     * forwarded ticket.
+     */
+
+    if (auth_context->flags & KRB5_AUTH_CONTEXT_CLEAR_FORWARDED_CRED) {
+        cred.enc_part.etype = KRB5_ENCTYPE_NULL;
+        cred.enc_part.kvno = NULL;
+        CHOWN_BUF(cred.enc_part.cipher.data, buf);
+        cred.enc_part.cipher.length = buf_size;
+    } else {
+        /*
+         * Here older versions then 0.7.2 of Heimdal used the local or
+         * remote subkey. That is wrong, the session key should be
+         * used. Heimdal 0.7.2 and newer have code to try both in the
+         * receiving end.
+         */
+
+        ret = krb5_crypto_init(context, auth_context->keyblock, 0, &crypto);
+        if (ret)
+            goto out;
+        ret = krb5_encrypt_EncryptedData(context,
+                                         crypto,
+                                         KRB5_KU_KRB_CRED,
+                                         buf,
+                                         len,
+                                         0,
+                                         &cred.enc_part);
+        DISOWN_BUF(buf);
+        krb5_crypto_destroy(context, crypto);
+    }
+
+    ASN1_MALLOC_ENCODE(KRB_CRED, buf, buf_size, &cred, &len, ret);
+    if (ret)
+        goto out;
+
+    CHOWN_BUF(out_data->data, buf);
+    out_data->length = len;
+    ret = 0;
+
+ out:
+    free_EncKrbCredPart(&enc_krb_cred_part);
+    free_KRB_CRED(&cred);
+    free(buf);
+    return ret;
+}
+
+/**
+ * Make a KRB-CRED PDU with 1 credential.
+ *
+ * @param context A kerberos 5 context.
+ * @param auth_context The auth context with the key to encrypt the out_data.
+ * @param ppcred A credential to forward.
+ * @param ppdata The output KRB-CRED (to be freed by caller).
+ * @param replay_data (unused).
+ *
+ * @return Return an error code or 0.
+ *
+ * @ingroup krb5_credential
+ */
+
+/* ARGSUSED */
+KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+krb5_mk_1cred(krb5_context context, krb5_auth_context auth_context,
+              krb5_creds *ppcred, krb5_data **ppdata,
+              krb5_replay_data *replay_data)
+{
+    krb5_creds *ppcreds[2] = { ppcred, NULL };
+
+    return krb5_mk_ncred(context, auth_context, ppcreds, ppdata, replay_data);
+}
+
+/* ARGSUSED */
+KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+_krb5_mk_1cred(krb5_context context, krb5_auth_context auth_context,
+               krb5_creds *ppcred, krb5_data *ppdata,
+               krb5_replay_data *replay_data)
+{
+    krb5_creds *ppcreds[2] = { ppcred, NULL };
+
+    return _krb5_mk_ncred(context, auth_context, ppcreds, ppdata, replay_data);
+}

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -451,8 +451,10 @@ HEIMDAL_KRB5_2.0 {
 		krb5_make_addrport;
 		krb5_make_principal;
 		krb5_max_sockaddr_size;
+		krb5_mk_1cred;
 		krb5_mk_error;
 		krb5_mk_error_ext;
+		krb5_mk_ncred;
 		krb5_mk_priv;
 		krb5_mk_rep;
 		krb5_mk_req;


### PR DESCRIPTION
This allows you to configure (in `/etc/krb5.conf`) that certain realms will "delegate-destination-tgt".  That is, rather than delegating a full TGT of the form krbtgt/START@START, you delegate a TGT of the form krbtgt/DEST@DEST. The interesting thing here is that the destination realm becomes a bit like the hotel california because you can't come back to the original realm as that will violate its transited policy.

This functionality works well for DMZ realms and the like where you want to allow access---and you want to be able to delegate creds which people can use to continue to SSH around in the DMZ, but you do not want them to be able to SSH back into the main environment.