### PR TITLE
gss-token(1) improvements and fixes.

### DIFF
--- a/lib/gssapi/gss-token.1
+++ b/lib/gssapi/gss-token.1
@@ -15,6 +15,7 @@
 .Fl r
 .Op Fl MNln
 .Op Fl C Ar ccache
+.Op Fl S Ar maxsize
 .Op Fl c count
 .Op Ar service@host
 .Sh DESCRIPTION
@@ -52,6 +53,11 @@ This can be used to load test the KDC.
 prepend
 .Dq Negotiate\ 
 to generated tokens and expect it on consumed tokens.
+.It Fl S Ar maxsize
+split each token that is generated into components of maximum
+size
+.Ar maxsize .
+Each token is base64 encoded and output separately.
 .It Fl c Ar count
 repeat the operation
 .Ar count

--- a/lib/gssapi/gss-token.1
+++ b/lib/gssapi/gss-token.1
@@ -20,7 +20,9 @@
 .Sh DESCRIPTION
 .Nm
 generates and consumes base64 encoded GSS tokens.
-It is mostly useful for testing.
+By default, it runs as an initiator and with the
+.Fl r
+flag it becomes an acceptor.
 .Pp
 .Nm
 supports the following options:
@@ -54,22 +56,22 @@ to generated tokens and expect it on consumed tokens.
 repeat the operation
 .Ar count
 times.
+This flag only changes the behaviour when operating in initiator mode.
 This is good for very basic benchmarking.
 .It Fl l
-loop infinitely in read mode.
-This is to support a multiple round trip GSS mechanism.
+loop indefinitely in acceptor mode.
 .It Fl n
-do not output the generated token.
+do not output the generated tokens.
 .It Fl r
-read a token rather than generate a token.
+run in acceptor mode.
 .El
 .Pp
 .Nm
 takes one argument, a
 .Ar host@service
 specifier.
-The argument is required when generating a token but is optional if
-consuming (reading) a token.
+The argument is required when running as an initiator but is optional as
+an acceptor.
 .Sh SEE ALSO
 .Xr gssapi 3 ,
 .Xr kerberos 8 .

--- a/lib/gssapi/gss-token.1
+++ b/lib/gssapi/gss-token.1
@@ -17,6 +17,7 @@
 .Op Fl C Ar ccache
 .Op Fl S Ar maxsize
 .Op Fl c count
+.Op Fl m mech
 .Op Ar service@host
 .Sh DESCRIPTION
 .Nm
@@ -66,6 +67,13 @@ This flag only changes the behaviour when operating in initiator mode.
 This is good for very basic benchmarking.
 .It Fl l
 loop indefinitely in acceptor mode.
+.It Fl m Ar mech
+specifies the GSS mechanism that will be used in initiator mode.
+If a mechanism name of
+.Do ? Dc
+is specified, a list of supported mechanisms will be output and
+.Nm
+will exit.
 .It Fl n
 do not output the generated tokens.
 .It Fl r

--- a/lib/gssapi/gss-token.1
+++ b/lib/gssapi/gss-token.1
@@ -78,6 +78,23 @@ takes one argument, a
 specifier.
 The argument is required when running as an initiator but is optional as
 an acceptor.
+.Pp
+.Nm
+will try to read a token whenever the GSS mechanism expects one
+and will output a token whenever the GSS mechanism provides one.
+Tokens are base64 encoded and terminated by either two successive
+newlines or one newline and EOF.
+The base64 encoding may be broken up by single newlines which will
+be ignored when read.  No extra whitespace will be ignored.
+.Sh EXAMPLES
+To test a simple GSS mechanism which doesn't require a round trip,
+a single
+.Pa /bin/sh
+pipeline will suffice:
+.Bd -literal -offset indent
+$ export KRB5_KTNAME=/path/to/keytab
+$ gss-token HTTP@$(hostname) | gss-token -r
+.Ed
 .Sh SEE ALSO
 .Xr gssapi 3 ,
 .Xr kerberos 8 .

--- a/lib/gssapi/gss-token.c
+++ b/lib/gssapi/gss-token.c
@@ -511,8 +511,10 @@ main(int argc, char **argv)
 	    { NULL, 'D', arg_flag, &Dflag, NULL, NULL },
 	    { NULL, 'M', arg_flag, &Mflag, NULL, NULL },
 	    { NULL, 'N', arg_flag, &Nflag, NULL, NULL },
-	    { NULL, 'r', arg_flag, &rflag, NULL, NULL },
+	    { NULL, 'c', arg_integer, &count, NULL, NULL },
 	    { NULL, 'l', arg_flag, &lflag, NULL, NULL },
+	    { NULL, 'n', arg_flag, &nflag, NULL, NULL },
+	    { NULL, 'r', arg_flag, &rflag, NULL, NULL },
 	};
 
 	setprogname(argv[0]);

--- a/lib/gssapi/gss-token.c
+++ b/lib/gssapi/gss-token.c
@@ -89,6 +89,7 @@
  * global variables
  */
 
+int	Sflag = 0;
 int	nflag = 0;
 
 static char *
@@ -207,18 +208,35 @@ write_token(gss_buffer_t out, int negotiate)
 	char	*outstr = NULL;
 	char	*p = out->value;
 	size_t	 len = out->length;
+	size_t	 inc;
 	int	 ret;
+	int	 first = 1;
 
 	if (nflag)
 		return 0;
 
-	ret = rk_base64_encode(p, len, &outstr);
-	if (ret < 0) {
-		fprintf(stderr, "Out of memory.\n");
-		return 1;
-	}
-	printf("%s%s\n", negotiate?"Negotiate ":"", outstr);
-	free(outstr);
+	inc = len;
+	if (Sflag)
+		inc = Sflag;
+
+	do {
+		if (first)
+			first = 0;
+		else
+			printf("\n");
+		if (len < inc)
+			inc = len;
+		ret = rk_base64_encode(p, inc, &outstr);
+		if (ret < 0) {
+			fprintf(stderr, "Out of memory.\n");
+			return 1;
+		}
+		printf("%s%s\n", negotiate?"Negotiate ":"", outstr);
+		free(outstr);
+		p   += inc;
+		len -= inc;
+	} while (len > 0);
+
 	return 0;
 }
 
@@ -528,6 +546,7 @@ main(int argc, char **argv)
 	    { NULL, 'D', arg_flag, &Dflag, NULL, NULL },
 	    { NULL, 'M', arg_flag, &Mflag, NULL, NULL },
 	    { NULL, 'N', arg_flag, &Nflag, NULL, NULL },
+	    { NULL, 'S', arg_integer, &Sflag, NULL, NULL },
 	    { NULL, 'c', arg_integer, &count, NULL, NULL },
 	    { NULL, 'l', arg_flag, &lflag, NULL, NULL },
 	    { NULL, 'n', arg_flag, &nflag, NULL, NULL },

--- a/lib/gssapi/gssapi/gssapi.h
+++ b/lib/gssapi/gssapi/gssapi.h
@@ -37,6 +37,7 @@
 /*
  * First, include stddef.h to get size_t defined.
  */
+#include <stdarg.h>
 #include <stddef.h>
 
 #include <krb5-types.h>


### PR DESCRIPTION
We present a series of improvements and fixes to gss-token(1). We clean up and restructure the code a bit. We re-implement a couple of flags that were forgot when it was imported and changed to use getargs(). We make the code implement a proper GSS loop rather than assuming that there is only a single input and output token. We provide a mechanism to split up tokens to test new functionality that is being developed. And finally, we implement a way to ask GSS to use a particular mech on the initiator side.