### PR TITLE
include <sys/exec_elf.h> if it's available.

### DIFF
--- a/cf/roken-frag.m4
+++ b/cf/roken-frag.m4
@@ -75,6 +75,7 @@ AC_CHECK_HEADERS([\
 	sys/auxv.h				\
 	sys/bswap.h				\
 	sys/errno.h				\
+	sys/exec_elf.h				\
 	sys/ioctl.h				\
 	sys/mman.h				\
 	sys/param.h				\

--- a/lib/roken/getauxval.h
+++ b/lib/roken/getauxval.h
@@ -40,6 +40,10 @@
 #include <sys/auxv.h>
 #endif
 
+#ifdef HAVE_SYS_EXEC_ELF_H
+#include <sys/exec_elf.h>
+#endif
+
 #ifndef HAVE_AUXV_T
 /*
  * Illumos defines auxv_t per the ABI standards, but all other OSes seem


### PR DESCRIPTION
This fixes the auxval logic on NetBSD.