### PR TITLE
Provide the correct principal name to verify_flags() for user2user tickets

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1651,6 +1651,9 @@ tgs_build_reply(astgs_request_t priv,
 	    goto out;
 	}
 	_krb5_principalname2krb5_principal(context, &p, t->sname, t->realm);
+	ret = krb5_unparse_name(context, p, &tpn);
+	if (ret)
+		goto out;
 	if(t->enc_part.kvno){
 	    second_kvno = *t->enc_part.kvno;
 	    kvno_ptr = &second_kvno;
@@ -1676,7 +1679,7 @@ tgs_build_reply(astgs_request_t priv,
 	if(ret)
 	    goto out;
 
-	ret = verify_flags(context, config, &adtkt, spn);
+	ret = verify_flags(context, config, &adtkt, tpn);
 	if (ret)
 	    goto out;
 


### PR DESCRIPTION
This is a patch to help Samba merge in a current upstrem Heimdal and is selected out of a larger patch by @metze-samba 

It looks like this codepath is tested by server_uu / check-uu but I've not manually checked it.

When b->kdc_options.enc_tkt_in_skey is set, the variable 'spn'
provided to verify_flags() for the purpose of logging is not
yet set, it is still NULL from the initialiser.

On Samba we see, when compiling with -O3 and strict warning rules with
gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04):

$ make -k
PYTHONHASHSEED=1 WAF_MAKE=1  ./buildtools/bin/waf build
Waf: Entering directory `/home/abartlet/heimdal-import/samba/bin/default'
	Selected embedded Heimdal build
[2822/4527] Compiling source4/heimdal/kdc/krb5tgs.c
In function ‘verify_flags’,
    inlined from ‘verify_flags’ at ../../source4/heimdal/kdc/krb5tgs.c:625:1,
    inlined from ‘tgs_build_reply.isra.0’ at ../../source4/heimdal/kdc/krb5tgs.c:1671:8:
../../source4/heimdal/kdc/krb5tgs.c:635:2: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  635 |  kdc_log(context, config, 4, "Ticket not valid (%s)", pstr);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘verify_flags’,
    inlined from ‘tgs_build_reply.isra.0’ at ../../source4/heimdal/kdc/krb5tgs.c:1671:8:
../../source4/heimdal/kdc/krb5tgs.c:631:2: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  631 |  kdc_log(context, config, 4, "Ticket expired (%s)", pstr);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Essentially, with an optimising compiler, the funciton is inlined
and the compiler notices that the kdc_log() argument is always NULL.

Selected from patches by Stefan Metzmacher <metze@samba.org>
in his master-heimdal branch at:
https://git.samba.org/?p=metze/samba/wip.git;a=commitdiff;h=2ac326b9cb8f896f874edfa6725f087034270322#patch2
https://git.samba.org/?p=metze/samba/wip.git;a=shortlog;h=refs/heads/master-heimdal

Signed-off-by: Andrew Bartlett <abartlet@samba.org>