### PR TITLE
Make the FILE ccache type a collection type!

### DIFF
--- a/kuser/kinit.1
+++ b/kuser/kinit.1
@@ -100,6 +100,10 @@ Supported options:
 .It Fl c Ar cachename Fl Fl cache= Ns Ar cachename
 The credentials cache to put the acquired ticket in, if other than
 default.
+.It Fl Fl cache-default-for
+Use a cache in the default collection (for the default cache type)
+named after the client principal.  This is useful for users with
+multiple client principals.
 .It Fl f Fl Fl forwardable
 Obtain a ticket than can be forwarded to another host.
 .It Fl F Fl Fl no-forwardable

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -56,6 +56,7 @@ int validate_flag	= 0;
 int version_flag	= 0;
 int help_flag		= 0;
 int addrs_flag		= -1;
+int default_for_flag	= -1;
 struct getarg_strings extra_addresses;
 int anonymous_flag	= 0;
 char *lifetime 		= NULL;
@@ -107,6 +108,9 @@ static struct getargs args[] = {
 
     { "cache", 		'c', arg_string, &cred_cache,
       NP_("credentials cache", ""), "cachename" },
+
+    { "cache-default-for"  , 0, arg_flag, &default_for_flag,
+      NP_("name cache after client principal", ""), NULL },
 
     { "forwardable",	'F', arg_negative_flag, &forwardable_flag,
       NP_("get tickets not forwardable", ""), NULL },
@@ -1475,9 +1479,11 @@ main(int argc, char **argv)
 				krb5_principal_get_realm(context, principal),
 				"afslog", TRUE, &do_afslog);
 
