### PR TITLE
autoconf-2.70 fix

### DIFF
--- a/cf/check-var.m4
+++ b/cf/check-var.m4
@@ -20,7 +20,7 @@ AC_MSG_RESULT($ac_foo)
 if test "$ac_foo" = yes; then
 	AC_DEFINE_UNQUOTED(AS_TR_CPP(HAVE_[]$1), 1, 
 		[Define if you have the `]$1[' variable.])
-	m4_ifval([$2], AC_CHECK_DECLS([$1],[],[],[$2]))
+	m4_ifval([$2], [AC_CHECK_DECLS([$1],[],[],[$2])])
 fi
 ])
 


### PR DESCRIPTION
autoconf-2.70 and newer are more strict with quoting etc. and thus generate
a broken configure file:
```
  configure: 20855: Syntax error: ")" unexpected (expecting "fi")
```
Gentoo-bug: https://bugs.gentoo.org/776241
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>