### PR TITLE
Strftime expand tokens

### DIFF
--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -678,7 +678,10 @@ typedef struct {
 
 extern const char *heimdal_version, *heimdal_long_version;
 
-typedef void (KRB5_CALLCONV * krb5_log_log_func_t)(const char*, const char*, void*);
+typedef void (KRB5_CALLCONV * krb5_log_log_func_t)(krb5_context,
+						   const char*,
+						   const char*,
+						   void*);
 typedef void (KRB5_CALLCONV * krb5_log_close_func_t)(void*);
 
 typedef struct krb5_log_facility {

--- a/lib/krb5/krb5_openlog.3
+++ b/lib/krb5/krb5_openlog.3
@@ -161,13 +161,24 @@ follows:
 .Bl -tag -width "xxx" -offset indent
 .It Li STDERR
 This logs to the program's stderr.
+.It Li EFILE: Ns Pa /file
+Log to the specified file if it exists, otherwise do nothing.
+All writes will be appended to the end of the file and the file
+will be re-opened for each new write.
+Non-existence of the file is cached for 1 second which reduces
+the potential performance impact significantly.
+This is useful for defining a trace file which can be enabled
+without restarting a server.
 .It Li FILE: Ns Pa /file
+Log to the specified file.
+All writes will be appended to the end of the file and the file
+will be re-opened for each new write.
 .It Li FILE= Ns Pa /file
-Log to the specified file. The form using a colon appends to the file, the
-form with an equal truncates the file. The truncating form keeps the file
-open, while the appending form closes it after each log message (which
-makes it possible to rotate logs). The truncating form is mainly for
-compatibility with the MIT libkrb5.
+On the first write, this form will
+.Xr truncate 2
+the file and then append all subsequent messages whilst keeping the
+file descriptor open.
+This form is mainly for compatibility with MIT libkrb5.
 .It Li DEVICE= Ns Pa /device
 This logs to the specified device, at present this is the same as
 .Li FILE:/device .
@@ -255,6 +266,7 @@ and facility
 .Bd -literal -offset indent
 [logging]
 	kdc = FILE:/var/log/kdc-%{strftime:%Y%m%d%H}
+	kdc = 4-/EFILE:/tmp/kdc-trace
 .Ed
 .Pp
 This will log all messages from the
@@ -266,6 +278,9 @@ As the file is
 .Xr open 2 ed
 each time a log message is written, this can be used to write
 automatically rotating log files.
+All of the KDC debugging messages will be written into
+.Pa /tmp/kdc-trace
+but only if it exists.
 .Sh SEE ALSO
 .Xr syslog 3 ,
 .Xr krb5.conf 5

--- a/lib/krb5/krb5_openlog.3
+++ b/lib/krb5/krb5_openlog.3
@@ -207,6 +207,16 @@ omitted, in this case min is assumed to be 0, and max is assumed to
 be 3.
 If you don't include a dash, both min and max get set to the
 specified value.
+.Pp
+The paths specified are subject to token expansion.
+For the purposes of logging, the most interesting token
+expansion is
+.ar %{strftime:<string>}
+which calls
+.Xr strftime 3
+on
+.Ar <string>
+with the localised current time of day.
 .Ss Levels
 Each log message has a level as follows:
 .Bl -tag -width "xxx" -offset indent
@@ -242,7 +252,20 @@ other messages will be logged to syslog with priority
 .Li LOG_INFO ,
 and facility
 .Li LOG_USER .
-All other programs will log all messages to their stderr.
+.Bd -literal -offset indent
+[logging]
+	kdc = FILE:/var/log/kdc-%{strftime:%Y%m%d%H}
+.Ed
+.Pp
+This will log all messages from the
+.Nm kdc
+program with level 0 to 3 (inclusively) to a file whose
+name is generated using
+.Xr strftime 3 .
+As the file is
+.Xr open 2 ed
+each time a log message is written, this can be used to write
+automatically rotating log files.
 .Sh SEE ALSO
 .Xr syslog 3 ,
 .Xr krb5.conf 5


### PR DESCRIPTION
So, here we define %{strftime:<string>} in our path expansion routines and then subject logging file definitions to token expansion. Now, we can do something like this:

[kdc]
        kdc = FILE:/var/log/auth/%{strftime:%Y%m%d%H}

for nice automatically rolling over logs.