### PR TITLE
Add in the ability to query the cert's RFC822 Name.

### DIFF
--- a/lib/hx509/libhx509-exports.def
+++ b/lib/hx509/libhx509-exports.def
@@ -94,6 +94,8 @@ EXPORTS
 	hx509_cert_check_eku
 	hx509_cert_cmp
 	hx509_cert_find_subjectAltName_otherName
+	hx509_cert_find_subjectAltName_heim_ia5_string
+	hx509_cert_find_subjectAltName_rfc822Name
 	hx509_cert_free
 	hx509_cert_get_SPKI
 	hx509_cert_get_SPKI_AlgorithmIdentifier


### PR DESCRIPTION
Also add in the ability to find any heim_ia5_string fields in the certificate's subjectAlternativeName.