### PR TITLE
Allow KDC to always return the salt in the PA-ETYPE-INFO[2]

### DIFF
--- a/kdc/kdc.h
+++ b/kdc/kdc.h
@@ -62,6 +62,14 @@ typedef struct krb5_kdc_configuration {
 
     krb5_boolean encode_as_rep_as_tgs_rep; /* bug compatibility */
 
+    /*
+     * Windows 2019 (and earlier versions) always sends the salt
+     * and Samba has testsuites that check this behaviour, so a
+     * Samba AD DC will set this flag to match the AS-REP packet
+     * exactly.
+     */
+    krb5_boolean force_include_pa_etype_salt;
+
     krb5_boolean tgt_use_strongest_session_key;
     krb5_boolean preauth_use_strongest_session_key;
     krb5_boolean svc_use_strongest_session_key;

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1404,6 +1404,15 @@ get_pa_etype_info_both(krb5_context context,
     krb5_error_code ret;
 
     /*
+     * Windows 2019 (and earlier versions) always sends the salt
+     * and Samba has testsuites that check this behaviour, so a
+     * Samba AD DC will set this flag to match the AS-REP packet
+     * more closely.
+     */
+    if (config->force_include_pa_etype_salt)
+	include_salt = TRUE;
+
+    /*
      * RFC4120 requires:
      *   When the AS server is to include pre-authentication data in a
      *   KRB-ERROR or in an AS-REP, it MUST use PA-ETYPE-INFO2, not


### PR DESCRIPTION
This is to match the Windows KDC behaviour, optionally.

Samba will use this mode, as Samba has tests that show
the difference and is keen for bug-for-bug/byte-for-byte
rather than strict RFC compliance where there is a
reasonable choice.

The behaviour was changed in:

commit de1f37a6aadb35fdce3254528d89bdac23fb120b
Author: Luke Howard <lukeh@padl.com>
Date:   Mon Jan 7 15:45:36 2019 +1100

    kdc: omit default salt from PA-ETYPE-INFO[2]

    If the salt for the AS-REP client key matches the default password salt for the
    client principal in the AS-REQ, then it can be omitted from the PA-ETYPE-INFO,
    PA-ETYPE-INFO2 (RFC4120) as the client will assume the default salt in its
    absence.

Signed-off-by: Andrew Bartlett <abartlet@samba.org>