### PR TITLE
Catch many compile warnings as errors in Travis CI with -Werror via --enable-developer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,12 @@ install:
                   --with-berkeley-db \
                   --with-berkeley-db-include=/usr/local/opt/berkeley-db/include
       else
-          ../configure --srcdir=`dirname "$PWD"` --enable-maintainer-mode $COVERAGE
+          # This list of -Wno-error options should be reduced over time where possible
+          if [ x"$TRAVIS_COMPILER" != x"clang" ]; then
+              CFLAGS="-Wno-error=empty-body -Wno-error=shadow -Wno-error=unused-value -Wno-error=unused-but-set-variable -Wno-error=bad-function-cast -Wno-error=unused-function -Wno-error=unused-result -Wno-error=deprecated-declarations" ../configure --enable-developer --srcdir=`dirname "$PWD"` --enable-maintainer-mode $COVERAGE
+          else
+              CFLAGS="-Wno-error=shadow -Wno-error=bad-function-cast -Wno-error=unused-function -Wno-error=unused-result -Wno-error=deprecated-declarations" ../configure --enable-developer --srcdir=`dirname "$PWD"` --enable-maintainer-mode $COVERAGE
+          fi
       fi
     - ulimit -c unlimited; make -j3
 

--- a/lib/gssapi/mech/gss_krb5.c
+++ b/lib/gssapi/mech/gss_krb5.c
@@ -486,7 +486,7 @@ gss_krb5_ccache_name(OM_uint32 *minor_status,
 		     const char **out_name)
 {
     struct _gss_mech_switch *m;
-    gss_buffer_desc buffer;
+    gss_buffer_desc buffer = GSS_C_EMPTY_BUFFER;
     OM_uint32 junk;
 
     _gss_load_mech();
@@ -494,11 +494,9 @@ gss_krb5_ccache_name(OM_uint32 *minor_status,
     if (out_name)
 	*out_name = NULL;
 
+    buffer.value = rk_UNCONST(name);
     if (name) {
-	buffer.value = rk_UNCONST(name);
 	buffer.length = strlen(name);
-    } else {
-	_mg_buffer_zero(&buffer);
     }
 
     HEIM_TAILQ_FOREACH(m, &_gss_mechs, gm_link) {


### PR DESCRIPTION
This should make it harder to introduce problem code into Heimdal and make it easier to import a new Heimdal version into Samba (where very strict warning options are in use).

Compiler warning options are very compiler version dependent so this list will need to be refined as the compiler used in Travis CI is upgraded.