### PR TITLE
pull up automake fixes from master so proper dependencies exist even with newer automake

### DIFF
--- a/lib/hcrypto/Makefile.am
+++ b/lib/hcrypto/Makefile.am
@@ -297,7 +297,7 @@ ltmsources = \
 	libtommath/bn_mp_to_unsigned_bin_n.c
 
 
-$(libhcrypto_la_OBJECTS): hcrypto-link
+$(libhcrypto_la_OBJECTS) $(test_rand_OBJECTS): hcrypto-link
 
 libhcrypto_la_CPPFLAGS = -DBUILD_HCRYPTO_LIB $(AM_CPPFLAGS)
 

--- a/lib/hx509/Makefile.am
+++ b/lib/hx509/Makefile.am
@@ -164,7 +164,7 @@ hxtool-commands.c hxtool-commands.h: hxtool-commands.in $(SLC)
 dist_hxtool_SOURCES = hxtool.c
 nodist_hxtool_SOURCES = hxtool-commands.c hxtool-commands.h
 
-$(hxtool_OBJECTS): hxtool-commands.h hx509_err.h
+$(hxtool_OBJECTS): hxtool-commands.h $(nodist_include_HEADERS)
 
 hxtool_LDADD = \
 	libhx509.la \


### PR DESCRIPTION
automake 1.16 and later don't work on the 7.1-branch without these fixes