### PR TITLE
Initialise err in hdb_create()

### DIFF
--- a/lib/hdb/hdb.c
+++ b/lib/hdb/hdb.c
@@ -737,7 +737,7 @@ load_config(krb5_context context, HDB *db)
 krb5_error_code
 hdb_create(krb5_context context, HDB **db, const char *filename)
 {
-    krb5_error_code ret;
+    krb5_error_code ret = ENOTSUP;
     struct cb_s cb_ctx;
 
     *db = NULL;


### PR DESCRIPTION
On Ubuntu 20.04 with gcc version 9.3.0 during a strict
Samba build with -Werror=maybe-uninitialized we get:

../../source4/heimdal/lib/hdb/hdb.c: In function ‘hdb_create’:
../../source4/heimdal/lib/hdb/hdb.c:831:13: error: ‘ret’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  831 |     if (*db && ret == 0)
      |         ~~~~^~~~~~~~~~~
cc1: all warnings being treated as errors

Signed-off-by: Andrew Bartlett <abartlet@samba.org>