### PR TITLE
gss/krb5: acquire_cred_with_password set opt default flags

### DIFF
--- a/lib/gssapi/krb5/acquire_cred.c
+++ b/lib/gssapi/krb5/acquire_cred.c
@@ -208,6 +208,7 @@ acquire_cred_with_password(OM_uint32 *minor_status,
     krb5_error_code kret;
     time_t now;
     OM_uint32 left;
+    const char *realm;
 
     if (!is_valid_password_cred_store(cred_store)) {
 	*minor_status = GSS_KRB5_S_G_BAD_PASSWORD_CRED_STORE;
@@ -238,6 +239,10 @@ acquire_cred_with_password(OM_uint32 *minor_status,
     kret = krb5_get_init_creds_opt_alloc(context, &opt);
     if (kret)
         goto end;
+
+    realm = krb5_principal_get_realm(context, handle->principal);
+
+    krb5_get_init_creds_opt_set_default_flags(context, "gss_krb5", realm, opt);
 
     /*
      * Get the current time before the AS exchange so we don't


### PR DESCRIPTION
acquire_cred_with_password() must call
krb5_get_init_creds_opt_set_default_flags() to initialize the
krb5_get_init_creds option flags to the values obtained from
the krb5_context.

Change-Id: Icd8c500dd0787a781c2382284f19cef277b1d30b