-    if (cred_cache)
+    if (cred_cache) {
 	ret = krb5_cc_resolve(context, cred_cache, &ccache);
-    else {
+    } else if (default_for_flag) {
+        ret = krb5_cc_default_for(context, principal, &ccache);
+    } else {
 	if (argc > 1) {
 	    char s[1024];
 	    ret = krb5_cc_new_unique(context, NULL, NULL, &ccache);

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -1316,12 +1316,65 @@ get_princ_kt(krb5_context context,
     free(def_realm);
 }
 
+static krb5_error_code
+get_switched_ccache(krb5_context context,
+		    const char * type,
+		    krb5_principal principal,
+		    krb5_ccache *ccache)
+{
+    krb5_error_code ret;
+
+#ifdef _WIN32
+    if (strcmp(type, "API") == 0) {
+	/*
+	 * Windows stores the default ccache name in the
+	 * registry which is shared across multiple logon
+	 * sessions for the same user.  The API credential
+	 * cache provides a unique name space per logon
+	 * session.  Therefore there is no need to generate
+	 * a unique ccache name.  Instead use the principal
+	 * name.  This provides a friendlier user experience.
+	 */
+	char * unparsed_name;
+	char * cred_cache;
+
+	ret = krb5_unparse_name(context, principal,
+				&unparsed_name);
+	if (ret)
+	    krb5_err(context, 1, ret,
+		     N_("unparsing principal name", ""));
+
+	ret = asprintf(&cred_cache, "API:%s", unparsed_name);
+	krb5_free_unparsed_name(context, unparsed_name);
+	if (ret == -1 || cred_cache == NULL)
+	    krb5_err(context, 1, ret,
+		      N_("building credential cache name", ""));
+
+	ret = krb5_cc_resolve(context, cred_cache, ccache);
+	free(cred_cache);
+    } else if (strcmp(type, "MSLSA") == 0) {
+	/*
+	 * The Windows MSLSA cache when it is writeable
+	 * stores tickets for multiple client principals
+	 * in a single credential cache.
+	 */
+	ret = krb5_cc_resolve(context, "MSLSA:", ccache);
+    } else {
+	ret = krb5_cc_new_unique(context, type, NULL, ccache);
+    }
+#else /* !_WIN32 */
+    ret = krb5_cc_new_unique(context, type, NULL, ccache);
+#endif /* _WIN32 */
+
+    return ret;
+}
+
 int
 main(int argc, char **argv)
 {
     krb5_error_code ret;
     krb5_context context;
-    krb5_ccache  ccache = NULL;
+    krb5_ccache  ccache;
     krb5_principal principal = NULL;
     int optidx = 0;
     krb5_deltat ticket_life = 0;
@@ -1424,8 +1477,42 @@ main(int argc, char **argv)
 
     if (cred_cache)
 	ret = krb5_cc_resolve(context, cred_cache, &ccache);
-    else
-        ret = krb5_cc_default_for(context, principal, &ccache);
+    else {
+	if (argc > 1) {
+	    char s[1024];
+	    ret = krb5_cc_new_unique(context, NULL, NULL, &ccache);
+	    if (ret)
+		krb5_err(context, 1, ret, "creating cred cache");
+	    snprintf(s, sizeof(s), "%s:%s",
+		     krb5_cc_get_type(context, ccache),
+		     krb5_cc_get_name(context, ccache));
+	    setenv("KRB5CCNAME", s, 1);
+	    unique_ccache = TRUE;
+	} else {
+	    ret = krb5_cc_cache_match(context, principal, &ccache);
+	    if (ret) {
+		const char *type;
+		ret = krb5_cc_default(context, &ccache);
+		if (ret)
+		    krb5_err(context, 1, ret,
+			     N_("resolving credentials cache", ""));
+
+		/*
+		 * Check if the type support switching, and we do,
+		 * then do that instead over overwriting the current
+		 * default credential
+		 */
+		type = krb5_cc_get_type(context, ccache);
+		if (krb5_cc_support_switch(context, type)) {
+		    krb5_cc_close(context, ccache);
+		    ret = get_switched_ccache(context, type, principal,
+					      &ccache);
+		    if (ret == 0)
+			unique_ccache = TRUE;
+		}
+	    }
+	}
+    }
     if (ret)
 	krb5_err(context, 1, ret, N_("resolving credentials cache", ""));
 

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -56,7 +56,7 @@ int validate_flag	= 0;
 int version_flag	= 0;
 int help_flag		= 0;
 int addrs_flag		= -1;
-int default_for_flag	= -1;
+int default_for_flag	= 0;
 struct getarg_strings extra_addresses;
 int anonymous_flag	= 0;
 char *lifetime 		= NULL;

--- a/lib/base/config_reg.c
+++ b/lib/base/config_reg.c
@@ -90,9 +90,8 @@ heim_store_string_to_reg_value(heim_context context,
                                const char *separator)
 {
     LONG        rcode;
-    DWORD       dwData;
+    int         dwData;
     BYTE        static_buffer[16384];
-    BYTE        *pbuffer = &static_buffer[0];
 
     if (data == NULL)
     {

--- a/lib/gssapi/gssapi/gssapi.h
+++ b/lib/gssapi/gssapi/gssapi.h
@@ -1231,7 +1231,7 @@ gss_release_cred_by_mech(
 GSSAPI_LIB_FUNCTION void GSSAPI_LIB_CALL
 gss_set_log_function(void *ctx, void (*func)(void * ctx, int level, const char *fmt, va_list));
 
-GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_FUNCTION
+GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
 gss_destroy_cred(OM_uint32 *minor_status,
 		 gss_cred_id_t *cred_handle);
 

--- a/lib/gssapi/krb5/store_cred.c
+++ b/lib/gssapi/krb5/store_cred.c
@@ -143,7 +143,6 @@ _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
     const char *cs_app_name = NULL;
     OM_uint32 major_status, junk;
     OM_uint32 overwrite_cred = store_cred_flags & GSS_C_STORE_CRED_OVERWRITE;
-    OM_uint32 default_cred = store_cred_flags & GSS_C_STORE_CRED_DEFAULT;
 
     *minor_status = 0;
 
@@ -212,11 +211,9 @@ _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
      *  - the default ccache
      */
     if (cs_ccache_name) {
-        default_cred = 0;
         ret = krb5_cc_resolve(context, cs_ccache_name, &id);
     } else if (cs_unique_ccache) {
         overwrite_cred = 1;
-        default_cred = 0;
         ret = krb5_cc_new_unique(context, cs_unique_ccache, NULL, &id);
     } else if (principal_is_best_for_user(context, cs_app_name,
                                           input_cred->principal,
@@ -254,8 +251,6 @@ _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
     if (ret == 0)
         ret = krb5_cc_copy_match_f(context, input_cred->ccache, id, NULL, NULL,
                                    NULL);
-    if (ret == 0 && default_cred)
-        krb5_cc_switch(context, id);
 
     if ((store_cred_flags & GSS_C_STORE_CRED_SET_PROCESS) && envp == NULL)
         envp = &env;

--- a/lib/gssapi/krb5/store_cred.c
+++ b/lib/gssapi/krb5/store_cred.c
@@ -160,7 +160,9 @@ _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
 	return GSS_S_NO_CRED;
     }
 
-    if (cs_ccache_name) {
+    if (cs_ccache_name && strcmp(cs_ccache_name, "unique") == 0) {
+        ret = krb5_cc_new_unique(context, NULL, NULL, &id);
+    } else if (cs_ccache_name) {
         default_cred = 0;
         ret = krb5_cc_resolve(context, cs_ccache_name, &id);
     } else {

--- a/lib/gssapi/krb5/store_cred.c
+++ b/lib/gssapi/krb5/store_cred.c
@@ -89,6 +89,35 @@ set_proc(OM_uint32 *minor, gss_buffer_set_t env)
     return GSS_S_COMPLETE;
 }
 
+/*
+ * A principal is the best principal for a user IFF
+ *
+ *  - it has one component
+ *  - the one component is the same as the user's name
+ *  - the real is the user_realm from configuration
+ */
+static int
+principal_is_best_for_user(krb5_context context,
+                           const char *app,
+                           krb5_const_principal p,
+                           const char *user)
+{
+    char *user_realm;
+    int ret;
+
+    if (!user)
+        return 0;
+
+    krb5_appdefault_string(context, app, NULL, "user_realm", NULL,
+                           &user_realm);
+    ret = user_realm &&
+        krb5_principal_get_num_comp(context, p) == 0 &&
+        strcmp(user, krb5_principal_get_comp_string(context, p, 0)) == 0 &&
+        strcmp(user_realm, krb5_principal_get_realm(context, p)) == 0;
+    free(user_realm);
+    return ret;
+}
+
 OM_uint32 GSSAPI_CALLCONV
 _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
 			  gss_const_cred_id_t input_cred_handle,
@@ -107,6 +136,7 @@ _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
     time_t exp_current;
     time_t exp_new;
     gss_buffer_set_t env = GSS_C_NO_BUFFER_SET;
+    const char *cs_unique_ccache = NULL;
     const char *cs_ccache_name = NULL;
     const char *cs_user_name = NULL;
     const char *cs_app_name = NULL;
@@ -142,11 +172,12 @@ _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
     /* Extract the ccache name from the store if given */
     if (cred_store != GSS_C_NO_CRED_STORE) {
 	major_status = __gsskrb5_cred_store_find(minor_status, cred_store,
+                                                 "unique_ccache_type",
+                                                 &cs_unique_ccache);
+	if (GSS_ERROR(major_status))
+	    return major_status;
+	major_status = __gsskrb5_cred_store_find(minor_status, cred_store,
 						 "ccache", &cs_ccache_name);
-	if (major_status == GSS_S_COMPLETE && cs_ccache_name == NULL) {
-	    *minor_status = GSS_KRB5_S_G_UNKNOWN_CRED_STORE_ELEMENT;
-	    major_status = GSS_S_NO_CRED;
-	}
 	if (GSS_ERROR(major_status))
 	    return major_status;
 	major_status = __gsskrb5_cred_store_find(minor_status, cred_store,
@@ -170,15 +201,28 @@ _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
 	return GSS_S_NO_CRED;
     }
 
-    if (cs_ccache_name && strcmp(cs_ccache_name, "unique") == 0) {
-        overwrite_cred = 1;
-        default_cred = 0;
-        ret = krb5_cc_new_unique(context, NULL, NULL, &id);
-    } else if (cs_ccache_name) {
+    /*
+     * Find an appropriate ccache, which will be one of:
+     *
+     *  - the one given in the cred_store, if given
+     *  - a new unique one for some ccache type in the cred_store, if given
+     *  - a subsidiary cache named for the principal in the default collection,
+     *    if the principal is the "best principal for the user"
+     *  - the default ccache
+     */
+    if (cs_ccache_name) {
         default_cred = 0;
         ret = krb5_cc_resolve(context, cs_ccache_name, &id);
-    } else {
+    } else if (cs_unique_ccache) {
+        overwrite_cred = 1;
+        default_cred = 0;
+        ret = krb5_cc_new_unique(context, cs_unique_ccache, NULL, &id);
+    } else if (principal_is_best_for_user(context, cs_app_name,
+                                          input_cred->principal,
+                                          cs_user_name)) {
         ret = krb5_cc_default_for(context, input_cred->principal, &id);
+    } else {
+        ret = krb5_cc_default(context, &id);
     }
 
     if (ret || id == NULL) {
@@ -209,34 +253,8 @@ _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
     if (ret == 0)
         ret = krb5_cc_copy_match_f(context, input_cred->ccache, id, NULL, NULL,
                                    NULL);
-    if (ret == 0 && default_cred) {
-        char *user_realm;
-
-        krb5_appdefault_string(context, cs_app_name ? cs_app_name : "kinit",
-                               NULL, "user_realm", NULL, &user_realm);
-
-        /*
-         * Switch the new ccache to be the default IFF:
-         *
-         *  - it was requested (default_cred)
-         *  - the principal has one component
-         *  - the principal's realm is the "user_realm" if configured
-         *  - the principal's one component is the given username if given
-         */
-        if (krb5_principal_get_num_comp(context, input_cred->principal) != 1)
-            default_cred = 0;
-        if (default_cred && user_realm &&
-            strcmp(user_realm,
-                   krb5_principal_get_realm(context, input_cred->principal)))
-            default_cred = 0;
-        if (default_cred && cs_user_name &&
-            strcmp(cs_user_name,
-                   krb5_principal_get_comp_string(context,
-                                                  input_cred->principal, 0)))
-            default_cred = 0;
-        if (default_cred)
-            krb5_cc_switch(context, id);
-    }
+    if (ret == 0 && default_cred)
+        krb5_cc_switch(context, id);
 
     if ((store_cred_flags & GSS_C_STORE_CRED_SET_PROCESS) && envp == NULL)
         envp = &env;

--- a/lib/gssapi/krb5/store_cred.c
+++ b/lib/gssapi/krb5/store_cred.c
@@ -76,13 +76,13 @@ add_env(OM_uint32 *minor,
 static OM_uint32
 set_proc(OM_uint32 *minor, gss_buffer_set_t env)
 {
-    size_t i;
-
     /*
      * XXX On systems with setpag(), call setpag().  On WIN32... create a
      * session, set the access token, ...?
      */
 #ifndef WIN32
+    size_t i;
+
     for (i = 0; i < env->count; i++)
         putenv(env->elements[i].value);
 #endif

--- a/lib/gssapi/krb5/store_cred.c
+++ b/lib/gssapi/krb5/store_cred.c
@@ -102,18 +102,19 @@ principal_is_best_for_user(krb5_context context,
                            krb5_const_principal p,
                            const char *user)
 {
-    char *user_realm;
+    char *default_realm = NULL;
+    char *user_realm = NULL;
     int ret;
 
-    if (!user)
-        return 0;
-
-    krb5_appdefault_string(context, app, NULL, "user_realm", NULL,
+    (void) krb5_get_default_realm(context, &default_realm);
+    krb5_appdefault_string(context, app, NULL, "user_realm", default_realm,
                            &user_realm);
     ret = user_realm &&
         krb5_principal_get_num_comp(context, p) == 0 &&
-        strcmp(user, krb5_principal_get_comp_string(context, p, 0)) == 0 &&
-        strcmp(user_realm, krb5_principal_get_realm(context, p)) == 0;
+        strcmp(user_realm, krb5_principal_get_realm(context, p)) == 0 &&
+        (!user ||
+         strcmp(user, krb5_principal_get_comp_string(context, p, 0)) == 0);
+    free(default_realm);
     free(user_realm);
     return ret;
 }

--- a/lib/gssapi/krb5/store_cred.c
+++ b/lib/gssapi/krb5/store_cred.c
@@ -221,9 +221,9 @@ _gsskrb5_store_cred_into2(OM_uint32         *minor_status,
     } else if (principal_is_best_for_user(context, cs_app_name,
                                           input_cred->principal,
                                           cs_user_name)) {
-        ret = krb5_cc_default_for(context, input_cred->principal, &id);
-    } else {
         ret = krb5_cc_default(context, &id);
+    } else {
+        ret = krb5_cc_default_for(context, input_cred->principal, &id);
     }
 
     if (ret || id == NULL) {

--- a/lib/gssapi/mech/gss_utils.c
+++ b/lib/gssapi/mech/gss_utils.c
@@ -196,8 +196,8 @@ _gss_mg_decode_le_uint16(const void *ptr, uint16_t *n)
 void
 _gss_mg_encode_be_uint16(uint16_t n, uint8_t *p)
 {
-    p[0] = (n >> 24) & 0xFF;
-    p[1] = (n >> 16) & 0xFF;
+    p[0] = (n >> 8) & 0xFF;
+    p[1] = (n >> 0) & 0xFF;
 }
 
 void

--- a/lib/hx509/ks_file.c
+++ b/lib/hx509/ks_file.c
@@ -619,7 +619,7 @@ mk_temp(const char *fn, char **tfn)
         return -1;
     }
 
-    if (p = strrchr(ds, '\\') == NULL) {
+    if ((p = strrchr(ds, '\\')) == NULL) {
         ret = asprintf(tfn, ".%s-XXXXXX", ds); /* XXX can't happen */
     } else {
         *(p++) = '\0';

--- a/lib/hx509/name.c
+++ b/lib/hx509/name.c
@@ -368,7 +368,7 @@ dsstringprep(const DirectoryString *ds, uint32_t **rname, size_t *rlen)
 {
     wind_profile_flags flags;
     size_t i, len;
-    int ret;
+    int ret = 0;
     uint32_t *name;
 
     *rname = NULL;
@@ -418,7 +418,10 @@ dsstringprep(const DirectoryString *ds, uint32_t **rname, size_t *rlen)
     /* try a couple of times to get the length right, XXX gross */
     for (i = 0; i < 4; i++) {
 	*rlen = *rlen * 2;
-	*rname = malloc(*rlen * sizeof((*rname)[0]));
+	if ((*rname = malloc(*rlen * sizeof((*rname)[0]))) == NULL) {
+            ret = ENOMEM;
+            break;
+        }
 
 	ret = wind_stringprep(name, len, *rname, rlen, flags);
 	if (ret == WIND_ERR_OVERRUN) {

--- a/lib/hx509/req.c
+++ b/lib/hx509/req.c
@@ -636,7 +636,7 @@ hx509_request_to_pkcs10(hx509_context context,
     if (ret == 0)
         ret = get_exts(context, req, &exts);
     if (ret == 0 && exts.len) {
-        Attribute *a;
+        Attribute *a = NULL; /* Quiet VC */
         heim_any extns;
 
         r.certificationRequestInfo.attributes =
@@ -655,7 +655,7 @@ hx509_request_to_pkcs10(hx509_context context,
         if (ret == 0)
             ASN1_MALLOC_ENCODE(Extensions, extns.data, extns.length,
                                &exts, &size, ret);
-        if (ret == 0)
+        if (ret == 0 && a)
             ret = der_copy_oid(&asn1_oid_id_pkcs9_extReq, &a->type);
         if (ret == 0)
             ret = add_AttributeValues(&a->value, &extns);

--- a/lib/kadm5/ipropd_master.c
+++ b/lib/kadm5/ipropd_master.c
@@ -1064,8 +1064,6 @@ get_left(kadm5_server_context *server_context, slave *s, krb5_storage *sp,
          */
     }
 
-    return left;
-
  err:
     flock(log_fd, LOCK_UN);
     return -1;
@@ -1190,7 +1188,6 @@ send_diffs(kadm5_server_context *server_context, slave *s, int log_fd,
     sp = krb5_storage_from_data(&data);
     if (sp == NULL) {
         krb5_err(context, IPROPD_RESTART_SLOW, ENOMEM, "out of memory");
-        krb5_warnx(context, "send_diffs: krb5_storage_from_data");
         return;
     }
     krb5_store_uint32(sp, FOR_YOU);

--- a/lib/krb5/acache.c
+++ b/lib/krb5/acache.c
@@ -450,7 +450,7 @@ acc_get_name(krb5_context context,
              const char **colname,
              const char **subsidiary)
 {
-    krb5_error_code ret;
+    krb5_error_code ret = 0;
     krb5_acc *a = ACACHE(id);
     int32_t error;
 
@@ -486,7 +486,7 @@ acc_get_name(krb5_context context,
     if (colname)
         *colname = "";
     if (subsidiary)
-    *subsidiary = a->cache_subsidiary;
+        *subsidiary = a->cache_subsidiary;
     return ret;
 }
 

--- a/lib/krb5/cache.c
+++ b/lib/krb5/cache.c
@@ -1895,7 +1895,7 @@ KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_cccol_cursor_next(krb5_context context, krb5_cccol_cursor cursor,
 		       krb5_ccache *cache)
 {
-    krb5_error_code ret;
+    krb5_error_code ret = 0;
 
     *cache = NULL;
 
@@ -2238,7 +2238,7 @@ _get_default_cc_name_from_registry(krb5_context context, HKEY hkBase)
     if (code != ERROR_SUCCESS)
         return NULL;
 
-    ccname = heim_parse_reg_value_as_string(context, hk_k5, "ccname",
+    ccname = heim_parse_reg_value_as_string(context->hcontext, hk_k5, "ccname",
                                             REG_NONE, 0);
 
     RegCloseKey(hk_k5);
@@ -2278,7 +2278,7 @@ _krb5_set_default_cc_name_to_registry(krb5_context context, krb5_ccache id)
     if (ret < 0)
         goto cleanup;
 
-    ret = heim_store_string_to_reg_value(context, hk_k5, "ccname",
+    ret = heim_store_string_to_reg_value(context->hcontext, hk_k5, "ccname",
                                          REG_SZ, ccname, -1, 0);
 
   cleanup:

--- a/lib/krb5/cache.c
+++ b/lib/krb5/cache.c
@@ -410,9 +410,22 @@ krb5_cc_resolve_for(krb5_context context,
     ret = krb5_unparse_name(context, principal, &p);
     if (ret)
         return ret;
-    /* Subsidiary components cannot have ':'s in them */
-    for (s = strchr(p, ':'); s; s = strchr(s + 1, ':'))
-        *s = '-';
+    /*
+     * Subsidiary components cannot have various chars in them that are used as
+     * separators.  ':' is used for subsidiary separators in all ccache types
+     * except FILE, where '+' is used instead because we can't use ':' in file
+     * paths on Windows and because ':' is not in the POSIX safe set.
+     */
+    for (s = p; *s; s++) {
+        switch (s[0]) {
+        case ':':
+        case '+':
+        case '/':
+        case '\\':
+            s[0] = '-';
+        default: break;
+        }
+    }
     ret = krb5_cc_resolve_sub(context, cctype, name, p, id);
     free(p);
     return ret;

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -764,6 +764,42 @@ krb5_set_config_files(krb5_context context, char **filenames)
     return ret;
 }
 
+#ifndef HEIMDAL_SMALLER
+/**
+ * Reinit the context from configuration file contents in a C string.
+ * This should only be used in tests.
+ *
+ * @param context context to add configuration too.
+ * @param config configuration.
+ *
+ * @return Returns 0 to indicate success.  Otherwise an kerberos et
+ * error code is returned, see krb5_get_error_message().
+ *
+ * @ingroup krb5
+ */
+
+KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+krb5_set_config(krb5_context context, const char *config)
+{
+    krb5_error_code ret;
+    krb5_config_binding *tmp = NULL;
+
+    if ((ret = krb5_config_parse_string_multi(context, config, &tmp)))
+        return ret;
+#if 0
+    /* with this enabled and if there are no config files, Kerberos is
+       considererd disabled */
+    if(tmp == NULL)
+	return ENXIO;
+#endif
+
+    krb5_config_file_free(context, context->cf);
+    context->cf = tmp;
+    ret = init_context_from_config_file(context);
+    return ret;
+}
+#endif
+
 static krb5_error_code
 add_file(char ***pfilenames, int *len, char *file)
 {

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -243,18 +243,15 @@ init_context_from_config_file(krb5_context context)
     context->configured_default_cc_name = NULL;
 
     tmp = secure_getenv("KRB5_TRACE");
+    if (tmp)
+        heim_add_debug_dest(context->hcontext, "libkrb5", tmp);
     s = krb5_config_get_strings(context, NULL, "logging", "krb5", NULL);
-    if (tmp || s) {
+    if (s) {
 	char **p;
 
-	if (s) {
-	    for (p = s; *p; p++)
-                heim_add_debug_dest(context->hcontext, "libkrb5", *p);
-	    krb5_config_free_strings(s);
-	}
-
-	if (tmp)
+        for (p = s; *p; p++)
             heim_add_debug_dest(context->hcontext, "libkrb5", *p);
+        krb5_config_free_strings(s);
     }
 
     tmp = krb5_config_get_string(context, NULL, "libdefaults",

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -789,7 +789,7 @@ krb5_set_config(krb5_context context, const char *config)
 #if 0
     /* with this enabled and if there are no config files, Kerberos is
        considererd disabled */
-    if(tmp == NULL)
+    if (tmp == NULL)
 	return ENXIO;
 #endif
 

--- a/lib/krb5/dcache.c
+++ b/lib/krb5/dcache.c
@@ -779,9 +779,10 @@ dcc_get_default_name(krb5_context context, char **str)
                                        "libdefaults", "default_cc_collection",
                                        NULL);
 
-    /* What if def_cc_colname does not start with DIR:?  We tolerate it. */
-    return _krb5_expand_default_cc_name(context, def_cc_colname,
-					str);
+    /* [libdefaults] default_cc_collection is for testing */
+    if (strncmp(def_cc_colname, "DIR:", sizeof("DIR:") - 1))
+        def_cc_colname = KRB5_DEFAULT_CCNAME_DIR;
+    return _krb5_expand_default_cc_name(context, def_cc_colname, str);
 }
 
 static krb5_error_code KRB5_CALLCONV

--- a/lib/krb5/fcache.c
+++ b/lib/krb5/fcache.c
@@ -37,6 +37,8 @@
 
 typedef struct krb5_fcache{
     char *filename;
+    char *res;
+    char *sub;
     char *tmpfn;
     int version;
 }krb5_fcache;
@@ -59,6 +61,8 @@ struct fcc_cursor {
 
 #define FILENAME(X) (FCACHE(X)->filename)
 #define TMPFILENAME(X) (FCACHE(X)->tmpfn)
+#define RESFILENAME(X) (FCACHE(X)->res)
+#define SUBFILENAME(X) (FCACHE(X)->sub)
 
 #define FCC_CURSOR(C) ((struct fcc_cursor*)(C))
 
@@ -199,38 +203,66 @@ fcc_lock(krb5_context context, krb5_ccache id,
 }
 
 static krb5_error_code KRB5_CALLCONV
+fcc_get_default_name(krb5_context, char **);
+
+/*
+ * This is the character used to separate the residual from the subsidiary name
+ * when both are given.  It's tempting to use ':' just as we do in the ccache
+ * names, but we can't on Windows.
+ */
+#define FILESUBSEP "+"
+#define FILESUBSEPCHR ((FILESUBSEP)[0])
+
+static krb5_error_code KRB5_CALLCONV
 fcc_resolve(krb5_context context,
             krb5_ccache *id,
             const char *res,
             const char *sub)
 {
     krb5_fcache *f;
+    char *freeme = NULL;
 
-    if (sub && *sub) {
-        krb5_set_error_message(context, KRB5_CC_NOSUPP,
-                               N_("FILE ccache type is not a collection "
-                                  "type", ""));
-        return KRB5_CC_NOSUPP;
+    if (res == NULL && sub == NULL)
+        return krb5_einval(context, 3);
+    if (res == NULL) {
+        krb5_error_code ret;
+
+        if ((ret = fcc_get_default_name(context, &freeme)))
+            return ret;
+        res = freeme + sizeof("FILE:") - 1;
+    } else if (!sub && (sub = strchr(res, FILESUBSEPCHR))) {
+        if (sub[1] == '\0') {
+            sub = NULL;
+        } else {
+            /* `res' has a subsidiary component, so split on it */
+            if ((freeme = strndup(res, sub - res)) == NULL)
+                return krb5_enomem(context);
+            res = freeme;
+            sub++;
+        }
     }
 
-    f = calloc(1, sizeof(*f));
-    if(f == NULL) {
-	krb5_set_error_message(context, KRB5_CC_NOMEM,
-			       N_("malloc: out of memory", ""));
-	return KRB5_CC_NOMEM;
+    if ((f = calloc(1, sizeof(*f))) == NULL ||
+        (f->res = strdup(res)) == NULL ||
+        (f->sub = sub ? strdup(sub) : NULL) == (sub ? NULL : "") ||
+        asprintf(&f->filename, "%s%s%s",
+                 res, sub ? FILESUBSEP : "", sub ? sub : "") == -1 ||
+        f->filename == NULL) {
+        if (f) {
+            free(f->filename);
+            free(f->res);
+            free(f->sub);
+        }
+        free(f);
+        free(freeme);
+        return krb5_enomem(context);
     }
     f->tmpfn = NULL;
-    f->filename = strdup(res);
-    if(f->filename == NULL){
-	free(f);
-	krb5_set_error_message(context, KRB5_CC_NOMEM,
-			       N_("malloc: out of memory", ""));
-	return KRB5_CC_NOMEM;
-    }
     f->version = 0;
     (*id)->data.data = f;
     (*id)->data.length = sizeof(*f);
 
+    free(freeme);
     return 0;
 }
 
@@ -353,6 +385,11 @@ fcc_gen_new(krb5_context context, krb5_ccache *id)
 	return KRB5_CC_NOMEM;
     }
     f->tmpfn = NULL;
+    /*
+     * XXX We should asprintf(&file, "%s:XXXXXX", KRB5_DEFAULT_CCNAME_FILE)
+     * instead so that new unique FILE ccaches can be found in the user's
+     * default collection.
+     * */
     ret = asprintf(&file, "%sXXXXXX", KRB5_DEFAULT_CCFILE_ROOT);
     if(ret < 0 || file == NULL) {
 	free(f);
@@ -379,6 +416,8 @@ fcc_gen_new(krb5_context context, krb5_ccache *id)
     }
     close(fd);
     f->filename = exp_file;
+    f->res = strdup(exp_file); /* XXX See above commentary about collection */
+    f->sub = NULL;
     f->version = 0;
     (*id)->data.data = f;
     (*id)->data.length = sizeof(*f);
@@ -466,7 +505,9 @@ fcc_open(krb5_context context,
     strict_checking = (flags & O_CREAT) == 0 &&
 	(context->flags & KRB5_CTX_F_FCACHE_STRICT_CHECKING) != 0;
 
+#ifndef WIN32
 again:
+#endif
     memset(&sb1, 0, sizeof(sb1));
     ret = lstat(filename, &sb1);
     if (ret == 0) {
@@ -662,6 +703,8 @@ fcc_close(krb5_context context,
     if (TMPFILENAME(id))
         (void) unlink(TMPFILENAME(id));
     free(TMPFILENAME(id));
+    free(RESFILENAME(id));
+    free(SUBFILENAME(id));
     free(FILENAME(id));
     krb5_data_free(&id->data);
     return 0;
@@ -903,14 +946,14 @@ fcc_get_principal(krb5_context context,
 }
 
 static krb5_error_code KRB5_CALLCONV
-fcc_end_get (krb5_context context,
-	     krb5_ccache id,
-	     krb5_cc_cursor *cursor);
+fcc_end_get(krb5_context context,
+	    krb5_ccache id,
+	    krb5_cc_cursor *cursor);
 
 static krb5_error_code KRB5_CALLCONV
-fcc_get_first (krb5_context context,
-	       krb5_ccache id,
-	       krb5_cc_cursor *cursor)
+fcc_get_first(krb5_context context,
+	      krb5_ccache id,
+	      krb5_cc_cursor *cursor)
 {
     krb5_error_code ret;
     krb5_principal principal;
@@ -1162,62 +1205,320 @@ fcc_get_version(krb5_context context,
     return FCACHE(id)->version;
 }
 
-struct fcache_iter {
-    int first;
-};
-
-static krb5_error_code KRB5_CALLCONV
-fcc_get_cache_first(krb5_context context, krb5_cc_cursor *cursor)
+static const char *
+my_basename(const char *fn)
 {
-    struct fcache_iter *iter;
+    const char *base, *p;
 
-    iter = calloc(1, sizeof(*iter));
-    if (iter == NULL) {
-	krb5_set_error_message(context, ENOMEM, N_("malloc: out of memory", ""));
-	return ENOMEM;
+    if (strncmp(fn, "FILE:", sizeof("FILE:") - 1))
+        return "";
+    fn += sizeof("FILE:") - 1;
+    for (p = base = fn; *p; p++) {
+#ifdef WIN32
+        if (*p == '/' || *p == '\\')
+            base = p + 1;
+#else
+        if (*p == '/')
+            base = p + 1;
+#endif
     }
-    iter->first = 1;
-    *cursor = iter;
+    return base;
+}
+
+/* We could use an rk_dirname()... */
+static char *
+my_dirname(const char *fn)
+{
+    size_t len, i;
+    char *dname;
+
+    if (strncmp(fn, "FILE:", sizeof("FILE:") - 1) == 0)
+        fn += sizeof("FILE:") - 1;
+
+    if ((dname = strdup(fn)) == NULL)
+        return NULL;
+    len = strlen(dname);
+    for (i = 0; i < len; i++) {
+#ifdef WIN32
+        if (dname[len - i] == '\\' ||
+            dname[len - i] == '/') {
+            dname[len - i] = '\0';
+            break;
+        }
+#else
+        if (dname[len - i] == '/') {
+            dname[len - i] = '\0';
+            break;
+        }
+#endif
+    }
+    if (i < len)
+        return dname;
+    free(dname);
+    return strdup(".");
+}
+
+/*
+ * This checks that a directory entry matches a required basename and has a
+ * non-empty subsidiary component.
+ */
+static int
+matchbase(const char *fn, const char *base, size_t baselen)
+{
+    return strncmp(fn, base, baselen) == 0 &&
+        (fn[baselen] == FILESUBSEPCHR && fn[baselen + 1] != '\0');
+}
+
+/*
+ * Check if `def_locs' contains `name' (which must be the default ccache name),
+ * in which case the caller may look for subsidiaries of all of `def_locs'.
+ *
+ * This is needed because the collection iterators don't take a base location
+ * as an argument, so we can only search default locations, but only if the
+ * current default ccache name is indeed a default (as opposed to from
+ * KRB5CCNAME being set in the environment pointing to a non-default name).
+ */
+static krb5_error_code
+is_default_collection(krb5_context context, const char *name,
+                      const char * const *def_locs, int *res)
+{
+    krb5_error_code ret;
+    const char *def_loc[2] = { KRB5_DEFAULT_CCNAME_FILE, NULL };
+    size_t i;
+
+    *res = 0;
+    if (name == NULL) {
+        *res = 1;
+        return 0;
+    }
+    if (def_locs == NULL)
+        def_locs = def_loc;
+    for (i = 0; !(*res) && def_locs[i]; i++) {
+        char *e = NULL;
+
+        if ((ret = _krb5_expand_default_cc_name(context, def_locs[i], &e)))
+            return ret;
+        *res = strcmp(name, e) == 0;
+        free(e);
+    }
     return 0;
 }
 
+/*
+ * Collection iterator cursor.
+ *
+ * There may be an array of locations, and for each location we'll try
+ * resolving it, as well as doing a readdir() of the dirname of it and output
+ * all ccache names in that directory that begin with the current location and
+ * end in "+${subsidiary}".
+ */
+struct fcache_iter {
+    const char *curr_location;
+    char *def_ccname;   /* The default ccname */
+    char **locations;   /* All the other places we'll look for a ccache */
+    char *dname;        /* dirname() of curr_location */
+    DIR *d;
+    struct dirent *dentry;
+    int location;       /* Index of `locations' */
+    unsigned int first:1;
+    unsigned int dead:1;
+};
+
+/* Initiate FILE collection iteration */
 static krb5_error_code KRB5_CALLCONV
-fcc_get_cache_next(krb5_context context, krb5_cc_cursor cursor, krb5_ccache *id)
+fcc_get_cache_first(krb5_context context, krb5_cc_cursor *cursor)
 {
-    struct fcache_iter *iter = cursor;
+    struct fcache_iter *iter = NULL;
     krb5_error_code ret;
-    const char *fn, *cc_type;
-    krb5_ccache cc;
+    const char *def_ccname = NULL;
+    char **def_locs = NULL;
+    int is_def_coll = 0;
 
-    if (iter == NULL)
-        return krb5_einval(context, 2);
-
-    if (!iter->first) {
-	krb5_clear_error_message(context);
-	return KRB5_CC_END;
+    if (krb5_config_get_bool_default(context, NULL, FALSE, "libdefaults",
+                                     "enable_file_cache_iteration", NULL)) {
+        def_ccname = krb5_cc_default_name(context);
+        def_locs = krb5_config_get_strings(context, NULL, "libdefaults",
+                                           "default_file_cache_collection",
+                                           NULL);
     }
-    iter->first = 0;
 
     /*
      * Note: do not allow krb5_cc_default_name() to recurse via
      * krb5_cc_cache_match().
      * Note that context->default_cc_name will be NULL even though
-     * KRB5CCNAME is set in the environment if
-     * krb5_cc_set_default_name() hasn't
+     * KRB5CCNAME is set in the environment if neither krb5_cc_default_name()
+     * nor krb5_cc_set_default_name() have been called.
      */
-    fn = krb5_cc_default_name(context);
-    ret = krb5_cc_resolve(context, fn, &cc);
-    if (ret != 0)
-        return ret;
-    cc_type = krb5_cc_get_type(context, cc);
-    if (strcmp(cc_type, "FILE") != 0) {
-        krb5_cc_close(context, cc);
-        return KRB5_CC_END;
+
+    /*
+     * Figure out if the current default ccache name is a really a default one
+     * so we know whether to search any other default FILE collection
+     * locations.
+     */
+    if ((ret = is_default_collection(context, def_ccname,
+                                     (const char **)def_locs,
+                                     &is_def_coll)))
+        goto out;
+
+    /* Setup the cursor */
+    if ((iter = calloc(1, sizeof(*iter))) == NULL ||
+        (def_ccname && (iter->def_ccname = strdup(def_ccname)) == NULL)) {
+        ret = krb5_enomem(context);
+        goto out;
     }
 
-    *id = cc;
+    if (is_def_coll) {
+        /* Since def_ccname is in the `def_locs', we'll include those */
+        iter->locations = def_locs;
+        free(iter->def_ccname);
+        iter->def_ccname = NULL;
+        def_locs = NULL;
+    } else {
+        /* Since def_ccname is NOT in the `def_locs', we'll exclude those */
+        iter->locations = NULL;
+    }
+    iter->curr_location = NULL;
+    iter->location = -1; /* Pre-incremented */
+    iter->first = 1;
+    iter->dname = NULL;
+    iter->d = NULL;
+    *cursor = iter;
+    iter = NULL;
+    ret = 0;
 
+out:
+    krb5_config_free_strings(def_locs);
+    free(iter);
+    return ret;
+}
+
+/* Pick the next location as the `iter->curr_location' */
+static krb5_error_code
+next_location(krb5_context context, struct fcache_iter *iter)
+{
+    if (iter->first && iter->def_ccname) {
+        iter->curr_location = iter->def_ccname;
+        iter->first = 0;
+        return 0;
+    }
+    iter->first = 0;
+
+    if (iter->d)
+        closedir(iter->d);
+    iter->d = NULL;
+    iter->curr_location = NULL;
+    if (iter->locations &&
+        (iter->curr_location = iter->locations[++(iter->location)]))
+        return 0;
+
+    iter->dead = 1; /* Do not run off the end of iter->locations */
+    return KRB5_CC_END;
+}
+
+/* Output the next match for `iter->curr_location' from readdir() */
+static krb5_error_code
+next_dir_match(krb5_context context, struct fcache_iter *iter, char **fn)
+{
+    struct stat st;
+    const char *base = my_basename(iter->curr_location);
+    size_t baselen = strlen(base);
+    char *s;
+
+    *fn = NULL;
+    if (iter->d == NULL)
+        return 0;
+    for (iter->dentry = readdir(iter->d);
+         iter->dentry;
+         iter->dentry = readdir(iter->d)) {
+        if (!matchbase(iter->dentry->d_name, base, baselen))
+            continue;
+        if (asprintf(&s, "FILE:%s/%s", iter->dname, iter->dentry->d_name) == -1 ||
+            s == NULL)
+            return krb5_enomem(context);
+        if (stat(s + sizeof("FILE:") - 1, &st) == 0 && S_ISREG(st.st_mode)) {
+            *fn = s;
+            return 0;
+        }
+        free(s);
+    }
+    iter->curr_location = NULL;
+    closedir(iter->d);
+    iter->d = NULL;
     return 0;
+}
+
+/* See if the given `ccname' is a FILE ccache we can resolve */
+static krb5_error_code
+try1(krb5_context context, const char *ccname, krb5_ccache *id)
+{
+    krb5_error_code ret;
+    krb5_ccache cc;
+
+    ret = krb5_cc_resolve(context, ccname, &cc);
+    if (ret == ENOMEM)
+        return ret;
+    if (ret == 0) {
+        if (strcmp(krb5_cc_get_type(context, cc), "FILE") == 0) {
+            *id = cc;
+            cc = NULL;
+        }
+        krb5_cc_close(context, cc);
+    }
+    return 0;
+}
+
+/* Output the next FILE ccache in the FILE ccache collection */
+static krb5_error_code KRB5_CALLCONV
+fcc_get_cache_next(krb5_context context, krb5_cc_cursor cursor, krb5_ccache *id)
+{
+    struct fcache_iter *iter = cursor;
+    krb5_error_code ret;
+    char *name = NULL;
+
+    *id = NULL;
+    if (iter == NULL)
+        return krb5_einval(context, 2);
+
+    /* Do not run off the end of iter->locations */
+    if (iter->dead)
+        return KRB5_CC_END;
+
+    if (!iter->curr_location) {
+        /* Next base location */
+        if ((ret = next_location(context, iter)))
+            return ret;
+        /* Output the current base location */
+        if ((ret = try1(context, iter->curr_location, id)) || *id)
+            return ret;
+    }
+
+    /* Look for subsidiaries of iter->curr_location */
+    if (!iter->d) {
+        free(iter->dname);
+        if ((iter->dname = my_dirname(iter->curr_location)) == NULL)
+            return krb5_enomem(context);
+        if ((iter->d = opendir(iter->dname)) == NULL) {
+            /* Dirname ENOENT -> next location */
+            if ((ret = next_location(context, iter)))
+                return ret;
+            /* Tail-recurse */
+            return fcc_get_cache_next(context, cursor, id);
+        }
+    }
+    for (ret = next_dir_match(context, iter, &name);
+         ret == 0 && name != NULL;
+         ret = next_dir_match(context, iter, &name)) {
+        if ((ret = try1(context, name, id)) || *id) {
+            free(name);
+            return ret;
+        }
+        free(name);
+    }
+
+    /* Directory listing exhausted -> go to next location, tail-recurse */
+    if ((ret = next_location(context, iter)))
+        return ret;
+    return fcc_get_cache_next(context, cursor, id);
 }
 
 static krb5_error_code KRB5_CALLCONV
@@ -1228,6 +1529,11 @@ fcc_end_cache_get(krb5_context context, krb5_cc_cursor cursor)
     if (iter == NULL)
         return krb5_einval(context, 2);
 
+    krb5_config_free_strings(iter->locations);
+    if (iter->d)
+        closedir(iter->d);
+    free(iter->def_ccname);
+    free(iter->dname);
     free(iter);
     return 0;
 }
@@ -1254,6 +1560,35 @@ fcc_get_default_name(krb5_context context, char **str)
     return _krb5_expand_default_cc_name(context,
 					KRB5_DEFAULT_CCNAME_FILE,
 					str);
+}
+
+static krb5_error_code KRB5_CALLCONV
+fcc_set_default_cache(krb5_context context, krb5_ccache id)
+{
+    krb5_error_code ret;
+    krb5_ccache dest;
+    char *s = NULL;
+
+    if (SUBFILENAME(id) == NULL)
+        return 0; /* Already a primary */
+    if (asprintf(&s, "FILE:%s", RESFILENAME(id)) == -1 || s == NULL)
+        return krb5_enomem(context);
+
+    /*
+     * We can't hard-link, since we refuse to open ccaches with st_nlink > 1,
+     * and we can't rename() the ccache because the old name should remain
+     * available.  Ergo, we copy the ccache.
+     */
+    ret = krb5_cc_resolve(context, s, &dest);
+    if (ret == 0)
+        ret = krb5_cc_copy_cache(context, id, dest);
+    free(s);
+    if (ret)
+	krb5_set_error_message(context, ret,
+                               N_("Failed to copy subsidiary cache file %s to "
+                                  "default %s", ""), FILENAME(id),
+                               RESFILENAME(id));
+    return ret;
 }
 
 static krb5_error_code KRB5_CALLCONV
@@ -1327,7 +1662,7 @@ KRB5_LIB_VARIABLE const krb5_cc_ops krb5_fcc_ops = {
     fcc_end_cache_get,
     fcc_move,
     fcc_get_default_name,
-    NULL,
+    fcc_set_default_cache,
     fcc_lastchange,
     fcc_set_kdc_offset,
     fcc_get_kdc_offset

--- a/lib/krb5/fcache.c
+++ b/lib/krb5/fcache.c
@@ -1338,7 +1338,7 @@ fcc_get_cache_first(krb5_context context, krb5_cc_cursor *cursor)
                                      "enable_file_cache_iteration", NULL)) {
         def_ccname = krb5_cc_default_name(context);
         def_locs = krb5_config_get_strings(context, NULL, "libdefaults",
-                                           "default_file_cache_collection",
+                                           "default_file_cache_collections",
                                            NULL);
     }
 

--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -209,6 +209,28 @@ If you want to change the type only use
 .Li default_cc_type .
 The string can contain variables that are expanded at runtime. See the TOKEN
 EXPANSION section.
+.It Li default_file_cache_collection = Va FILE:/path/with/tokens ...
+This multi-valued parameter allows more than one path to be
+configured for the FILE credentials cache type to look in.  The FILE
+credentials cache type will also consider file names whose prefixes
+match these and end in
+.Va +name
+as subsidiary caches in the collection.  The values of this
+parameter are subject to token expansion.  See the TOKEN EXPANSION
+section.
+.It Li enable_file_cache_iteration = Va boolean
+If enabled, the
+.Va FILE
+credential cache type will support iteration of all subsidiary
+caches in the default collection, meaning that
+.Xr kinit 1
+.Va -l
+option will list them.  This does require scanning the directory
+containing a given
+.Va FILE
+ccache, which, if it is
+.Va /tmp
+may be a slow operation.  Defaults to false.
 .It Li default_etypes = Va etypes ...
 A list of default encryption types to use. (Default: all enctypes if
 allow_weak_crypto = TRUE, else all enctypes except single DES enctypes.)

--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -209,7 +209,7 @@ If you want to change the type only use
 .Li default_cc_type .
 The string can contain variables that are expanded at runtime. See the TOKEN
 EXPANSION section.
-.It Li default_file_cache_collection = Va FILE:/path/with/tokens ...
+.It Li default_file_cache_collections = Va FILE:/path/with/tokens ...
 This multi-valued parameter allows more than one path to be
 configured for the FILE credentials cache type to look in.  The FILE
 credentials cache type will also consider file names whose prefixes

--- a/lib/krb5/kx509.c
+++ b/lib/krb5/kx509.c
@@ -760,7 +760,7 @@ mk_kx509_req(krb5_context context,
     HMAC_CTX ctx;
     const char *hostname;
     char *start_realm = NULL;
-    size_t len;
+    size_t len = 0;
 
     krb5_data_zero(&pre_req);
     memset(&spki, 0, sizeof(spki));

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -601,6 +601,7 @@ EXPORTS
 	krb5_sendto_ctx_set_type
 	krb5_sendto_kdc
 	krb5_sendto_kdc_flags
+	krb5_set_config
 	krb5_set_config_files
 	krb5_set_debug_dest
 	krb5_set_default_in_tkt_etypes

--- a/lib/krb5/plugin.c
+++ b/lib/krb5/plugin.c
@@ -104,7 +104,7 @@ krb5_plugin_register(krb5_context context,
 KRB5_LIB_FUNCTION void KRB5_LIB_CALL
 _krb5_load_plugins(krb5_context context, const char *name, const char **paths)
 {
-    return heim_load_plugins(context->hcontext, name, paths);
+    heim_load_plugins(context->hcontext, name, paths);
 }
 
 /**

--- a/lib/krb5/scache.c
+++ b/lib/krb5/scache.c
@@ -384,7 +384,7 @@ scc_alloc(krb5_context context,
 
         if ((subsidiary = strrchr(s->file, ':'))) {
 #ifdef WIN32
-            if (subsidiary == &s->file + 1)
+            if (subsidiary == s->file + 1)
                 subsidiary = NULL;
             else
 #endif

--- a/lib/krb5/store_sock.c
+++ b/lib/krb5/store_sock.c
@@ -112,6 +112,7 @@ krb5_storage_from_socket(krb5_socket_t sock_in)
 #ifdef _WIN32
     WSAPROTOCOL_INFO info;
 
+    sock = rk_INVALID_SOCKET;
     if (WSADuplicateSocket(sock_in, GetCurrentProcessId(), &info) == 0)
     {
 

--- a/lib/krb5/store_stdio.c
+++ b/lib/krb5/store_stdio.c
@@ -34,6 +34,11 @@
 #include "krb5_locl.h"
 #include "store-int.h"
 
+#ifndef HAVE_FSEEKO
+#define fseeko fseek
+#define ftello ftell
+#endif
+
 typedef struct stdio_storage {
     FILE *f;
     off_t pos;

--- a/lib/krb5/test_cc.c
+++ b/lib/krb5/test_cc.c
@@ -815,7 +815,9 @@ test_cccol_dcache(krb5_context context)
         (void) unlink(s);
         free(s);
     }
-    (void) rmdir(template + sizeof("DIR:") - 1); /* XXX Check that this succeeds */
+    if (rmdir(template + sizeof("DIR:") - 1))
+        krb5_warn(context, errno, "Could not rmdir(%s) (DIR)",
+                  template + sizeof("DIR:") - 1);
     if (ret)
         krb5_err(context, 1, errno, "%s", what);
 }
@@ -1057,6 +1059,40 @@ main(int argc, char **argv)
             krb5_err(context, 1, ret, "%s", what);
     }
 #endif /* HAVE_KEYUTILS_H */
+
+    {
+        const char *what;
+        char *config;
+        char *fname;
+        char *d;
+
+        if ((d = strdup("FILE:filesXXXXXX")) == NULL ||
+            mkdtemp(d + sizeof("FILE:") - 1) == NULL ||
+            asprintf(&fname, "%s/foobar", d) == -1 ||
+            fname == NULL ||
+            asprintf(&config,
+                     "[libdefaults]\n"
+                     "\tdefault_file_cache_collection = %1$s/foobar\n"
+                     "\tenable_file_cache_iteration = true\n",
+                     d) == -1 || config == NULL)
+            krb5_err(context, 1, errno, "Could not make temp dir");
+        ret = krb5_set_config(context, config);
+        if (ret)
+            krb5_err(context, 1, ret,
+                     "Could not configure context from string:\n%s\n", config);
+        ret = test_cccol(context, fname, &what);
+        if (ret)
+            krb5_err(context, 1, ret, "%s", what);
+        if (chdir(d + sizeof("FILE:") - 1) == 0) {
+            unlink("foobar");
+            unlink("foobar+lha@H5L.SE");
+            unlink("foobar+lha@SU.SE");
+            chdir("..");
+        }
+        if (rmdir(d + sizeof("FILE:") - 1))
+            krb5_warn(context, errno, "Could not rmdir(%s) (FILE)",
+                      d + sizeof("FILE:") - 1);
+    }
 
     krb5_free_context(context);
 

--- a/lib/krb5/test_cc.c
+++ b/lib/krb5/test_cc.c
@@ -1072,7 +1072,7 @@ main(int argc, char **argv)
             fname == NULL ||
             asprintf(&config,
                      "[libdefaults]\n"
-                     "\tdefault_file_cache_collection = %1$s/foobar\n"
+                     "\tdefault_file_cache_collections = %1$s/foobar\n"
                      "\tenable_file_cache_iteration = true\n",
                      d) == -1 || config == NULL)
             krb5_err(context, 1, errno, "Could not make temp dir");

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -594,6 +594,7 @@ HEIMDAL_KRB5_2.0 {
 		krb5_sendto_ctx_set_type;
 		krb5_sendto_kdc;
 		krb5_sendto_kdc_flags;
+		krb5_set_config;
 		krb5_set_config_files;
 		krb5_set_debug_dest;
 		krb5_set_default_in_tkt_etypes;

--- a/lib/roken/getauxval.c
+++ b/lib/roken/getauxval.c
@@ -68,7 +68,7 @@ static void
 do_readprocauxv(void)
 {
     char *p = (void *)auxv;
-    ssize_t bytes;
+    ssize_t bytes = 0;
     size_t sz = sizeof(auxv) - sizeof(auxv[0]); /* leave terminator */
     int save_errno = errno;
     int fd;

--- a/lib/roken/getuserinfo.c
+++ b/lib/roken/getuserinfo.c
@@ -320,7 +320,7 @@ roken_get_loginname(char *user, size_t usersz)
         return NULL;
 #endif
 #endif
-#endif
     errno = 0;
     return NULL;
+#endif
 }

--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -448,7 +448,7 @@ rk_wcsdup(const unsigned short *);
 
 #ifndef HAVE_MEMMEM
 #define memmem rk_smemmem
-ROKEN_LIB_FUNCTION char * ROKEN_LIB_CALL memmem(const char *);
+ROKEN_LIB_FUNCTION void * ROKEN_LIB_CALL memmem(const void *, size_t, const void *, size_t);
 #endif
 
 #ifdef HAVE_WINSOCK

--- a/lib/roken/sleep.c
+++ b/lib/roken/sleep.c
@@ -41,7 +41,7 @@ ROKEN_LIB_FUNCTION unsigned int ROKEN_LIB_CALL
 sleep(unsigned int seconds)
 {
     if (SleepEx(1000 * (DWORD) seconds, FALSE) != 0)
-	return -1;
+	return 1; /* XXX Should get time before and after */
     return 0;
 }
 
@@ -50,6 +50,6 @@ ROKEN_LIB_FUNCTION unsigned int ROKEN_LIB_CALL
 usleep(unsigned int useconds)
 {
     if (SleepEx((DWORD)(useconds / 1000), FALSE) != 0)
-	return -1;
+	return 1000; /* XXX Should get time before and after */
     return 0;
 }

--- a/tests/kdc/check-cc.in
+++ b/tests/kdc/check-cc.in
@@ -139,8 +139,8 @@ export KRB5_CONFIG
 unset KRB5CCNAME
 rm -rf ${objdir}/kt ${objdir}/cc_dir
 mkdir ${objdir}/cc_dir || { ec=1 ; eval "${testfailed}"; }
-${kinit} foo@${R} || { ec=1 ; eval "${testfailed}"; }
-${kinit} --no-change-default bar@${R} || { ec=1 ; eval "${testfailed}"; }
+${kinit} --cache-default-for foo@${R} || { ec=1 ; eval "${testfailed}"; }
+${kinit} --cache-default-for --no-change-default bar@${R} || { ec=1 ; eval "${testfailed}"; }
 primary=`cat ${objdir}/cc_dir/primary`
 [ "x$primary" = xtkt.foo@${R} ] || { ec=1 ; eval "${testfailed}"; }
 ${klist} -l |


### PR DESCRIPTION
This makes the `FILE` ccache type a collection type.

Minimally, the `FILE` type will consider all ccaches whose prefix is the default `FILE` ccache name, followed by `:name` as subsidiaries.

As well, one can now configure multiple default locations in `krb5.conf` using the new `default_file_cache_collection` parameter in `[libdefaults]`.  See the man page.