### PR TITLE
heimdal 7 1 branch pullups

### DIFF
--- a/lib/gssapi/krb5/acquire_cred.c
+++ b/lib/gssapi/krb5/acquire_cred.c
@@ -100,6 +100,7 @@ acquire_cred_with_password(OM_uint32 *minor_status,
     krb5_error_code kret;
     time_t now;
     OM_uint32 left;
+    const char *realm;
 
     if (cred_usage == GSS_C_ACCEPT) {
         /*
@@ -125,6 +126,10 @@ acquire_cred_with_password(OM_uint32 *minor_status,
     kret = krb5_get_init_creds_opt_alloc(context, &opt);
     if (kret)
         goto end;
+
+    realm = krb5_principal_get_realm(context, handle->principal);
+
+    krb5_get_init_creds_opt_set_default_flags(context, "gss_krb5", realm, opt);
 
     /*
      * Get the current time before the AS exchange so we don't

--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -976,7 +976,7 @@ _gssapi_wrap_iov_arcfour(OM_uint32 *minor_status,
 	header_len -= data_len;
     }
 
-    if (GSS_IOV_BUFFER_FLAGS(header->type) & GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE) {
+    if (GSS_IOV_BUFFER_FLAGS(header->type) & GSS_IOV_BUFFER_FLAG_ALLOCATE) {
 	major_status = _gk_allocate_buffer(minor_status, header,
 					   header_len);
 	if (major_status != GSS_S_COMPLETE)
@@ -990,7 +990,7 @@ _gssapi_wrap_iov_arcfour(OM_uint32 *minor_status,
     }
 
     if (padding) {
-	if (GSS_IOV_BUFFER_FLAGS(padding->type) & GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE) {
+	if (GSS_IOV_BUFFER_FLAGS(padding->type) & GSS_IOV_BUFFER_FLAG_ALLOCATE) {
 	    major_status = _gk_allocate_buffer(minor_status, padding, 1);
 	    if (major_status != GSS_S_COMPLETE)
 		goto failure;

--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -880,7 +880,8 @@ _gssapi_wrap_iov_length_arcfour(OM_uint32 *minor_status,
 	}
     }
 
-    major_status = _gk_verify_buffers(minor_status, ctx, header, padding, trailer);
+    major_status = _gk_verify_buffers(minor_status, ctx, header,
+				      padding, trailer, FALSE);
     if (major_status != GSS_S_COMPLETE) {
 	    return major_status;
     }
@@ -937,7 +938,8 @@ _gssapi_wrap_iov_arcfour(OM_uint32 *minor_status,
     padding = _gk_find_buffer(iov, iov_count, GSS_IOV_BUFFER_TYPE_PADDING);
     trailer = _gk_find_buffer(iov, iov_count, GSS_IOV_BUFFER_TYPE_TRAILER);
 
-    major_status = _gk_verify_buffers(minor_status, ctx, header, padding, trailer);
+    major_status = _gk_verify_buffers(minor_status, ctx, header,
+				      padding, trailer, FALSE);
     if (major_status != GSS_S_COMPLETE) {
 	return major_status;
     }
@@ -1181,10 +1183,11 @@ _gssapi_unwrap_iov_arcfour(OM_uint32 *minor_status,
 
     /* Check if the packet is correct */
     major_status = _gk_verify_buffers(minor_status,
-				  ctx,
-				  header,
-				  padding,
-				  trailer);
+				      ctx,
+				      header,
+				      padding,
+				      trailer,
+				      FALSE); /* behaves as stream cipher */
     if (major_status != GSS_S_COMPLETE) {
 	return major_status;
     }

--- a/lib/gssapi/krb5/cfx.c
+++ b/lib/gssapi/krb5/cfx.c
@@ -206,11 +206,25 @@ gss_iov_buffer_desc *
 _gk_find_buffer(gss_iov_buffer_desc *iov, int iov_count, OM_uint32 type)
 {
     int i;
+    gss_iov_buffer_t iovp = GSS_C_NO_IOV_BUFFER;
 
-    for (i = 0; i < iov_count; i++)
-	if (type == GSS_IOV_BUFFER_TYPE(iov[i].type))
-	    return &iov[i];
-    return NULL;
+    if (iov == GSS_C_NO_IOV_BUFFER)
+	return GSS_C_NO_IOV_BUFFER;
+
+    /*
+     * This function is used to find header, padding or trailer buffers
+     * which are singletons; return NULL if multiple instances are found.
+     */
+    for (i = 0; i < iov_count; i++) {
+	if (type == GSS_IOV_BUFFER_TYPE(iov[i].type)) {
+	    if (iovp == GSS_C_NO_IOV_BUFFER)
+		iovp = &iov[i];
+	    else
+		return GSS_C_NO_IOV_BUFFER;
+	}
+    }
+
+    return iovp;
 }
 
 OM_uint32

--- a/lib/gssapi/krb5/cfx.c
+++ b/lib/gssapi/krb5/cfx.c
@@ -224,6 +224,17 @@ _gk_find_buffer(gss_iov_buffer_desc *iov, int iov_count, OM_uint32 type)
 	}
     }
 
