### PR TITLE
gss: smarter mechanism selection in SPNEGO

### DIFF
--- a/lib/gssapi/spnego/accept_sec_context.c
+++ b/lib/gssapi/spnego/accept_sec_context.c
@@ -79,7 +79,7 @@ acceptor_approved(OM_uint32 *minor_status,
     if (gss_oid_equal(mech, GSS_NEGOEX_MECHANISM)) {
 	size_t i;
 
-	ret = _gss_spnego_indicate_mechs(minor_status, &oidset);
+	ret = _gss_spnego_indicate_mechs(minor_status, 0, &oidset);
 	if (ret != GSS_S_COMPLETE)
 	    return ret;
 
@@ -132,7 +132,7 @@ send_supported_mechs (OM_uint32 *minor_status,
     nt.u.negTokenInit.mechToken = NULL;
     nt.u.negTokenInit.negHints = NULL;
 
-    ret = _gss_spnego_indicate_mechtypelist(minor_status, NULL,
+    ret = _gss_spnego_indicate_mechtypelist(minor_status, GSS_C_NO_NAME, 0,
 					    acceptor_approved, ctx, 1, acceptor_cred,
 					    &nt.u.negTokenInit.mechTypes, NULL);
     if (ret != GSS_S_COMPLETE) {
@@ -674,11 +674,11 @@ acceptor_start
     }
 
     if (acceptor_cred_handle != GSS_C_NO_CREDENTIAL)
-	ret = _gss_spnego_inquire_cred_mechs(minor_status,
+	ret = _gss_spnego_inquire_cred_mechs(minor_status, 0,
 					     acceptor_cred_handle,
 					     &supported_mechs);
     else
-	ret = _gss_spnego_indicate_mechs(minor_status, &supported_mechs);
+	ret = _gss_spnego_indicate_mechs(minor_status, 0, &supported_mechs);
     if (ret != GSS_S_COMPLETE)
 	goto out;
 

--- a/lib/gssapi/spnego/context_stubs.c
+++ b/lib/gssapi/spnego/context_stubs.c
@@ -438,7 +438,7 @@ OM_uint32 GSSAPI_CALLCONV _gss_spnego_inquire_names_for_mech (
 
     *name_types = NULL;
 
-    ret = _gss_spnego_indicate_mechs(minor_status, &mechs);
+    ret = _gss_spnego_indicate_mechs(minor_status, 0, &mechs);
     if (ret != GSS_S_COMPLETE)
 	return ret;
 

--- a/lib/gssapi/spnego/cred_stubs.c
+++ b/lib/gssapi/spnego/cred_stubs.c
@@ -72,7 +72,7 @@ OM_uint32 GSSAPI_CALLCONV _gss_spnego_acquire_cred_from
 
     *output_cred_handle = GSS_C_NO_CREDENTIAL;
 
-    ret = _gss_spnego_indicate_mechs(minor_status, &mechs);
+    ret = _gss_spnego_indicate_mechs(minor_status, 0, &mechs);
     if (ret != GSS_S_COMPLETE)
 	return ret;
 

--- a/lib/gssapi/spnego/init_sec_context.c
+++ b/lib/gssapi/spnego/init_sec_context.c
@@ -285,6 +285,7 @@ spnego_initial(OM_uint32 * minor_status,
 
     sub = _gss_spnego_indicate_mechtypelist(&minor,
 					    ctx->target_name,
+					    req_flags,
 					    initiator_approved,
 					    &sel,
 					    0,


### PR DESCRIPTION
Make SPNEGO (and NegoEx) smarter about mechanism selection. If the initiator has specified GSS_C_MUTUAL_FLAG and/or GSS_C_ANON_FLAG, only consider mechanisms that support GSS_C_MA_AUTH_TARG and/or GSS_C_MA_AUTH_INIT_ANON (respectively) for negotiation.