### PR TITLE
Fix Windows i386 test failures

### DIFF
--- a/lib/asn1/asn1-template.h
+++ b/lib/asn1/asn1-template.h
@@ -94,11 +94,11 @@ struct asn1_template {
     const void *ptr;
 };
 
-typedef int (*asn1_type_decode)(const unsigned char *, size_t, void *, size_t *);
-typedef int (*asn1_type_encode)(unsigned char *, size_t, const void *, size_t *);
-typedef size_t (*asn1_type_length)(const void *);
-typedef void (*asn1_type_release)(void *);
-typedef int (*asn1_type_copy)(const void *, void *);
+typedef int (ASN1CALL *asn1_type_decode)(const unsigned char *, size_t, void *, size_t *);
+typedef int (ASN1CALL *asn1_type_encode)(unsigned char *, size_t, const void *, size_t *);
+typedef size_t (ASN1CALL *asn1_type_length)(const void *);
+typedef void (ASN1CALL *asn1_type_release)(void *);
+typedef int (ASN1CALL *asn1_type_copy)(const void *, void *);
 
 struct asn1_type_func {
     asn1_type_encode encode;

--- a/lib/asn1/der_get.c
+++ b/lib/asn1/der_get.c
@@ -41,7 +41,7 @@
  * Either 0 or an error code is returned.
  */
 
-int
+int ASN1CALL
 der_get_unsigned (const unsigned char *p, size_t len,
 		  unsigned *ret, size_t *size)
 {
@@ -60,7 +60,7 @@ der_get_unsigned (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_unsigned64 (const unsigned char *p, size_t len,
                    uint64_t *ret, size_t *size)
 {
@@ -79,7 +79,7 @@ der_get_unsigned64 (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_integer (const unsigned char *p, size_t len,
 		 int *ret, size_t *size)
 {
@@ -99,7 +99,7 @@ der_get_integer (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_integer64 (const unsigned char *p, size_t len,
 		   int64_t *ret, size_t *size)
 {
@@ -120,7 +120,7 @@ der_get_integer64 (const unsigned char *p, size_t len,
 }
 
 
-int
+int ASN1CALL
 der_get_length (const unsigned char *p, size_t len,
 		size_t *val, size_t *size)
 {
@@ -154,7 +154,7 @@ der_get_length (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_boolean(const unsigned char *p, size_t len, int *data, size_t *size)
 {
     if(len < 1)
@@ -167,7 +167,7 @@ der_get_boolean(const unsigned char *p, size_t len, int *data, size_t *size)
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_general_string (const unsigned char *p, size_t len,
 			heim_general_string *str, size_t *size)
 {
@@ -203,7 +203,7 @@ der_get_general_string (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_utf8string (const unsigned char *p, size_t len,
 		    heim_utf8_string *str, size_t *size)
 {
@@ -213,7 +213,7 @@ der_get_utf8string (const unsigned char *p, size_t len,
 #define gen_data_zero(_data) \
 	do { (_data)->length = 0; (_data)->data = NULL; } while(0)
 
-int
+int ASN1CALL
 der_get_printable_string(const unsigned char *p, size_t len,
 			 heim_printable_string *str, size_t *size)
 {
@@ -233,14 +233,14 @@ der_get_printable_string(const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_ia5_string(const unsigned char *p, size_t len,
 		   heim_ia5_string *str, size_t *size)
 {
     return der_get_printable_string(p, len, str, size);
 }
 
-int
+int ASN1CALL
 der_get_bmp_string (const unsigned char *p, size_t len,
 		    heim_bmp_string *data, size_t *size)
 {
@@ -276,7 +276,7 @@ der_get_bmp_string (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_universal_string (const unsigned char *p, size_t len,
 			  heim_universal_string *data, size_t *size)
 {
@@ -311,14 +311,14 @@ der_get_universal_string (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_visible_string (const unsigned char *p, size_t len,
 			heim_visible_string *str, size_t *size)
 {
     return der_get_general_string(p, len, str, size);
 }
 
-int
+int ASN1CALL
 der_get_octet_string (const unsigned char *p, size_t len,
 		      heim_octet_string *data, size_t *size)
 {
@@ -331,7 +331,7 @@ der_get_octet_string (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_octet_string_ber (const unsigned char *p, size_t len,
 			  heim_octet_string *data, size_t *size)
 {
@@ -400,7 +400,7 @@ der_get_octet_string_ber (const unsigned char *p, size_t len,
 }
 
 
-int
+int ASN1CALL
 der_get_heim_integer (const unsigned char *p, size_t len,
 		      heim_integer *data, size_t *size)
 {
@@ -486,7 +486,7 @@ generalizedtime2time (const char *s, time_t *t)
     return 0;
 }
 
-static int
+static int ASN1CALL
 der_get_time (const unsigned char *p, size_t len,
 	      time_t *data, size_t *size)
 {
@@ -507,21 +507,21 @@ der_get_time (const unsigned char *p, size_t len,
     return e;
 }
 
-int
+int ASN1CALL
 der_get_generalized_time (const unsigned char *p, size_t len,
 			  time_t *data, size_t *size)
 {
     return der_get_time(p, len, data, size);
 }
 
-int
+int ASN1CALL
 der_get_utctime (const unsigned char *p, size_t len,
 			  time_t *data, size_t *size)
 {
     return der_get_time(p, len, data, size);
 }
 
-int
+int ASN1CALL
 der_get_oid (const unsigned char *p, size_t len,
 	     heim_oid *data, size_t *size)
 {
@@ -569,7 +569,7 @@ der_get_oid (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_tag (const unsigned char *p, size_t len,
 	     Der_class *cls, Der_type *type,
 	     unsigned int *tag, size_t *size)
@@ -601,7 +601,7 @@ der_get_tag (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_match_tag (const unsigned char *p, size_t len,
 	       Der_class cls, Der_type type,
 	       unsigned int tag, size_t *size)
@@ -615,7 +615,7 @@ der_match_tag (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_match_tag2 (const unsigned char *p, size_t len,
 		Der_class cls, Der_type *type,
 		unsigned int tag, size_t *size)
@@ -637,7 +637,7 @@ der_match_tag2 (const unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_match_tag_and_length (const unsigned char *p, size_t len,
 			  Der_class cls, Der_type *type, unsigned int tag,
 			  size_t *length_ret, size_t *size)
@@ -682,7 +682,7 @@ _heim_fix_dce(size_t reallen, size_t *len)
     return 0;
 }
 
-int
+int ASN1CALL
 der_get_bit_string (const unsigned char *p, size_t len,
 		    heim_bit_string *data, size_t *size)
 {

--- a/lib/asn1/gen.c
+++ b/lib/asn1/gen.c
@@ -806,7 +806,7 @@ define_type (int level, const char *name, const char *basename, Type *t, int typ
         if (max_memno > 63)
             range.max = INT64_MAX;
         else
-            range.max = 1LU << max_memno;
+            range.max = 1ULL << max_memno;
 
 	i.type = TInteger;
 	i.range = &range;

--- a/lib/asn1/gen_decode.c
+++ b/lib/asn1/gen_decode.c
@@ -384,7 +384,7 @@ decode_type(const char *name, const Type *t, int optional, struct value *defval,
 	    decode_type (s, m->type, 0, NULL, forwstr, m->gen_name, NULL, depth + 1);
 	    free (s);
 
-	    fprintf(codefile, "members |= (1LU << %u);\n", memno);
+	    fprintf(codefile, "members |= (1ULL << %u);\n", memno);
 	    memno++;
 	    fprintf(codefile, "break;\n");
 	}
@@ -400,7 +400,7 @@ decode_type(const char *name, const Type *t, int optional, struct value *defval,
 
 	    if (asprintf (&s, "%s->%s", name, m->gen_name) < 0 || s == NULL)
 		errx(1, "malloc");
-	    fprintf(codefile, "if((members & (1LU << %u)) == 0)\n", memno);
+	    fprintf(codefile, "if((members & (1ULL << %u)) == 0)\n", memno);
 	    if(m->optional)
 		fprintf(codefile, "%s = NULL;\n", s);
 	    else if(m->defval)

--- a/lib/asn1/gen_glue.c
+++ b/lib/asn1/gen_glue.c
@@ -53,7 +53,7 @@ generate_2int (const Type *t, const char *gen_name)
 	     gen_name, gen_name);
 
     HEIM_TAILQ_FOREACH(m, t->members, members) {
-	fprintf (codefile, "if(f.%s) r |= (1LU << %d);\n",
+	fprintf (codefile, "if(f.%s) r |= (1ULL << %d);\n",
 		 m->gen_name, m->val);
     }
     fprintf (codefile, "return r;\n"
@@ -114,7 +114,7 @@ generate_units (const Type *t, const char *gen_name)
     if(t->members) {
 	HEIM_TAILQ_FOREACH_REVERSE(m, t->members, memhead, members) {
 	    fprintf (codefile,
-		     "\t{\"%s\",\t1LU << %d},\n", m->name, m->val);
+		     "\t{\"%s\",\t1ULL << %d},\n", m->name, m->val);
 	}
     }
 


### PR DESCRIPTION
These two commits fix transient failures of the in-tree tests on Windows i386.

For discussion only at this point.   The impact of the ASN1CALL change on 32-bit Windows consumers must be evaluated in more detail.