### PR TITLE
Declare variables at the beginning of a block.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -383,6 +383,7 @@ tags
 /lib/roken/strpftime-test
 /lib/roken/test-auxval
 /lib/roken/test-detach
+/lib/roken/test-getuserinfo
 /lib/roken/test-readenv
 /lib/roken/tsearch-test
 /lib/roken/vis.h
@@ -453,9 +454,9 @@ tags
 /tests/gss/current-db.db
 /tests/gss/foopassword
 /tests/gss/krb5.conf
-/tests/gss/krb5ccfile
-/tests/gss/krb5ccfile2
-/tests/gss/krb5ccfile-ds
+/tests/gss/krb5ccfile*
+/tests/gss/krb5ccfile2*
+/tests/gss/krb5ccfile-ds*
 /tests/gss/server.keytab
 /tests/gss/tempfile
 /tests/java/KerberosInit$1.class
@@ -467,10 +468,12 @@ tags
 /tests/java/jgssapi_server.class
 /tests/java/server.keytab
 /tests/java/krb5.conf
-/tests/kdc/acache.krb5
+/tests/kdc/acache.krb5*
 /tests/kdc/barpassword
 /tests/kdc/ca.crt
-/tests/kdc/cache.krb5
+/tests/kdc/cache.krb5*
+/tests/kdc/cache1.krb5*
+/tests/kdc/cache2.krb5*
 /tests/kdc/cdigest-reply
 /tests/kdc/check-authz
 /tests/kdc/check-canon
@@ -513,6 +516,8 @@ tags
 /tests/kdc/krb5.conf
 /tests/kdc/krb5-cc.conf
 /tests/kdc/krb5.conf.keys
+/tests/kdc/kx509-template.crt
+/tests/kdc/kx509.pem
 /tests/kdc/localname
 /tests/kdc/notfoopassword
 /tests/kdc/o2cache.krb5
@@ -533,6 +538,7 @@ tags
 /tests/ldap/check-ldap
 /tests/ldap/krb5.conf
 /tests/ldap/slapd-init
+/tests/plugin/cache.krb5*
 /tests/plugin/check-pac
 /tests/plugin/current-db.db
 /tests/plugin/foopassword

--- a/NTMakefile
+++ b/NTMakefile
@@ -34,7 +34,7 @@ thirdparty=thirdparty
 !endif
 
 !ifdef APPVEYOR
-SUBDIRS = include lib kuser kdc admin kadmin kpasswd appl doc \
+SUBDIRS = include lib kuser kdc admin kadmin kpasswd appl \
 	tools tests packages etc
 !else
 SUBDIRS = include lib kuser kdc admin kadmin kpasswd appl doc \

--- a/cf/w32-check-exported-symbols.pl
+++ b/cf/w32-check-exported-symbols.pl
@@ -60,7 +60,7 @@ while(<$vs>)
 {
     next unless m/^([^#]+)/;
 
-    @a = split(/\s+|({|})/,$1);
+    @a = split(/\s+|(\{|})/,$1);
 
     for $f (@a) {
 	given ($f) {

--- a/lib/hx509/hxtool.c
+++ b/lib/hx509/hxtool.c
@@ -2504,9 +2504,9 @@ acert1_sans(struct acert_options *opt,
             }
         } else if (gn->element == choice_GeneralName_registeredID) {
             for (k = 0; k < opt->has_registeredID_san_strings.num_strings; k++) {
-                s = opt->has_registeredID_san_strings.strings[k];
                 heim_oid oid;
 
+                s = opt->has_registeredID_san_strings.strings[k];
                 memset(&oid, 0, sizeof(oid));
                 if ((ret = der_parse_heim_oid(s, NULL, &oid)))
                     break;
@@ -2854,6 +2854,7 @@ int
 acert(struct acert_options *opt, int argc, char **argv)
 {
     hx509_cursor cursor = NULL;
+    hx509_query *q = NULL;
     hx509_certs certs = NULL;
     hx509_cert cert = NULL;
     size_t n = 0;
@@ -2871,7 +2872,6 @@ acert(struct acert_options *opt, int argc, char **argv)
         hx509_err(context, 1, ret, "Could not load certificates from %s",
                   argv[0]);
 
-    hx509_query *q = NULL;
     if (opt->expr_string) {
         if ((ret = hx509_query_alloc(context, &q)))
             hx509_err(context, 1, ret, "Could not initialize query");

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -438,7 +438,6 @@ EXPORTS
 	krb5_kt_resolve
 	krb5_kt_start_seq_get
 	krb5_kuserok
-        krb5_kx509
 	krb5_kx509
         krb5_kx509_ctx_add_auth_data
         krb5_kx509_ctx_add_eku
@@ -448,14 +447,11 @@ EXPORTS
         krb5_kx509_ctx_add_san_registeredID
         krb5_kx509_ctx_add_san_rfc822Name
         krb5_kx509_ctx_add_san_xmpp
-        krb5_kx509_ctx_free
 	krb5_kx509_ctx_free
-        krb5_kx509_ctx_init
 	krb5_kx509_ctx_init
 	krb5_kx509_ctx_set_csr_der
 	krb5_kx509_ctx_set_key
 	krb5_kx509_ctx_set_realm
-        krb5_kx509_ext
 	krb5_kx509_ext
 	krb5_log
 	krb5_log_msg

--- a/lib/krb5/test_cc.c
+++ b/lib/krb5/test_cc.c
@@ -40,6 +40,8 @@
  *      $ keyctl new_session
  */
 
+#ifndef WIN32
+
 #include "krb5_locl.h"
 #include <getarg.h>
 #include <err.h>
@@ -866,3 +868,12 @@ main(int argc, char **argv)
 
     return 0;
 }
+
+#else
+int
+main(int argc, char **argv)
+{
+
+    return 0;
+}
+#endif

--- a/lib/roken/test-detach.c
+++ b/lib/roken/test-detach.c
@@ -50,6 +50,11 @@
 
 int main(int argc, char **argv)
 {
+/*
+ * XXXrcd: let's see how much further the tests get when we disable this
+ *         on Windows.
+ */
+#ifndef WIN32
     char *ends;
     long n;
     int fd = -1;
@@ -89,4 +94,7 @@ int main(int argc, char **argv)
     sleep(5);
     fprintf(stderr, "Daemon child done\n");
     return 0;
+#else
+    return 0;
+#endif
 }


### PR DESCRIPTION
Looks like this partially fixes the Appveyor build.

We now need to fix the building of the documentation. It's missing a Perl module at the moment, which is likely just a tweak to Appveyor @jaltman? Or alternately, we could change appveyor to pass `--disable-heimdal-documentation` to `./configure`. This should fix the build as the documentation is the last thing to build---and we are getting there.