### PR TITLE
gss: try all mechanisms in gss_accept_sec_context()

### DIFF
--- a/lib/gssapi/krb5/accept_sec_context.c
+++ b/lib/gssapi/krb5/accept_sec_context.c
@@ -373,6 +373,13 @@ gsskrb5_acceptor_start(OM_uint32 * minor_status,
 				GSS_KRB5_MECHANISM);
 
     if (ret) {
+	/* Could be a raw AP-REQ (check for APPLICATION tag) */
+	if (input_token_buffer->length == 0 ||
+	    ((const uint8_t *)input_token_buffer->value)[0] != 0x6E) {
+	    *minor_status = ASN1_MISPLACED_FIELD;
+	    return GSS_S_DEFECTIVE_TOKEN;
+	}
+
 	/* Assume that there is no OID wrapping. */
 	indata.length	= input_token_buffer->length;
 	indata.data	= input_token_buffer->value;

--- a/lib/gssapi/ntlm/accept_sec_context.c
+++ b/lib/gssapi/ntlm/accept_sec_context.c
@@ -139,7 +139,7 @@ _gss_ntlm_accept_sec_context
 	if (ret) {
 	    _gss_ntlm_delete_sec_context(minor_status, context_handle, NULL);
 	    *minor_status = ret;
-	    return GSS_S_FAILURE;
+	    return GSS_S_DEFECTIVE_TOKEN;
 	}
 
 	if ((type1.flags & NTLM_NEG_UNICODE) == 0) {
@@ -195,7 +195,7 @@ _gss_ntlm_accept_sec_context
 	if (ret) {
 	    _gss_ntlm_delete_sec_context(minor_status, context_handle, NULL);
 	    *minor_status = ret;
-	    return GSS_S_FAILURE;
+	    return GSS_S_DEFECTIVE_TOKEN;
 	}
 
 	maj_stat = (*ctx->server->nsi_type3)(minor_status,

--- a/lib/gssapi/ntlm/init_sec_context.c
+++ b/lib/gssapi/ntlm/init_sec_context.c
@@ -347,7 +347,7 @@ _gss_ntlm_init_sec_context
 	if (ret) {
 	    _gss_ntlm_delete_sec_context(minor_status, context_handle, NULL);
 	    *minor_status = ret;
-	    return GSS_S_FAILURE;
+	    return GSS_S_DEFECTIVE_TOKEN;
 	}
 
 	ctx->flags = type2.flags;
@@ -437,7 +437,7 @@ _gss_ntlm_init_sec_context
 		_gss_ntlm_delete_sec_context(minor_status,
 					     context_handle, NULL);
 		*minor_status = ret;
-		return GSS_S_FAILURE;
+		return GSS_S_DEFECTIVE_TOKEN;
 	    }
 
 	    if (ti.domainname && strcmp(ti.domainname, name->domain) != 0) {


### PR DESCRIPTION
Rather than including specific cases in the mechanism glue for NTLMSSP and unframed Kerberos, try all mechanisms when accepting a first initiator token, moving onto the next one if `GSS_S_DEFECTIVE_TOKEN` or `GSS_S_BAD_MECH` is returned.