### PR TITLE
RFC4757/padding fixes

### DIFF
--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -976,7 +976,7 @@ _gssapi_wrap_iov_arcfour(OM_uint32 *minor_status,
 	header_len -= data_len;
     }
 
-    if (GSS_IOV_BUFFER_FLAGS(header->type) & GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE) {
+    if (GSS_IOV_BUFFER_FLAGS(header->type) & GSS_IOV_BUFFER_FLAG_ALLOCATE) {
 	major_status = _gk_allocate_buffer(minor_status, header,
 					   header_len);
 	if (major_status != GSS_S_COMPLETE)
@@ -990,7 +990,7 @@ _gssapi_wrap_iov_arcfour(OM_uint32 *minor_status,
     }
 
     if (padding) {
-	if (GSS_IOV_BUFFER_FLAGS(padding->type) & GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE) {
+	if (GSS_IOV_BUFFER_FLAGS(padding->type) & GSS_IOV_BUFFER_FLAG_ALLOCATE) {
 	    major_status = _gk_allocate_buffer(minor_status, padding, 1);
 	    if (major_status != GSS_S_COMPLETE)
 		goto failure;

--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -880,7 +880,8 @@ _gssapi_wrap_iov_length_arcfour(OM_uint32 *minor_status,
 	}
     }
 
-    major_status = _gk_verify_buffers(minor_status, ctx, header, padding, trailer);
+    major_status = _gk_verify_buffers(minor_status, ctx, header,
+				      padding, trailer, FALSE);
     if (major_status != GSS_S_COMPLETE) {
 	    return major_status;
     }
@@ -937,7 +938,8 @@ _gssapi_wrap_iov_arcfour(OM_uint32 *minor_status,
     padding = _gk_find_buffer(iov, iov_count, GSS_IOV_BUFFER_TYPE_PADDING);
     trailer = _gk_find_buffer(iov, iov_count, GSS_IOV_BUFFER_TYPE_TRAILER);
 
-    major_status = _gk_verify_buffers(minor_status, ctx, header, padding, trailer);
+    major_status = _gk_verify_buffers(minor_status, ctx, header,
+				      padding, trailer, FALSE);
     if (major_status != GSS_S_COMPLETE) {
 	return major_status;
     }
@@ -1181,10 +1183,11 @@ _gssapi_unwrap_iov_arcfour(OM_uint32 *minor_status,
 
     /* Check if the packet is correct */
     major_status = _gk_verify_buffers(minor_status,
-				  ctx,
-				  header,
-				  padding,
-				  trailer);
+				      ctx,
+				      header,
+				      padding,
+				      trailer,
+				      FALSE); /* behaves as stream cipher */
     if (major_status != GSS_S_COMPLETE) {
 	return major_status;
     }

--- a/lib/gssapi/test_context.c
+++ b/lib/gssapi/test_context.c
@@ -451,7 +451,7 @@ wrapunwrap_iov(gss_ctx_id_t cctx, gss_ctx_id_t sctx, int flags, gss_OID mechoid)
 
     memset(iov, 0, sizeof(iov));
 
-    iov[0].type = GSS_IOV_BUFFER_TYPE_HEADER | GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE;
+    iov[0].type = GSS_IOV_BUFFER_TYPE_HEADER | GSS_IOV_BUFFER_FLAG_ALLOCATE;
 
     if (header.length != 0) {
 	iov[1].type = GSS_IOV_BUFFER_TYPE_SIGN_ONLY;
@@ -481,7 +481,7 @@ wrapunwrap_iov(gss_ctx_id_t cctx, gss_ctx_id_t sctx, int flags, gss_OID mechoid)
     if (dce_style_flag) {
 	iov[4].type = GSS_IOV_BUFFER_TYPE_EMPTY;
     } else {
-	iov[4].type = GSS_IOV_BUFFER_TYPE_PADDING | GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE;
+	iov[4].type = GSS_IOV_BUFFER_TYPE_PADDING | GSS_IOV_BUFFER_FLAG_ALLOCATE;
     }
     iov[4].buffer.length = 0;
     iov[4].buffer.value = 0;
@@ -490,7 +490,7 @@ wrapunwrap_iov(gss_ctx_id_t cctx, gss_ctx_id_t sctx, int flags, gss_OID mechoid)
     } else if (flags & USE_HEADER_ONLY) {
 	iov[5].type = GSS_IOV_BUFFER_TYPE_EMPTY;
     } else {
-	iov[5].type = GSS_IOV_BUFFER_TYPE_TRAILER | GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE;
+	iov[5].type = GSS_IOV_BUFFER_TYPE_TRAILER | GSS_IOV_BUFFER_FLAG_ALLOCATE;
     }
     iov[5].buffer.length = 0;
     iov[5].buffer.value = 0;


### PR DESCRIPTION
Fixes for #739

* gss_unwrap_iov() with rc4-hmac (RFC4757) encryption types would fail unless GSS_C_DCE_STYLE was specified, as an incorrect length was passed to _gssapi_verify_mech_header(). (The correct length is the header length for GSS_C_DCE_STYLE, and the wrap token length otherwise.)

* RFC 4121/4757 don't require padding as they operate as stream ciphers. Make the PADDING buffer optional when using these encryption types with gss_wrap_iov() and gss_unwrap_iov().