### PR TITLE
Fix krb5_ccache plugins on master 

### DIFF
--- a/lib/base/common_plugin.h
+++ b/lib/base/common_plugin.h
@@ -37,19 +37,25 @@
 #define HEIMDAL_BASE_COMMON_PLUGIN_H
 
 #ifdef _WIN32
-#ifndef HEIM_CALLCONV
-#define HEIM_CALLCONV __stdcall
-#endif
-#ifndef HEIM_LIB_CALL
-#define HEIM_LIB_CALL __stdcall
-#endif
+# ifndef HEIM_CALLCONV
+#  define HEIM_CALLCONV __stdcall
+# endif
+# ifndef HEIM_LIB_CALL
+#  define HEIM_LIB_CALL __stdcall
+# endif
 #else
-#ifndef HEIM_CALLCONV
-#define HEIM_CALLCONV
+# ifndef HEIM_CALLCONV
+#  define HEIM_CALLCONV
+# endif
+# ifndef HEIM_LIB_CALL
+#  define HEIM_LIB_CALL
+# endif
 #endif
-#ifndef HEIM_LIB_CALL
-#define HEIM_LIB_CALL
+#ifndef KRB5_CALLCONV
+# define KRB5_CALLCONV HEIM_CALLCONV
 #endif
+#ifndef KRB5_LIB_CALL
+# define KRB5_LIB_CALL HEIM_LIB_CALL
 #endif
 
 /* For krb5 plugins, this is a krb5_context */

--- a/lib/heimdal/NTMakefile
+++ b/lib/heimdal/NTMakefile
@@ -53,7 +53,9 @@ DLLSDKDEPS= \
 	secur32.lib	\
 	shell32.lib	\
 	dnsapi.lib      \
-        shlwapi.lib
+	shlwapi.lib 	\
+	version.lib
+
 
 dlllflags=$(dlllflags) /DELAYLOAD:bcrypt.dll
 DLLSDKDEPS=$(DLLSDKDEPS)\

--- a/lib/krb5/acache.c
+++ b/lib/krb5/acache.c
@@ -444,11 +444,11 @@ get_cc_name(krb5_acc *a)
 
 
 static krb5_error_code KRB5_CALLCONV
-acc_get_name(krb5_context context,
-	     krb5_ccache id,
-             const char **name,
-             const char **colname,
-             const char **subsidiary)
+acc_get_name_2(krb5_context context,
+	       krb5_ccache id,
+	       const char **name,
+	       const char **colname,
+	       const char **subsidiary)
 {
     krb5_error_code ret = 0;
     krb5_acc *a = ACACHE(id);
@@ -523,7 +523,7 @@ acc_alloc(krb5_context context, krb5_ccache *id)
 }
 
 static krb5_error_code KRB5_CALLCONV
