### PR TITLE
Pullups from master for 7-1-branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,9 @@
 install:
   - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
   - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
-  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf automake bison flex"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S zstd"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf automake"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S  bison flex"
 
 build_script:
   - set PSDKDir=C:\Program Files\Microsoft SDKs\Windows\v7.1

--- a/lib/krb5/config_file.c
+++ b/lib/krb5/config_file.c
@@ -353,6 +353,9 @@ krb5_config_parse_debug (struct fileptr *f,
     char buf[KRB5_BUFSIZ];
     krb5_error_code ret;
 
+    *lineno = 0;
+    *err_message = "";
+
     while (config_fgets(buf, sizeof(buf), f) != NULL) {
 	char *p;
 

--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -684,15 +684,15 @@ static int
 not_found(krb5_context context, krb5_const_principal p, krb5_error_code code)
 {
     krb5_error_code ret;
-    char *str;
+    char *str, *err;
 
+    err = krb5_get_error_message(context, code);
     ret = krb5_unparse_name(context, p, &str);
     if(ret) {
 	krb5_clear_error_message(context);
 	return code;
     }
-    krb5_set_error_message(context, code,
-			   N_("Matching credential (%s) not found", ""), str);
+    krb5_set_error_message(context, code, N_("%s (%s)", ""), err, str);
     free(str);
     return code;
 }


### PR DESCRIPTION
appveyor: Install zstd before other pkgs

krb5: krb5_config_parse_debug initialize output parameters

lib/krb5: not_found() do not substitute the error text
