### PR TITLE
derived keys: ensure that princ is correct

### DIFF
--- a/kdc/misc.c
+++ b/kdc/misc.c
@@ -218,6 +218,8 @@ _fetch_it(krb5_context context, krb5_kdc_configuration *config, HDB *db,
 	log_princ(context, config, 7, "    for %s", princ);
 	log_princ(context, config, 7, "    from %s", tmpprinc);
 	_derive_the_keys(context, config, princ, kvno, ent);
+	/* the next function frees the target */
+	copy_Principal(princ, ent->entry.principal);
     }
 
     free(host);


### PR DESCRIPTION
We copy the princ in the hdb_entry so that if it is later used, it
will reflect what we want.