-acc_resolve(krb5_context context, krb5_ccache *id, const char *res, const char *sub)
+acc_resolve_2(krb5_context context, krb5_ccache *id, const char *res, const char *sub)
 {
     krb5_error_code ret;
     cc_time_t offset;
@@ -1095,10 +1095,10 @@ acc_lastchange(krb5_context context, krb5_ccache id, krb5_timestamp *mtime)
  */
 
 KRB5_LIB_VARIABLE const krb5_cc_ops krb5_acc_ops = {
-    KRB5_CC_OPS_VERSION,
+    KRB5_CC_OPS_VERSION_5,
     "API",
-    acc_get_name,
-    acc_resolve,
+    NULL,
+    NULL,
     acc_gen_new,
     acc_initialize,
     acc_destroy,
@@ -1121,6 +1121,8 @@ KRB5_LIB_VARIABLE const krb5_cc_ops krb5_acc_ops = {
     acc_lastchange,
     NULL,
     NULL,
+    acc_get_name_2,
+    acc_resolve_2
 };
 
 #endif

--- a/lib/krb5/dcache.c
+++ b/lib/krb5/dcache.c
@@ -244,11 +244,11 @@ get_default_cache(krb5_context context, krb5_dcache *dc,
 
 
 static krb5_error_code KRB5_CALLCONV
-dcc_get_name(krb5_context context,
-	     krb5_ccache id,
-             const char **name,
-             const char **dir,
-             const char **sub)
+dcc_get_name_2(krb5_context context,
+	       krb5_ccache id,
+	       const char **name,
+	       const char **dir,
+	       const char **sub)
 {
     krb5_dcache *dc = DCACHE(id);
 
@@ -329,10 +329,10 @@ get_default_dir(krb5_context context, char **res)
 }
 
 static krb5_error_code KRB5_CALLCONV
-dcc_resolve(krb5_context context,
-            krb5_ccache *id,
-            const char *res,
-            const char *sub)
+dcc_resolve_2(krb5_context context,
+	      krb5_ccache *id,
+	      const char *res,
+	      const char *sub)
 {
     krb5_error_code ret;
     krb5_dcache *dc = NULL;
@@ -505,7 +505,7 @@ dcc_gen_new(krb5_context context, krb5_ccache *id)
     if (ret == 0 && (fd = mkstemp(name + sizeof("DIR::") - 1)) == -1)
 	ret = errno;
     if (ret == 0)
-        ret = dcc_resolve(context, id, name + sizeof("DIR:") - 1, NULL);
+	ret = dcc_resolve_2(context, id, name + sizeof("DIR:") - 1, NULL);
 
     free(def_dir);
     free(name);
@@ -824,10 +824,10 @@ dcc_get_kdc_offset(krb5_context context, krb5_ccache id, krb5_deltat *kdc_offset
  */
 
 KRB5_LIB_VARIABLE const krb5_cc_ops krb5_dcc_ops = {
-    KRB5_CC_OPS_VERSION,
+    KRB5_CC_OPS_VERSION_5,
     "DIR",
-    dcc_get_name,
-    dcc_resolve,
+    NULL,
+    NULL,
     dcc_gen_new,
     dcc_initialize,
     dcc_destroy,
@@ -849,5 +849,7 @@ KRB5_LIB_VARIABLE const krb5_cc_ops krb5_dcc_ops = {
     dcc_set_default,
     dcc_lastchange,
     dcc_set_kdc_offset,
-    dcc_get_kdc_offset
+    dcc_get_kdc_offset,
+    dcc_get_name_2,
+    dcc_resolve_2
 };

--- a/lib/krb5/fcache.c
+++ b/lib/krb5/fcache.c
@@ -67,11 +67,11 @@ struct fcc_cursor {
 #define FCC_CURSOR(C) ((struct fcc_cursor*)(C))
 
 static krb5_error_code KRB5_CALLCONV
-fcc_get_name(krb5_context context,
-	     krb5_ccache id,
-             const char **name,
-             const char **colname,
-             const char **sub)
+fcc_get_name_2(krb5_context context,
+	       krb5_ccache id,
+	       const char **name,
+	       const char **colname,
+	       const char **sub)
 {
     if (FCACHE(id) == NULL)
         return KRB5_CC_NOTFOUND;
@@ -196,7 +196,7 @@ fcc_lock(krb5_context context, krb5_ccache id,
 
     if (exclusive == FALSE)
         return 0;
-    ret = fcc_get_name(context, id, &name, NULL, NULL);
+    ret = fcc_get_name_2(context, id, &name, NULL, NULL);
     if (ret == 0)
         ret = _krb5_xlock(context, fd, exclusive, name);
     return ret;
@@ -214,10 +214,10 @@ fcc_get_default_name(krb5_context, char **);
 #define FILESUBSEPCHR ((FILESUBSEP)[0])
 
 static krb5_error_code KRB5_CALLCONV
-fcc_resolve(krb5_context context,
-            krb5_ccache *id,
-            const char *res,
-            const char *sub)
+fcc_resolve_2(krb5_context context,
+	      krb5_ccache *id,
+	      const char *res,
+	      const char *sub)
 {
     krb5_fcache *f;
     char *freeme = NULL;
@@ -1662,10 +1662,10 @@ fcc_get_kdc_offset(krb5_context context, krb5_ccache id, krb5_deltat *kdc_offset
  */
 
 KRB5_LIB_VARIABLE const krb5_cc_ops krb5_fcc_ops = {
-    KRB5_CC_OPS_VERSION,
+    KRB5_CC_OPS_VERSION_5,
     "FILE",
-    fcc_get_name,
-    fcc_resolve,
+    NULL,
+    NULL,
     fcc_gen_new,
     fcc_initialize,
     fcc_destroy,
@@ -1687,5 +1687,7 @@ KRB5_LIB_VARIABLE const krb5_cc_ops krb5_fcc_ops = {
     fcc_set_default_cache,
     fcc_lastchange,
     fcc_set_kdc_offset,
-    fcc_get_kdc_offset
+    fcc_get_kdc_offset,
+    fcc_get_name_2,
+    fcc_resolve_2
 };

--- a/lib/krb5/kcm.c
+++ b/lib/krb5/kcm.c
@@ -232,11 +232,11 @@ kcm_free(krb5_context context, krb5_ccache *id)
 }
 
 static krb5_error_code KRB5_CALLCONV
-kcm_get_name(krb5_context context,
-	     krb5_ccache id,
-             const char **name,
-             const char **col,
-             const char **sub)
+kcm_get_name_2(krb5_context context,
+	       krb5_ccache id,
+	       const char **name,
+	       const char **col,
+	       const char **sub)
 {
     /*
      * TODO:
@@ -255,10 +255,10 @@ kcm_get_name(krb5_context context,
 }
 
 static krb5_error_code
-kcm_resolve(krb5_context context,
-            krb5_ccache *id,
-            const char *res,
-            const char *sub)
+kcm_resolve_2(krb5_context context,
+	      krb5_ccache *id,
+	      const char *res,
+	      const char *sub)
 {
     /*
      * For now, for KCM the `res' is the `sub'.
@@ -1126,7 +1126,7 @@ kcm_get_kdc_offset(krb5_context context, krb5_ccache id, krb5_deltat *kdc_offset
  */
 
 KRB5_LIB_VARIABLE const krb5_cc_ops krb5_kcm_ops = {
-    KRB5_CC_OPS_VERSION,
+    KRB5_CC_OPS_VERSION_5,
     "KCM",
     kcm_get_name,
     kcm_resolve,
@@ -1151,14 +1151,16 @@ KRB5_LIB_VARIABLE const krb5_cc_ops krb5_kcm_ops = {
     kcm_set_default,
     kcm_lastchange,
     kcm_set_kdc_offset,
-    kcm_get_kdc_offset
+    kcm_get_kdc_offset,
+    kcm_get_name_2,
+    kcm_resolve_2
 };
 
 KRB5_LIB_VARIABLE const krb5_cc_ops krb5_akcm_ops = {
-    KRB5_CC_OPS_VERSION,
+    KRB5_CC_OPS_VERSION_5,
     "API",
-    kcm_get_name,
-    kcm_resolve,
+    NULL,
+    NULL,
     kcm_gen_new,
     kcm_initialize,
     kcm_destroy,
@@ -1180,7 +1182,9 @@ KRB5_LIB_VARIABLE const krb5_cc_ops krb5_akcm_ops = {
     kcm_set_default,
     kcm_lastchange,
     NULL,
-    NULL
+    NULL,
+    kcm_get_name_2,
+    kcm_resolve_2
 };
 
 

--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -491,16 +491,19 @@ typedef struct krb5_creds {
 
 typedef struct krb5_cc_cache_cursor_data *krb5_cc_cache_cursor;
 
-#define KRB5_CC_OPS_VERSION 4
+#define KRB5_CC_OPS_VERSION_0	0
+#define KRB5_CC_OPS_VERSION_1	1
+#define KRB5_CC_OPS_VERSION_2	2
+#define KRB5_CC_OPS_VERSION_3	3
+#define KRB5_CC_OPS_VERSION_5	5
 
+/* Only extend the structure. Do not change signatures. */
 typedef struct krb5_cc_ops {
+    /* Version 0 */
     int version;
     const char *prefix;
-    krb5_error_code (KRB5_CALLCONV * get_name)(krb5_context, krb5_ccache,
-                                               const char **, const char **,
-                                               const char **);
-    krb5_error_code (KRB5_CALLCONV * resolve)(krb5_context, krb5_ccache *, const char *,
-                                              const char *);
+    const char* (KRB5_CALLCONV * get_name)(krb5_context, krb5_ccache);
+    krb5_error_code (KRB5_CALLCONV * resolve)(krb5_context, krb5_ccache *, const char *);
     krb5_error_code (KRB5_CALLCONV * gen_new)(krb5_context, krb5_ccache *);
     krb5_error_code (KRB5_CALLCONV * init)(krb5_context, krb5_ccache, krb5_principal);
     krb5_error_code (KRB5_CALLCONV * destroy)(krb5_context, krb5_ccache);
@@ -523,10 +526,20 @@ typedef struct krb5_cc_ops {
     krb5_error_code (KRB5_CALLCONV * end_cache_get)(krb5_context, krb5_cc_cursor);
     krb5_error_code (KRB5_CALLCONV * move)(krb5_context, krb5_ccache, krb5_ccache);
     krb5_error_code (KRB5_CALLCONV * get_default_name)(krb5_context, char **);
+    /* Version 1 */
     krb5_error_code (KRB5_CALLCONV * set_default)(krb5_context, krb5_ccache);
+    /* Version 2 */
     krb5_error_code (KRB5_CALLCONV * lastchange)(krb5_context, krb5_ccache, krb5_timestamp *);
+    /* Version 3 */
     krb5_error_code (KRB5_CALLCONV * set_kdc_offset)(krb5_context, krb5_ccache, krb5_deltat);
     krb5_error_code (KRB5_CALLCONV * get_kdc_offset)(krb5_context, krb5_ccache, krb5_deltat *);
+    /* Version 5 */
+    krb5_error_code (KRB5_CALLCONV * get_name_2)(krb5_context, krb5_ccache,
+						 const char **id, const char **res,
+						 const char **sub);
+    krb5_error_code (KRB5_CALLCONV * resolve_2)(krb5_context, krb5_ccache *id, const char *res,
+						const char *sub);
+    /* Add new functions here for versions 6 and above */
 } krb5_cc_ops;
 
 typedef struct heim_config_binding krb5_config_binding;

--- a/lib/krb5/krcache.c
+++ b/lib/krb5/krcache.c
@@ -1054,10 +1054,10 @@ make_cache(krb5_context context,
 
 /* Create a keyring ccache handle for the given residual string. */
 static krb5_error_code KRB5_CALLCONV
-krcc_resolve(krb5_context context,
-             krb5_ccache *id,
-             const char *residual,
-             const char *sub)
+krcc_resolve_2(krb5_context context,
+	       krb5_ccache *id,
+	       const char *residual,
+	       const char *sub)
 {
     krb5_error_code ret;
     key_serial_t collection_id, cache_id;
@@ -1346,11 +1346,11 @@ cleanup:
 
 /* Return an alias to the residual string of the cache. */
 static krb5_error_code KRB5_CALLCONV
-krcc_get_name(krb5_context context,
-              krb5_ccache id,
-              const char **name,
-              const char **collection_name,
-              const char **subsidiary_name)
+krcc_get_name_2(krb5_context context,
+		krb5_ccache id,
+		const char **name,
+		const char **collection_name,
+		const char **subsidiary_name)
 {
     krb5_krcache *data = KRCACHE(id);
 
@@ -2040,10 +2040,10 @@ krcc_get_default_name(krb5_context context, char **str)
  * be stored at the process or thread level respectively.
  */
 KRB5_LIB_VARIABLE const krb5_cc_ops krb5_krcc_ops = {
-    KRB5_CC_OPS_VERSION,
+    KRB5_CC_OPS_VERSION_5,
     "KEYRING",
-    krcc_get_name,
-    krcc_resolve,
+    NULL,
+    NULL,
     krcc_gen_new,
     krcc_initialize,
     krcc_destroy,
@@ -2066,6 +2066,8 @@ KRB5_LIB_VARIABLE const krb5_cc_ops krb5_krcc_ops = {
     krcc_lastchange,
     krcc_set_kdc_offset,
     krcc_get_kdc_offset,
+    krcc_get_name_2,
+    krcc_resolve_2
 };
 
 #endif /* HAVE_KEYUTILS_H */

--- a/lib/krb5/mcache.c
+++ b/lib/krb5/mcache.c
@@ -59,11 +59,11 @@ static struct krb5_mcache *mcc_head;
 #define MISDEAD(X)	((X)->dead)
 
 static krb5_error_code KRB5_CALLCONV
-mcc_get_name(krb5_context context,
-	     krb5_ccache id,
-             const char **name,
-             const char **col,
-             const char **sub)
+mcc_get_name_2(krb5_context context,
+	       krb5_ccache id,
+	       const char **name,
+	       const char **col,
+	       const char **sub)
 {
     if (name)
         *name = MCACHE(id)->name;
@@ -157,10 +157,10 @@ again:
 }
 
 static krb5_error_code KRB5_CALLCONV
-mcc_resolve(krb5_context context,
-            krb5_ccache *id,
-            const char *res,
-            const char *sub)
+mcc_resolve_2(krb5_context context,
+	      krb5_ccache *id,
+	      const char *res,
+	      const char *sub)
 {
     krb5_error_code ret;
     krb5_mcache *m;
@@ -610,10 +610,10 @@ mcc_get_kdc_offset(krb5_context context, krb5_ccache id, krb5_deltat *kdc_offset
  */
 
 KRB5_LIB_VARIABLE const krb5_cc_ops krb5_mcc_ops = {
-    KRB5_CC_OPS_VERSION,
+    KRB5_CC_OPS_VERSION_5,
     "MEMORY",
-    mcc_get_name,
-    mcc_resolve,
+    NULL,
+    NULL,
     mcc_gen_new,
     mcc_initialize,
     mcc_destroy,
@@ -635,5 +635,7 @@ KRB5_LIB_VARIABLE const krb5_cc_ops krb5_mcc_ops = {
     NULL,
     mcc_lastchange,
     mcc_set_kdc_offset,
-    mcc_get_kdc_offset
+    mcc_get_kdc_offset,
+    mcc_get_name_2,
+    mcc_resolve_2
 };

--- a/lib/krb5/pcache.c
+++ b/lib/krb5/pcache.c
@@ -48,7 +48,7 @@ cc_plugin_register_to_context(krb5_context context, const void *plug, void *plug
     krb5_cc_ops *ccops = (krb5_cc_ops *)plugctx;
     krb5_error_code ret;
 
-    if (ccops == NULL || ccops->version < KRB5_CC_OPS_VERSION)
+    if (ccops == NULL)
        return KRB5_PLUGIN_NO_HANDLE;
 
     ret = krb5_cc_register(context, ccops, TRUE);

--- a/lib/krb5/plugin.c
+++ b/lib/krb5/plugin.c
@@ -170,13 +170,39 @@ _krb5_plugin_run_f(krb5_context context,
  * @ingroup	krb5_support
  */
 
+#ifdef WIN32
+static uintptr_t
+djb2(uintptr_t hash, unsigned char *str)
+{
+    int c;
+
+    while (c = *str++)
+	hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+
+    return hash;
+}
+#endif
+
 KRB5_LIB_FUNCTION uintptr_t KRB5_LIB_CALL
 krb5_get_instance(const char *libname)
 {
+#ifdef WIN32
+    char *version;
+    char *name;
+    uintptr_t instance;
+
+    if (win32_getLibraryVersion("heimdal", &name, &version))
+	return 0;
+    instance = djb2(5381, name);
+    instance = djb2(instance, version);
+    free(name);
+    free(version);
+    return instance;
+#else
     static const char *instance = "libkrb5";
 
     if (strcmp(libname, "krb5") == 0)
 	return (uintptr_t)instance;
-
     return 0;
+#endif
 }

--- a/lib/krb5/scache.c
+++ b/lib/krb5/scache.c
@@ -566,11 +566,11 @@ bind_principal(krb5_context context,
  */
 
 static krb5_error_code KRB5_CALLCONV
-scc_get_name(krb5_context context,
-	     krb5_ccache id,
-             const char **name,
-             const char **file,
-             const char **sub)
+scc_get_name_2(krb5_context context,
+	       krb5_ccache id,
+	       const char **name,
+	       const char **file,
+	       const char **sub)
 {
     if (name)
         *name = SCACHE(id)->name;
@@ -582,10 +582,10 @@ scc_get_name(krb5_context context,
 }
 
 static krb5_error_code KRB5_CALLCONV
-scc_resolve(krb5_context context,
-            krb5_ccache *id,
-            const char *res,
-            const char *sub)
+scc_resolve_2(krb5_context context,
+	      krb5_ccache *id,
+	      const char *res,
+	      const char *sub)
 {
     krb5_error_code ret;
     krb5_scache *s;
@@ -1351,7 +1351,7 @@ again:
 
     ret = _krb5_cc_allocate(context, &krb5_scc_ops, id);
     if (ret == 0)
-        ret = scc_resolve(context, id, ctx->file, name);
+	ret = scc_resolve_2(context, id, ctx->file, name);
     if (ret) {
         free(*id);
         *id = NULL;
@@ -1485,10 +1485,10 @@ scc_set_default(krb5_context context, krb5_ccache id)
  */
 
 KRB5_LIB_VARIABLE const krb5_cc_ops krb5_scc_ops = {
-    KRB5_CC_OPS_VERSION,
+    KRB5_CC_OPS_VERSION_5,
     "SCC",
-    scc_get_name,
-    scc_resolve,
+    NULL,
+    NULL,
     scc_gen_new,
     scc_initialize,
     scc_destroy,
@@ -1510,7 +1510,9 @@ KRB5_LIB_VARIABLE const krb5_cc_ops krb5_scc_ops = {
     scc_set_default,
     NULL,
     NULL,
-    NULL
+    NULL,
+    scc_get_name_2,
+    scc_resolve_2
 };
 
 #endif

--- a/lib/roken/NTMakefile
+++ b/lib/roken/NTMakefile
@@ -130,6 +130,7 @@ libroken_la_OBJS =			\
 	$(OBJ)\warnerr.obj		\
 	$(OBJ)\warnx.obj		\
         $(OBJ)\win32_alloc.obj          \
+	$(OBJ)\win32_version.obj        \
 	$(OBJ)\writev.obj               \
 	$(OBJ)\xfree.obj
 

--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -1321,6 +1321,10 @@ int ROKEN_LIB_FUNCTION rk_socket(int, int, int);
 #define EWOULDBLOCK             140
 #endif
 
+#ifdef WIN32
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+win32_getLibraryVersion(const char *libname, char **outname, char **outversion);
+#endif
 
 #ifdef SOCKET_WRAPPER_REPLACE
 #include <socket_wrapper.h>

--- a/lib/roken/win32_version.c
+++ b/lib/roken/win32_version.c
@@ -1,0 +1,128 @@
+#include <config.h>
+#include "roken.h"
+#include <psapi.h>
+
+static DWORD
+GetVersionInfo(CHAR *filename, CHAR *szOutput, DWORD dwOutput)
+{
+    DWORD dwVersionHandle;
+    LPVOID pVersionInfo = 0;
+    DWORD retval = 0;
+    LPDWORD pLangInfo = 0;
+    LPTSTR szVersion = 0;
+    UINT len = 0;
+    TCHAR szVerQ[] = TEXT("\\StringFileInfo\\12345678\\FileVersion");
+    DWORD size = GetFileVersionInfoSize(filename, &dwVersionHandle);
+
+    if (!size)
+	return GetLastError();
+
+    pVersionInfo = malloc(size);
+    if (!pVersionInfo)
+	return ERROR_NOT_ENOUGH_MEMORY;
+
+    GetFileVersionInfo(filename, dwVersionHandle, size, pVersionInfo);
+    if (retval = GetLastError())
+	goto cleanup;
+
+    VerQueryValue(pVersionInfo, TEXT("\\VarFileInfo\\Translation"),
+		       (LPVOID*)&pLangInfo, &len);
+    if (retval = GetLastError())
+	goto cleanup;
+
+    wsprintf(szVerQ,
+	     TEXT("\\StringFileInfo\\%04x%04x\\FileVersion"),
+	     LOWORD(*pLangInfo), HIWORD(*pLangInfo));
+
+    VerQueryValue(pVersionInfo, szVerQ, (LPVOID*)&szVersion, &len);
+    if (retval = GetLastError()) {
+	/* try again with language 409 since the old binaries were tagged wrong */
+	wsprintf(szVerQ,
+		  TEXT("\\StringFileInfo\\0409%04x\\FileVersion"),
+		  HIWORD(*pLangInfo));
+
+	VerQueryValue(pVersionInfo, szVerQ, (LPVOID*)&szVersion, &len);
+	if (retval = GetLastError())
+	    goto cleanup;
+    }
+    snprintf(szOutput, dwOutput, TEXT("%s"), szVersion);
+    szOutput[dwOutput - 1] = 0;
+
+ cleanup:
+    free(pVersionInfo);
+
+    return retval;
+}
+
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+win32_getLibraryVersion(const char *libname, char **outname, char **outversion)
+{
+    CHAR modVersion[128];
+    HMODULE hMods[1024];
+    HANDLE hProcess;
+    DWORD cbNeeded;
+    unsigned int i;
+    int success = -1;
+    HINSTANCE hPSAPI;
+    DWORD (WINAPI *pGetModuleFileNameExA)(HANDLE hProcess, HMODULE hModule, LPTSTR lpFilename, DWORD nSize);
+    BOOL (WINAPI *pEnumProcessModules)(HANDLE hProcess, HMODULE* lphModule, DWORD cb, LPDWORD lpcbNeeded);
+
+    if (outversion)
+	*outversion = NULL;
+    if (outname)
+	*outname = NULL;
+
+    hPSAPI = LoadLibrary("psapi");
+    if ( hPSAPI == NULL )
+	return -1;
+
+    if (((FARPROC) pGetModuleFileNameExA =
+	  GetProcAddress( hPSAPI, "GetModuleFileNameExA" )) == NULL ||
+	 ((FARPROC) pEnumProcessModules =
+	   GetProcAddress( hPSAPI, "EnumProcessModules" )) == NULL)
+    {
+	goto out;
+    }
+
+    // Get a list of all the modules in this process.
+    hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+			   FALSE, GetCurrentProcessId());
+
+    if (pEnumProcessModules(hProcess, hMods, sizeof(hMods), &cbNeeded))
+    {
+	for (i = 0; i < (cbNeeded / sizeof(HMODULE)); i++)
+	{
+	    char szModName[2048];
+
+	    // Get the full path to the module's file.
+	    if (pGetModuleFileNameExA(hProcess, hMods[i], szModName, sizeof(szModName)))
+	    {
+		CHAR checkName[1024];
+		lstrcpy(checkName, szModName);
+		strlwr(checkName);
+
+		if (strstr(checkName, libname)) {
+		    if (GetVersionInfo(szModName, modVersion, sizeof(modVersion)) == 0) {
+			success = 0;
+			if (outversion)	{
+			    *outversion = strdup(modVersion);
+			    if (*outversion == NULL)
+				success = -1;
+			}
+			if (outname)	{
+			    *outname = strdup(szModName);
+			    if (*outname == NULL)
+				success = -1;
+			}
+		    }
+		    break;
+		}
+	    }
+	}
+    }
+    CloseHandle(hProcess);
+
+  out:
+    FreeLibrary(hPSAPI);
+    return success;
+}


### PR DESCRIPTION
- lib/krb5: krb5_get_instance does not work on Windows 7
- base: common_plugin.h define KRB5_CALLCONV / KRB5_LIB_CALL
- krb5: krb5_cc_ops backward compatibility and extensibility