### PR TITLE
gss: update SAnon for draft-howard-gss-sanon-13

### DIFF
--- a/lib/gssapi/sanon/inquire_context.c
+++ b/lib/gssapi/sanon/inquire_context.c
@@ -64,7 +64,8 @@ _gss_sanon_inquire_context(OM_uint32 *minor,
         if (open_context)
             *open_context = 0;
         if (ctx_flags)
-            *ctx_flags = sc->flags;
+            *ctx_flags = GSS_C_REPLAY_FLAG | GSS_C_SEQUENCE_FLAG |
+			 GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG | GSS_C_ANON_FLAG;
     } else {
         major = gss_inquire_context(minor, sc->rfc4121, NULL, NULL, NULL,
                                     NULL, ctx_flags, locally_initiated,

--- a/lib/gssapi/sanon/sanon_locl.h
+++ b/lib/gssapi/sanon/sanon_locl.h
@@ -48,11 +48,9 @@ typedef struct sanon_ctx_desc {
     uint8_t sk[crypto_scalarmult_curve25519_BYTES];
     /* X25519 ECDH public key */
     uint8_t pk[crypto_scalarmult_curve25519_BYTES];
-    /* GSS_C_*_FLAG */
-    uint32_t flags;
     /* krb5 context for message protection/PRF */
     gss_ctx_id_t rfc4121;
-    int is_initiator;
+    int is_initiator : 1;
 } *sanon_ctx;
 
 extern gss_name_t _gss_sanon_anonymous_identity;
@@ -79,5 +77,8 @@ buffer_equal_p(gss_const_buffer_t b1, gss_const_buffer_t b2)
     return b1->length == b2->length &&
 	memcmp(b1->value, b2->value, b2->length) == 0;
 }
+
+/* flags that are valid to be sent from a SAnon initiator in the flags field */
+#define SANON_PROTOCOL_FLAG_MASK ( GSS_C_DCE_STYLE | GSS_C_IDENTIFY_FLAG | GSS_C_EXTENDED_ERROR_FLAG )
 
 #endif /* SANON_LOCL_H */


### PR DESCRIPTION
draft-howard-gss-sanon-13 will move extended (RFC4757) flags from the NegoEx metadata to an optional component of the initial context token