### PR TITLE
Reintroduce krb5_addlog_func() as as supported API

### DIFF
--- a/lib/krb5/log.c
+++ b/lib/krb5/log.c
@@ -52,13 +52,13 @@ struct krb5_addlog_func_wrapper {
     void *data;
 };
 
-static void HEIM_CALLCONV krb5_addlog_func_wrapper_log(heim_context hcontext,
-                                                       const char *prefix,
-                                                       const char *msg,
-                                                       void *data)
+static void HEIM_CALLCONV
+krb5_addlog_func_wrapper_log(heim_context hcontext,
+			     const char *prefix,
+			     const char *msg,
+			     void *data)
 {
-    struct krb5_addlog_func_wrapper *w =
-        (struct krb5_addlog_func_wrapper *)data;
+    struct krb5_addlog_func_wrapper *w = data;
 
     w->log_func(w->context,
                 prefix,
@@ -66,10 +66,10 @@ static void HEIM_CALLCONV krb5_addlog_func_wrapper_log(heim_context hcontext,
                 w->data);
 }
 
-static void HEIM_CALLCONV krb5_addlog_func_wrapper_close(void *data)
+static void HEIM_CALLCONV
+krb5_addlog_func_wrapper_close(void *data)
 {
-    struct krb5_addlog_func_wrapper *w =
-        (struct krb5_addlog_func_wrapper *)data;
+    struct krb5_addlog_func_wrapper *w = data;
 
     w->close_func(w->data);
     free(w);

--- a/lib/krb5/log.c
+++ b/lib/krb5/log.c
@@ -45,17 +45,60 @@ krb5_initlog(krb5_context context,
     return heim_initlog(context->hcontext, program, fac);
 }
 
+struct krb5_addlog_func_wrapper {
+    krb5_context context;
+    krb5_log_log_func_t log_func;
+    krb5_log_close_func_t close_func;
+    void *data;
+};
+
+static void HEIM_CALLCONV krb5_addlog_func_wrapper_log(heim_context hcontext,
+                                                       const char *prefix,
+                                                       const char *msg,
+                                                       void *data)
+{
+    struct krb5_addlog_func_wrapper *w =
+        (struct krb5_addlog_func_wrapper *)data;
+
+    w->log_func(w->context,
+                prefix,
+                msg,
+                w->data);
+}
+
+static void HEIM_CALLCONV krb5_addlog_func_wrapper_close(void *data)
+{
+    struct krb5_addlog_func_wrapper *w =
+        (struct krb5_addlog_func_wrapper *)data;
+
+    w->close_func(w->data);
+    free(w);
+}
+
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_addlog_func(krb5_context context,
-		 krb5_log_facility *fac,
-		 int min,
-		 int max,
-		 krb5_log_log_func_t log_func,
-		 krb5_log_close_func_t close_func,
-		 void *data)
-    KRB5_DEPRECATED_FUNCTION("Use X instead")
+                 krb5_log_facility *fac,
+                 int min,
+                 int max,
+                 krb5_log_log_func_t log_func,
+                 krb5_log_close_func_t close_func,
+                 void *data)
 {
-    return ENOTSUP;
+    struct krb5_addlog_func_wrapper *w = NULL;
+
+    w = calloc(1, sizeof(*w));
+    if (w == NULL)
+	return krb5_enomem(context);
+
+    w->context = context;
+    w->log_func = log_func;
+    w->close_func = close_func;
+    w->data = data;
+
+    return heim_addlog_func(context->hcontext, fac, min, max,
+                            krb5_addlog_func_wrapper_log,
+                            krb5_addlog_func_wrapper_close,
+                            w);
 }
 
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL


### PR DESCRIPTION
krb5_addlog_func() is used by Samba to obtain Kerberos log messages
and place them into the Samba logs.

Providing a hook down to the heim_addlog_func() is less disruptive
than needing to call multiple different APIs as Samba compiles
both with an included copy of Heimdal and against a system
Heimdal (when not an AD DC).

This API was deprecated and stubbed out in March 2020 by
ea90ca86664c73fb8d415f3cc7baacdf8a6dd685 and was previously
stable until 0c869176f4122fb04b60453d1210fa6b7630624f
(which looks like it should have been part of
e44c680d8efbb20ab1980e604178eb9d0d38cdcb).

Despite the need for the extra argument, which we add a test for,
Samba would prefer to keep the krb5_addlog_func() facility,
so this adds it back.

Selected from patches by Stefan Metzmacher <metze@samba.org>
in his master-heimdal branch at:
https://git.samba.org/?p=metze/samba/wip.git;a=commitdiff;h=40d98064f44c54b42420ed81f7f39e5469aefaa8#patch4
https://git.samba.org/?p=metze/samba/wip.git;a=shortlog;h=refs/heads/master-heimdal

Signed-off-by: Andrew Bartlett <abartlet@samba.org>