### PR TITLE
Add const to _kdc_set_e_text()

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -387,7 +387,7 @@ _kdc_r_log(astgs_request_t r, int level, const char *fmt, ...)
 }
 
 void
-_kdc_set_e_text(astgs_request_t r, char *fmt, ...)
+_kdc_set_e_text(astgs_request_t r, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)))
 {
     va_list ap;


### PR DESCRIPTION
On Ubuntu 20.04 with gcc version 9.3.0 in a Samba compile
using -Wdiscarded-qualifiers and -Werror we get:

../../source4/heimdal/kdc/kerberos5.c:2516:21: warning: passing argument 2 of ‘_kdc_set_e_text’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 2516 |  _kdc_set_e_text(r, "Client have no reply key");
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
../../source4/heimdal/kdc/kerberos5.c:428:42: note: expected ‘char *’ but argument is of type ‘const char *’
  428 | _kdc_set_e_text(astgs_request_t r, char *fmt, ...)
      |                                    ~~~~~~^~~

Signed-off-by: Andrew Bartlett <abartlet@samba.org>