### PR TITLE
Windows: Fix type cast warning.

### DIFF
--- a/lib/hcrypto/rand-w32.c
+++ b/lib/hcrypto/rand-w32.c
@@ -47,9 +47,9 @@ static HCRYPTPROV
 _hc_CryptProvider(void)
 {
     BOOL rv;
-    HCRYPTPROV cryptprovider = (HCRYPTPROV)NULL;
+    HCRYPTPROV cryptprovider = (HCRYPTPROV)0;
 
-    if (g_cryptprovider != (HCRYPTPROV)NULL)
+    if (g_cryptprovider)
 	goto out;
 
     rv = CryptAcquireContext(&cryptprovider, NULL,

--- a/lib/hcrypto/rand-w32.c
+++ b/lib/hcrypto/rand-w32.c
@@ -41,15 +41,15 @@
 
 #include "randi.h"
 
-volatile static HCRYPTPROV g_cryptprovider = NULL;
+volatile static HCRYPTPROV g_cryptprovider;
 
 static HCRYPTPROV
 _hc_CryptProvider(void)
 {
     BOOL rv;
-    HCRYPTPROV cryptprovider = NULL;
+    HCRYPTPROV cryptprovider = (HCRYPTPROV)NULL;
 
-    if (g_cryptprovider != NULL)
+    if (g_cryptprovider != (HCRYPTPROV)NULL)
 	goto out;
 
     rv = CryptAcquireContext(&cryptprovider, NULL,


### PR DESCRIPTION
Since at least SDK V6.1 HCRYPTPROV has been specified as ULONG_PTR
this means that comparing one with NULL causes a cast warning.

Fix this by introducing an explicit NULL_HCRYPTPROV.