### PR TITLE
Fix user2user principal (again)

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1690,7 +1690,7 @@ tgs_build_reply(astgs_request_t priv,
 	    goto out;
         }
 
-	ret = verify_flags(context, config, &adtkt, spn);
+	ret = verify_flags(context, config, &adtkt, tpn);
 	if (ret) {
             _kdc_audit_addreason((kdc_request_t)priv,
                                  "User-to-user TGT expired or invalid");


### PR DESCRIPTION
73debbc1668adb4080165fcc1a7028ecae36e9b7 accidentially reverted
the critical part of 040a093654bfbb602ef0ab9807f51a5c83cf9596,
presumably during conflict resolution.

Found by a strict Samba compile during import of current Heimdal.

See #780

Signed-off-by: Andrew Bartlett <abartlet@samba.org>