### PR TITLE
hdb: Remove default HDB backend footgun

### DIFF
--- a/lib/hdb/Makefile.am
+++ b/lib/hdb/Makefile.am
@@ -7,6 +7,7 @@ AM_CPPFLAGS += $(INCLUDE_openldap) -DHDB_DB_DIR=\"$(DIR_hdbdir)\"
 AM_CPPFLAGS += -I$(srcdir)/../krb5
 AM_CPPFLAGS += $(INCLUDE_sqlite3)
 AM_CPPFLAGS += $(INCLUDE_libintl)
+AM_CPPFLAGS += -DHDB_DEFAULT_DB_TYPE=\"$(db_type):\"
 if HAVE_DBHEADER
 AM_CPPFLAGS += -I$(DBHEADER)
 endif

--- a/lib/hdb/hdb-ldap.c
+++ b/lib/hdb/hdb-ldap.c
@@ -2092,6 +2092,7 @@ fini(void *ctx)
 
 struct hdb_method hdb_ldap_interface = {
     HDB_INTERFACE_VERSION,
+    0 /*is_file_based*/, 0 /*can_taste*/,
     init,
     fini,
     "ldap",

--- a/lib/hdb/hdb.c
+++ b/lib/hdb/hdb.c
@@ -802,7 +802,19 @@ hdb_create(krb5_context context, HDB **db, const char *filename)
             *db = NULL;
         }
     }
+#ifdef HDB_DEFAULT_DB_TYPE
+    if (cb_ctx.h == NULL || cb_ctx.h->prefix == NULL) {
+        /*
+         * If still we've not picked a backend, use a build configuration time
+         * default.
+         */
+        for (cb_ctx.h = methods; cb_ctx.h->prefix != NULL; cb_ctx.h++)
+            if (strcmp(cb_ctx.h->prefix, HDB_DEFAULT_DB_TYPE) == 0)
+                break;
+    }
+#endif
     if (cb_ctx.h == NULL || cb_ctx.h->prefix == NULL)
+        /* Last resort default */
         cb_ctx.h = &default_dbmethod;
     if (cb_ctx.h == NULL || cb_ctx.h->prefix == NULL) {
         krb5_set_error_message(context, ENOTSUP,

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -303,6 +303,8 @@ typedef struct HDB {
 
 struct hdb_method {
     int			version;
+    unsigned int	is_file_based:1;
+    unsigned int	can_taste:1;
     krb5_error_code	(*init)(krb5_context, void **);
     void		(*fini)(void *);
     const char *prefix;

--- a/lib/hdb/test_namespace.c
+++ b/lib/hdb/test_namespace.c
@@ -243,12 +243,15 @@ struct hdb_method hdb_test =
 #ifdef WIN32
     /* Not c99 */
     HDB_INTERFACE_VERSION,
+    1 /*is_file_based*/, 1 /*can_taste*/,
     hdb_test_init,
     hdb_test_fini,
     "test",
     hdb_test_create
 #else
     .version = HDB_INTERFACE_VERSION,
+    .is_file_based = 1,
+    .can_taste = 1,
     .init = hdb_test_init,
     .fini = hdb_test_fini,
     .prefix = "test",


### PR DESCRIPTION
The current state of the world is such that the default HDB is named `"heimdal"` in the `LOCALSTATEDIR`, so typically it's `/var/heimdal/heimdal`.  The actual backend for this is to be determined at run-time because a backend type prefix is not part of the default HDB name.

Well, the default backend type selection at run-time depends build configuration.  So if you have BDB installed but not LMDB, you'll get BDB as the default backend, but if you later install LMDB and rebuild Heimdal then default backend type selection will change, and if you install the resulting artifacts and restart a KDC that was running with the default HDB... the KDC will fail to start!

The fix is to be a bit smarter about default backend selection.

This PR includes two commits:

 - The first commit implements HDB "tasting" for file-based HDB backends so that if you have an HDB of type `foo:` and later add support for a new preferred backend `bar:` you won't stop being able to open the default HDB that exists.

 - The second commit uses an HDB type from the `./configure` run, which can be affected by the `./configure` `--with-db-type-preference=<list>` option.