### PR TITLE
Replace dead link in kerberos.8

### DIFF
--- a/lib/krb5/kerberos.8
+++ b/lib/krb5/kerberos.8
@@ -71,9 +71,12 @@ or
 .Ic ftp ,
 without giving your password.
 .Pp
-For more information on how Kerberos works, and other general Kerberos
-questions see the Kerberos FAQ at
-.Lk http://www.cmf.nrl.navy.mil/krb/kerberos-faq.html .
+For more information on how Kerberos works, see the tutorial at
+.Lk https://kerberos.org/software/tutorial.html
+or the informal
+.Dq dialogue
+at
+.Lk https://web.mit.edu/kerberos/dialogue.html .
 .Pp
 For setup instructions see the Heimdal Texinfo manual.
 .Sh SEE ALSO


### PR DESCRIPTION
While Ken Hornstein's FAQ was useful in its day, much of its content
is no longer relevant (e.g., Kerberos 4) or even actively harmful
(e.g., the latest version of MIT krb5 is not 1.2.1).  It was also
somewhat MIT-krb5-focused, especially relating to configuration file
snippets, which is not necessarily a great fit for the Heimdal
documentation.

Replace it with a tutorial hosted on kerberos.org and the classic
"dialogue" from Bill Bryant.