+    /*
+     * For compatibility with SSPI, an empty padding buffer is treated
+     * equivalent to an absent padding buffer (unless the caller is
+     * requesting that a padding buffer be allocated).
+     */
+    if (iovp &&
+	iovp->buffer.length == 0 &&
+	type == GSS_IOV_BUFFER_TYPE_PADDING &&
+	(GSS_IOV_BUFFER_FLAGS(iovp->type) & GSS_IOV_BUFFER_FLAG_ALLOCATE) == 0)
+	iovp = NULL;
+
     return iovp;
 }
 

--- a/lib/gssapi/test_context.c
+++ b/lib/gssapi/test_context.c
@@ -349,7 +349,7 @@ wrapunwrap_iov(gss_ctx_id_t cctx, gss_ctx_id_t sctx, int flags, gss_OID mechoid)
 
     memset(iov, 0, sizeof(iov));
 
-    iov[0].type = GSS_IOV_BUFFER_TYPE_HEADER | GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE;
+    iov[0].type = GSS_IOV_BUFFER_TYPE_HEADER | GSS_IOV_BUFFER_FLAG_ALLOCATE;
 
     if (header.length != 0) {
 	iov[1].type = GSS_IOV_BUFFER_TYPE_SIGN_ONLY;
@@ -375,7 +375,7 @@ wrapunwrap_iov(gss_ctx_id_t cctx, gss_ctx_id_t sctx, int flags, gss_OID mechoid)
     if (dce_style_flag) {
 	iov[4].type = GSS_IOV_BUFFER_TYPE_EMPTY;
     } else {
-	iov[4].type = GSS_IOV_BUFFER_TYPE_PADDING | GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE;
+	iov[4].type = GSS_IOV_BUFFER_TYPE_PADDING | GSS_IOV_BUFFER_FLAG_ALLOCATE;
     }
     iov[4].buffer.length = 0;
     iov[4].buffer.value = 0;
@@ -384,7 +384,7 @@ wrapunwrap_iov(gss_ctx_id_t cctx, gss_ctx_id_t sctx, int flags, gss_OID mechoid)
     } else if (flags & USE_HEADER_ONLY) {
 	iov[5].type = GSS_IOV_BUFFER_TYPE_EMPTY;
     } else {
-	iov[5].type = GSS_IOV_BUFFER_TYPE_TRAILER | GSS_IOV_BUFFER_TYPE_FLAG_ALLOCATE;
+	iov[5].type = GSS_IOV_BUFFER_TYPE_TRAILER | GSS_IOV_BUFFER_FLAG_ALLOCATE;
     }
     iov[5].buffer.length = 0;
     iov[5].buffer.value = 0;

--- a/lib/kafs/afssysdefs.h
+++ b/lib/kafs/afssysdefs.h
@@ -104,10 +104,6 @@
 #define AFS_SYSCALL 210
 #endif
 
-#ifdef __APPLE__		/* MacOS X */
-#define AFS_SYSCALL 230
-#endif
-
 #ifdef SYS_afs_syscall
 #define AFS_SYSCALL3	SYS_afs_syscall
 #endif


### PR DESCRIPTION
- 61c845761 kafs: disable use of AFS syscall on macOS
- 87ab10e3d gss/krb5: acquire_cred_with_password set opt default flags
- 3baf636ac gssapi/krb5: make PADDING buffer optional in GSS IOV API
- b75cc5449 gssapi/krb5: fix rc4-hmac gss_unwrap_iov() without DCE_STYLE
- e1b6a7480 gssapi/krb5: use GSS_IOV_BUFFER_FLAG_ALLOCATE constants
- 0108aa85a gssapi/krb5: ensure singleton buffer in _gk_find_buffer()
- c8abd9aa5 gssapi/krb5: treat empty padding buffers as absent