### PR TITLE
Deadlock in lib/krb5/mcache.c #432

### DIFF
--- a/lib/krb5/mcache.c
+++ b/lib/krb5/mcache.c
@@ -248,27 +248,28 @@ mcc_destroy(krb5_context context,
 {
     krb5_mcache **n, *m = MCACHE(id);
 
+    HEIMDAL_MUTEX_lock(&mcc_mutex);
     HEIMDAL_MUTEX_lock(&(m->mutex));
     if (m->refcnt == 0)
     {
     	HEIMDAL_MUTEX_unlock(&(m->mutex));
+	HEIMDAL_MUTEX_unlock(&mcc_mutex);
     	krb5_abortx(context, "mcc_destroy: refcnt already 0");
     }
 
     if (!MISDEAD(m)) {
 	/* if this is an active mcache, remove it from the linked
            list, and free all data */
-	HEIMDAL_MUTEX_lock(&mcc_mutex);
 	for(n = &mcc_head; n && *n; n = &(*n)->next) {
 	    if(m == *n) {
 		*n = m->next;
 		break;
 	    }
 	}
-	HEIMDAL_MUTEX_unlock(&mcc_mutex);
 	mcc_destroy_internal(context, m);
     }
     HEIMDAL_MUTEX_unlock(&(m->mutex));
+    HEIMDAL_MUTEX_unlock(&mcc_mutex);
     return 0;
 }
 


### PR DESCRIPTION
We've been hitting this deadlock with a customer using heimdal 7.7, found this was fixed back in 2018 but not integrated into 7.7.  Submitting PR for issue.