### PR TITLE
Add enforce_ok_as_delegate setting

### DIFF
--- a/lib/gssapi/krb5/init_sec_context.c
+++ b/lib/gssapi/krb5/init_sec_context.c
@@ -488,6 +488,17 @@ init_auth_restart
     *minor_status = 0;
 
     /*
+     * Check if our configuration requires us to follow the KDC's
+     * guidance.  If so, we transmogrify the GSS_C_DELEG_FLAG into
+     * the GSS_C_DELEG_POLICY_FLAG.
+     */
+    if ((context->flags & KRB5_CTX_F_ENFORCE_OK_AS_DELEGATE)
+	&& (req_flags & GSS_C_DELEG_FLAG)) {
+        req_flags &= ~GSS_C_DELEG_FLAG;
+        req_flags |= GSS_C_DELEG_POLICY_FLAG;
+    }
+
+    /*
      * If the credential doesn't have ok-as-delegate, check if there
      * is a realm setting and use that.
      */

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -234,6 +234,7 @@ init_context_from_config_file(krb5_context context)
     INIT_FIELD(context, int, max_msg_size, 1000 * 1024, "maximum_message_size");
     INIT_FLAG(context, flags, KRB5_CTX_F_DNS_CANONICALIZE_HOSTNAME, TRUE, "dns_canonicalize_hostname");
     INIT_FLAG(context, flags, KRB5_CTX_F_CHECK_PAC, TRUE, "check_pac");
+    INIT_FLAG(context, flags, KRB5_CTX_F_ENFORCE_OK_AS_DELEGATE, FALSE, "enforce_ok_as_delegate");
 
     if (context->default_cc_name)
 	free(context->default_cc_name);

--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -232,6 +232,16 @@ See the TOKEN EXPANSION section.
 Use DNS SRV records to lookup KDC services location.
 .It Li dns_lookup_realm = Va boolean
 Use DNS TXT records to lookup domain to realm mappings.
+.It Li enforce_ok_as_delegate = Va boolean
+If this flag to true, GSSAPI credential delegation will be
+disabled when the 
+.Ar ok-as-delegate
+flag is not set in the service ticket.
+If this flag is false, the 
+.Ar ok-as-delegate
+ticket flag is only enforced when an application specifically
+requests enforcement.
+The default value is false.
 .It Li kdc_timesync = Va boolean
 Try to keep track of the time differential between the local machine
 and the KDC, and then compensate for that when issuing requests.

--- a/lib/krb5/krb5_locl.h
+++ b/lib/krb5/krb5_locl.h
@@ -286,6 +286,7 @@ typedef struct krb5_context_data {
 #define KRB5_CTX_F_SOCKETS_INITIALIZED          8
 #define KRB5_CTX_F_RD_REQ_IGNORE		16
 #define KRB5_CTX_F_FCACHE_STRICT_CHECKING	32
+#define KRB5_CTX_F_ENFORCE_OK_AS_DELEGATE	64
     struct send_to_kdc *send_to_kdc;
 #ifdef PKINIT
     hx509_context hx509ctx;


### PR DESCRIPTION
If this flag is set to true, then GSSAPI credential delegation will
be disabled when the "ok-as-delegate" flag is not set in the service
ticket.