### PR TITLE
Callers of krb5_config_[v]get_list() require struct krb5_config_binding

### DIFF
--- a/lib/base/heimbase.h
+++ b/lib/base/heimbase.h
@@ -120,15 +120,17 @@ struct heim_plugin_data {
     heim_get_instance_func_t get_instance;
 };
 
-typedef struct heim_config_binding heim_config_binding;
+/*
+ * heim_config_binding is identical to struct krb5_config_binding
+ * within krb5.h.  Its format is public and used by callers of
+ * krb5_config_get_list() and krb5_config_vget_list().
+ */
+enum heim_config_type {
+    heim_config_string,
+    heim_config_list,
+};
 struct heim_config_binding {
-    enum {
-        heim_config_string,
-        heim_config_list,
-        /* For compatibility in krb5 code */
-        krb5_config_string = heim_config_string,
-        krb5_config_list = heim_config_list,
-    } type;
+    enum heim_config_type type;
     char *name;
     struct heim_config_binding *next;
     union {
@@ -137,6 +139,7 @@ struct heim_config_binding {
         void *generic;
     } u;
 };
+typedef struct heim_config_binding heim_config_binding;
 typedef struct heim_config_binding heim_config_section;
 
 /*

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -695,7 +695,7 @@ krb5_set_config_files(krb5_context context, char **filenames)
                                      &tmp)))
         return ret;
     krb5_config_file_free(context, context->cf);
-    context->cf = tmp;
+    context->cf = (krb5_config_binding *)tmp;
     return init_context_from_config_file(context);
 }
 

--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -534,7 +534,27 @@ typedef struct krb5_cc_ops {
     /* Add new functions here for versions 6 and above */
 } krb5_cc_ops;
 
-typedef struct heim_config_binding krb5_config_binding;
+/*
+ * krb5_config_binding is identical to struct heim_config_binding
+ * within heimbase.h.  Its format is public and used by callers of
+ * krb5_config_get_list() and krb5_config_vget_list().
+ */
+enum krb5_config_type {
+    krb5_config_string,
+    krb5_config_list,
+};
+struct krb5_config_binding {
+    enum krb5_config_type type;
+    char *name;
+    struct krb5_config_binding *next;
+    union {
+        char *string;
+        struct krb5_config_binding *list;
+        void *generic;
+    } u;
+};
+
+typedef struct krb5_config_binding krb5_config_binding;
 typedef krb5_config_binding krb5_config_section;
 
 typedef struct krb5_ticket {

--- a/lib/krb5/verify_krb5_conf.c
+++ b/lib/krb5/verify_krb5_conf.c
@@ -37,10 +37,6 @@
 #include <err.h>
 
 /* verify krb5.conf */
-
-#define krb5_config_string  heim_config_string
-#define krb5_config_list    heim_config_list
-
 static int dumpconfig_flag = 0;
 static int version_flag = 0;
 static int help_flag	= 0;


### PR DESCRIPTION
ea90ca86664c73fb8d415f3cc7baacdf8a6dd685 removed the definition of struct krb5_config_binding which is required by callers of krb5_config_get_list() and krb5_config_vget_list().   

This PR permits out of tree callers to continue using these functions.  Since the structure was public it cannot be changed or removed unless krb5_config_get_list() and krb5_config_vget_list() are unsupported.