### PR TITLE
kdc: Provide flag to hint to KDC that this is a FAST key lookup

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -53,7 +53,7 @@ get_fastuser_crypto(astgs_request_t r, krb5_enctype enctype,
 	goto out;
 
     ret = _kdc_db_fetch(r->context, r->config, fast_princ,
-			HDB_F_GET_CLIENT, NULL, NULL, &fast_user);
+			HDB_F_GET_FAST_COOKIE, NULL, NULL, &fast_user);
     krb5_free_principal(r->context, fast_princ);
     if (ret)
 	goto out;
@@ -429,7 +429,8 @@ _kdc_fast_unwrap_request(astgs_request_t r)
     }
 
     ret = _kdc_db_fetch(r->context, r->config, armor_server,
-			HDB_F_GET_SERVER, NULL, NULL, &armor_user);
+			HDB_F_GET_SERVER|HDB_F_GET_KRBTGT,
+			NULL, NULL, &armor_user);
     if(ret == HDB_ERR_NOT_FOUND_HERE) {
 	kdc_log(r->context, r->config, 5,
 		"armor key does not have secrets at this KDC, "

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -65,7 +65,8 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
 #define HDB_F_ALL_KVNOS		2048	/* we want all the keys, live or not */
 #define HDB_F_FOR_AS_REQ	4096	/* fetch is for a AS REQ */
 #define HDB_F_FOR_TGS_REQ	8192	/* fetch is for a TGS REQ */
-#define HDB_F_PRECHECK		16384	/* check that the operation would succeed */
+#define HDB_F_PRECHECK	       16384	/* check that the operation would succeed */
+#define HDB_F_GET_FAST_COOKIE  32768	/* fetch the FX-COOKIE key (not a normal principal) */
 
 /* hdb_capability_flags */
 #define HDB_CAP_F_HANDLE_ENTERPRISE_PRINCIPAL 1


### PR DESCRIPTION
For Samba the FAST key is not stored in the replicated DB, so
this helps Samba find it in the Samba hdb module.

Likewise, the armor key might be either a server or a krbtgt
key so call this with the right flags.

In-tree databases in Heimdal do not use these flags.

Signed-off-by: Andrew Bartlett <abartlet@samba.org>