### PR TITLE
gss: remove dead GSS_C_PEER_HAS_UPDATED_SPNEGO

### DIFF
--- a/lib/gssapi/gssapi/gssapi_oid.h
+++ b/lib/gssapi/gssapi/gssapi_oid.h
@@ -154,9 +154,6 @@ extern GSSAPI_LIB_VARIABLE gss_OID_desc __gss_spnego_mechanism_oid_desc;
 #define GSS_SPNEGO_MECHANISM (&__gss_spnego_mechanism_oid_desc)
 
  /* From Luke Howard */
-extern GSSAPI_LIB_VARIABLE gss_OID_desc __gss_c_peer_has_updated_spnego_oid_desc;
-#define GSS_C_PEER_HAS_UPDATED_SPNEGO (&__gss_c_peer_has_updated_spnego_oid_desc)
-
 extern GSSAPI_LIB_VARIABLE gss_OID_desc __gss_c_ntlm_reset_crypto_oid_desc;
 #define GSS_C_NTLM_RESET_CRYPTO (&__gss_c_ntlm_reset_crypto_oid_desc)
 

--- a/lib/gssapi/krb5/inquire_sec_context_by_oid.c
+++ b/lib/gssapi/krb5/inquire_sec_context_by_oid.c
@@ -263,41 +263,6 @@ static OM_uint32 inquire_sec_context_authz_data
     return ret;
 }
 
-static OM_uint32 inquire_sec_context_has_updated_spnego
-           (OM_uint32 *minor_status,
-            const gsskrb5_ctx context_handle,
-            gss_buffer_set_t *data_set)
-{
-    int is_updated = 0;
-
-    *minor_status = 0;
-    *data_set = GSS_C_NO_BUFFER_SET;
-
-    /*
-     * For Windows SPNEGO implementations, both the initiator and the
-     * acceptor are assumed to have been updated if a "newer" [CLAR] or
-     * different enctype is negotiated for use by the Kerberos GSS-API
-     * mechanism.
-     */
-    HEIMDAL_MUTEX_lock(&context_handle->ctx_id_mutex);
-    is_updated = (context_handle->more_flags & IS_CFX);
-    if (is_updated == 0) {
-	krb5_keyblock *acceptor_subkey;
-
-	if (context_handle->more_flags & LOCAL)
-	    acceptor_subkey = context_handle->auth_context->remote_subkey;
-	else
-	    acceptor_subkey = context_handle->auth_context->local_subkey;
-
-	if (acceptor_subkey != NULL)
-	    is_updated = (acceptor_subkey->keytype !=
-			  context_handle->auth_context->keyblock->keytype);
-    }
-    HEIMDAL_MUTEX_unlock(&context_handle->ctx_id_mutex);
-
-    return is_updated ? GSS_S_COMPLETE : GSS_S_FAILURE;
-}
-
 /*
  *
  */
@@ -549,10 +514,6 @@ OM_uint32 GSSAPI_CALLCONV _gsskrb5_inquire_sec_context_by_oid
 	return inquire_sec_context_tkt_flags(minor_status,
 					     ctx,
 					     data_set);
