### PR TITLE
Move out: label to inside #endif of HAVE_DLOPEN

### DIFF
--- a/lib/gssapi/mech/gss_mech_switch.c
+++ b/lib/gssapi/mech/gss_mech_switch.c
@@ -457,9 +457,10 @@ _gss_load_mech(void)
 		continue;
 	}
 	fclose(fp);
-#endif
 
 out:
+
+#endif
 	add_builtin(__gss_sanon_initialize());
 	HEIMDAL_MUTEX_unlock(&_gss_mech_mutex);
 }


### PR DESCRIPTION
Samba compiles Heimdal internally without HAVE_DLOPEN to keep
to internally supplied mechanisms and plugins.

Samba compiles with strict warning flags and on Ubuntu 20.04
with gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04) we see:

../../source4/heimdal/lib/gssapi/mech/gss_mech_switch.c: In function ‘_gss_load_mech’:
../../source4/heimdal/lib/gssapi/mech/gss_mech_switch.c:462:1: error: label ‘out’ defined but not used [-Werror=unused-label]
  462 | out:
      | ^~~
cc1: all warnings being treated as errors

Signed-off-by: Andrew Bartlett <abartlet@samba.org>