### PR TITLE
hx509 context memory leaks

### DIFF
--- a/lib/base/context.c
+++ b/lib/base/context.c
@@ -209,16 +209,22 @@ add_file(char ***pfilenames, int *len, char *file)
 
 #ifdef WIN32
 static char *
-get_default_config_config_files_from_registry(void)
+get_default_config_config_files_from_registry(const char *envvar)
 {
     static const char *KeyName = "Software\\Heimdal"; /* XXX #define this */
+    const char *ValueName;
     char *config_file = NULL;
     LONG rcode;
     HKEY key;
 
+    if (stricmp(envvar, "KRB5_CONFIG") == 0)
+	ValueName = "config";
+    else
+	ValueName = envvar;
+
     rcode = RegOpenKeyEx(HKEY_CURRENT_USER, KeyName, 0, KEY_READ, &key);
     if (rcode == ERROR_SUCCESS) {
-        config_file = heim_parse_reg_value_as_multi_string(NULL, key, "config",
+	config_file = heim_parse_reg_value_as_multi_string(NULL, key, ValueName,
                                                            REG_NONE, 0, PATH_SEP);
         RegCloseKey(key);
     }
@@ -228,7 +234,7 @@ get_default_config_config_files_from_registry(void)
 
     rcode = RegOpenKeyEx(HKEY_LOCAL_MACHINE, KeyName, 0, KEY_READ, &key);
     if (rcode == ERROR_SUCCESS) {
-        config_file = heim_parse_reg_value_as_multi_string(NULL, key, "config",
+	config_file = heim_parse_reg_value_as_multi_string(NULL, key, ValueName,
                                                            REG_NONE, 0, PATH_SEP);
         RegCloseKey(key);
     }
@@ -326,7 +332,7 @@ heim_get_default_config_files(const char *def,
 #ifdef _WIN32
     if (files == NULL) {
         char * reg_files;
-        reg_files = get_default_config_config_files_from_registry();
+	reg_files = get_default_config_config_files_from_registry(envvar);
         if (reg_files != NULL) {
             heim_error_code code;
 

--- a/lib/gssapi/krb5/delete_sec_context.c
+++ b/lib/gssapi/krb5/delete_sec_context.c
@@ -75,6 +75,8 @@ _gsskrb5_delete_sec_context(OM_uint32 * minor_status,
     krb5_data_free(&ctx->fwd_data);
     if (ctx->crypto)
     	krb5_crypto_destroy(context, ctx->crypto);
+    if (ctx->ccache && (ctx->more_flags & CLOSE_CCACHE))
+	krb5_cc_close(context, ctx->ccache);
 
     HEIMDAL_MUTEX_unlock(&ctx->ctx_id_mutex);
     HEIMDAL_MUTEX_destroy(&ctx->ctx_id_mutex);

--- a/lib/hx509/cert.c
+++ b/lib/hx509/cert.c
@@ -262,6 +262,7 @@ hx509_context_free(hx509_context *context)
     free_error_table ((*context)->et_list);
     if ((*context)->querystat)
 	free((*context)->querystat);
+    heim_config_file_free((*context)->hcontext, (*context)->cf);
     heim_context_free(&(*context)->hcontext);
     memset(*context, 0, sizeof(**context));
     free(*context);

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -660,8 +660,7 @@ krb5_free_context(krb5_context context)
     krb5_set_send_to_kdc_func(context, NULL, NULL);
 
 #ifdef PKINIT
-    if (context->hx509ctx)
-	hx509_context_free(&context->hx509ctx);
+    hx509_context_free(&context->hx509ctx);
 #endif
 
     if (context->flags & KRB5_CTX_F_SOCKETS_INITIALIZED) {


### PR DESCRIPTION
The implementation of hx509_context_free() fails to free the parsed configuration file data.

On Windows, no differentiation was made between KRB5_CONFIG and new configurations such as HX509_CONFIG when obtaining configuration file lists from the registry.