-    } else if (gss_oid_equal(desired_object, GSS_C_PEER_HAS_UPDATED_SPNEGO)) {
-	return inquire_sec_context_has_updated_spnego(minor_status,
-						      ctx,
-						      data_set);
     } else if (gss_oid_equal(desired_object, GSS_KRB5_GET_SUBKEY_X)) {
 	return inquire_sec_context_get_subkey(minor_status,
 					      ctx,

--- a/lib/gssapi/libgssapi-exports.def
+++ b/lib/gssapi/libgssapi-exports.def
@@ -168,7 +168,6 @@ EXPORTS
 	__gss_krb5_mechanism_oid_desc	DATA
 	__gss_ntlm_mechanism_oid_desc	DATA
 	__gss_spnego_mechanism_oid_desc	DATA
-	__gss_c_peer_has_updated_spnego_oid_desc	DATA
 	__gss_c_ma_mech_concrete_oid_desc	DATA
 	__gss_c_ma_mech_pseudo_oid_desc	DATA
 	__gss_c_ma_mech_composite_oid_desc	DATA

--- a/lib/gssapi/mech/gss_oid.c
+++ b/lib/gssapi/mech/gss_oid.c
@@ -142,9 +142,6 @@ gss_OID_desc GSSAPI_LIB_VARIABLE __gss_ntlm_mechanism_oid_desc = { 10, rk_UNCONS
 /* GSS_SPNEGO_MECHANISM - 1.3.6.1.5.5.2 */
 gss_OID_desc GSSAPI_LIB_VARIABLE __gss_spnego_mechanism_oid_desc = { 6, rk_UNCONST("\x2b\x06\x01\x05\x05\x02") };
 
-/* GSS_C_PEER_HAS_UPDATED_SPNEGO - 1.3.6.1.4.1.5322.19.5 */
-gss_OID_desc GSSAPI_LIB_VARIABLE __gss_c_peer_has_updated_spnego_oid_desc = { 9, rk_UNCONST("\x2b\x06\x01\x04\x01\xa9\x4a\x13\x05") };
-
 /* GSS_C_NTLM_RESET_CRYPTO - 1.3.6.1.4.1.7165.655.1.3 */
 gss_OID_desc GSSAPI_LIB_VARIABLE __gss_c_ntlm_reset_crypto_oid_desc = { 11, rk_UNCONST("\x2b\x06\x01\x04\x01\xb7\x7d\x85\x0f\x01\x03") };
 
@@ -325,7 +322,6 @@ gss_OID _gss_ot_internal[] = {
   &__gss_krb5_mechanism_oid_desc,
   &__gss_ntlm_mechanism_oid_desc,
   &__gss_spnego_mechanism_oid_desc,
-  &__gss_c_peer_has_updated_spnego_oid_desc,
   &__gss_c_ntlm_reset_crypto_oid_desc,
   &__gss_negoex_mechanism_oid_desc,
   &__gss_c_ma_mech_concrete_oid_desc,

--- a/lib/gssapi/oid.txt
+++ b/lib/gssapi/oid.txt
@@ -66,7 +66,6 @@ oid	base	GSS_SPNEGO_MECHANISM			1.3.6.1.5.5.2
 
 # /* From Luke Howard */
 
-oid	base	GSS_C_PEER_HAS_UPDATED_SPNEGO		1.3.6.1.4.1.5322.19.5
 oid	base	GSS_C_NTLM_RESET_CRYPTO			1.3.6.1.4.1.7165.655.1.3
 oid	base	GSS_NEGOEX_MECHANISM			1.3.6.1.4.1.311.2.2.30
 

--- a/lib/gssapi/version-script.map
+++ b/lib/gssapi/version-script.map
@@ -171,7 +171,6 @@ HEIMDAL_GSS_2.0 {
 		__gss_krb5_mechanism_oid_desc;
 		__gss_ntlm_mechanism_oid_desc;
 		__gss_spnego_mechanism_oid_desc;
-		__gss_c_peer_has_updated_spnego_oid_desc;
 		__gss_c_ma_mech_concrete_oid_desc;
 		__gss_c_ma_mech_pseudo_oid_desc;
 		__gss_c_ma_mech_composite_oid_desc;


### PR DESCRIPTION
`GSS_C_PEER_HAS_UPDATED_SPNEGO` was previously used to indicate to the SPNEGO implementation that the peer is not running an older version of Windows that cannot correctly support the generation and verification of mechListMIC. (The last version of Windows to have this bug was Windows 2003, support for which ended in 2010.)

SPNEGO is now harmonized with RFC4178 and MIT, and omits mechListMIC when the most preferred mechanism was selected, unless the peer or mechanism explicitly requires it. Samba has tested this version of SPNEGO with no known issues.

Remove GSS_C_PEER_HAS_UPDATED_SPNEGO as it has no consumers. A publicly exported symbol is being removed by this patch, but it was a private API that should have had no consumers.