### PR TITLE
kcm: Fix SEGV in kcm_get_cache_next

### DIFF
--- a/lib/krb5/kcm.c
+++ b/lib/krb5/kcm.c
@@ -900,7 +900,7 @@ kcm_get_cache_next(krb5_context context, krb5_cc_cursor cursor, const krb5_cc_op
 
     ret = krb5_kcm_call(context, request, &response, &response_data);
     krb5_storage_free(request);
-    if (ret == KRB5_CC_END)
+    if (ret == KRB5_CC_END || ret == KRB5_FCC_NOFILE)
 	goto again;
 
     ret = krb5_ret_stringz(response, &name);


### PR DESCRIPTION
The 'KCM_OP_GET_CACHE_BY_UUID' op may return 'KRB5_FCC_NOFILE' if
user access gets refused by KCM access control.
In this case, kcm_get_cache_next ignores it and may trigger a NULL pointer dereference
in "krb5_ret_stringz".

This patch fixes it by catching it like a 'KRB5_CC_END' error (no more ccaches).