### PR TITLE
Check some error returns from *asprintf()

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -332,13 +332,14 @@ _kdc_set_e_text(astgs_request_t r, char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)))
 {
     va_list ap;
-    char *e_text;
+    char *e_text = NULL;
+    int vasprintf_ret;
 
     va_start(ap, fmt);
-    vasprintf(&e_text, fmt, ap);
+    vasprintf_ret = vasprintf(&e_text, fmt, ap);
     va_end(ap);
 
-    if (!e_text)
+    if (vasprintf_ret < 0 || !e_text)
 	/* not much else to do... */
 	return;
 

--- a/lib/base/expand_path.c
+++ b/lib/base/expand_path.c
@@ -490,8 +490,10 @@ expand_token(heim_context context,
 
             errcode = 0;
             if (*colon == ':') {
-                asprintf(&arg, "%.*s", (int)(token_end - colon - 1), colon + 1);
-                if (!arg)
+                int asprintf_ret = asprintf(&arg, "%.*s",
+                                            (int)(token_end - colon - 1),
+                                            colon + 1);
+                if (asprintf_ret < 0 || !arg)
                     errcode = ENOMEM;
             }
             if (!errcode)

--- a/lib/base/log.c
+++ b/lib/base/log.c
@@ -638,18 +638,18 @@ fmtkv(int flags, const char *k, const char *fmt, va_list ap)
         __attribute__ ((__format__ (__printf__, 3, 0)))
 {
     heim_string_t str;
-    size_t i,j;
+    size_t i;
+    ssize_t j;
     char *buf1;
     char *buf2;
     char *buf3;
-
-    vasprintf(&buf1, fmt, ap);
-    if (!buf1)
+    int ret = vasprintf(&buf1, fmt, ap);
+    if (ret < 0 || !buf1)
 	return NULL;;
 
     j = asprintf(&buf2, "%s=%s", k, buf1);
     free(buf1);
-    if (!buf2)
+    if (j < 0 || !buf2)
 	return NULL;;
 
     /* We optionally eat the whitespace. */

--- a/lib/gssapi/mech/context.c
+++ b/lib/gssapi/mech/context.c
@@ -203,16 +203,17 @@ gss_mg_set_error_string(gss_OID mech,
     char *str = NULL;
     OM_uint32 junk;
     va_list ap;
+    int vasprintf_ret;
 
     mg = _gss_mechglue_thread();
     if (mg == NULL)
 	return maj;
 
     va_start(ap, fmt);
-    (void) vasprintf(&str, fmt, ap);
+    vasprintf_ret = vasprintf(&str, fmt, ap);
     va_end(ap);
 
-    if (str) {
+    if (vasprintf_ret >= 0 && str) {
 	gss_release_buffer(&junk, &mg->min_error);
 
 	mg->mech = mech;
@@ -303,6 +304,7 @@ _gss_mg_log_name(int level,
     if (_gss_find_mn(&junk, name, mech_type, &mn) == GSS_S_COMPLETE) {
 	OM_uint32 maj_stat = GSS_S_COMPLETE;
 	gss_buffer_desc namebuf;
+	int ret;
 
 	if (mn == NULL) {
 	    namebuf.value = "no name";
@@ -316,10 +318,10 @@ _gss_mg_log_name(int level,
 	    va_list ap;
 
 	    va_start(ap, fmt);
-	    (void) vasprintf(&str, fmt, ap);
+	    ret = vasprintf(&str, fmt, ap);
 	    va_end(ap);
 
-	    if (str)
+	    if (ret >= 0 && str)
 	        _gss_mg_log(level, "%s %.*s", str,
 			    (int)namebuf.length, (char *)namebuf.value);
 	    free(str);
@@ -338,15 +340,16 @@ _gss_mg_log_cred(int level,
     struct _gss_mechanism_cred *mc;
     char *str;
     va_list ap;
+    int ret;
 
     if (!_gss_mg_log_level(level))
         return;
 
     va_start(ap, fmt);
-    (void) vasprintf(&str, fmt, ap);
+    ret = vasprintf(&str, fmt, ap);
     va_end(ap);
 
-    if (cred) {
+    if (ret >=0 && cred) {
 	HEIM_TAILQ_FOREACH(mc, &cred->gc_mc, gmc_link) {
 	    _gss_mg_log(1, "%s: %s", str, mc->gmc_mech->gm_name);
 	}


### PR DESCRIPTION
This avoids these compiler warnings on Ubuntu 18.04
gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)

expand_path.c: In function ‘expand_token’:
expand_path.c:493:17: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
                 asprintf(&arg, "%.*s", (int)(token_end - colon - 1), colon + 1);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
log.c: In function ‘fmtkv’:
log.c:646:5: warning: ignoring return value of ‘vasprintf’, declared with attribute warn_unused_result [-Wunused-result]
     vasprintf(&buf1, fmt, ap);
     ^~~~~~~~~~~~~~~~~~~~~~~~~

mech/context.c: In function ‘gss_mg_set_error_string’:
mech/context.c:212:5: warning: ignoring return value of ‘vasprintf’, declared with attribute warn_unused_result [-Wunused-result]
     (void) vasprintf(&str, fmt, ap);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mech/context.c: In function ‘_gss_mg_log_name’:
mech/context.c:319:6: warning: ignoring return value of ‘vasprintf’, declared with attribute warn_unused_result [-Wunused-result]
      (void) vasprintf(&str, fmt, ap);
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mech/context.c: In function ‘_gss_mg_log_cred’:
mech/context.c:346:5: warning: ignoring return value of ‘vasprintf’, declared with attribute warn_unused_result [-Wunused-result]
     (void) vasprintf(&str, fmt, ap);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

kerberos5.c: In function ‘_kdc_set_e_text’:
kerberos5.c:338:5: warning: ignoring return value of ‘vasprintf’, declared with attribute warn_unused_result [-Wunused-result]
     vasprintf(&e_text, fmt, ap);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Andrew Bartlett <abartlet@samba.org>