### PR TITLE
Supply useful HDB flags for FAST

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -429,7 +429,8 @@ _kdc_fast_unwrap_request(astgs_request_t r)
     }
 
     ret = _kdc_db_fetch(r->context, r->config, armor_server,
-			HDB_F_GET_SERVER | HDB_F_DELAY_NEW_KEYS,
+			HDB_F_GET_KRBTGT
+			| HDB_F_DELAY_NEW_KEYS,
 			NULL, NULL, &armor_user);
     if(ret == HDB_ERR_NOT_FOUND_HERE) {
 	kdc_log(r->context, r->config, 5,

--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -53,7 +53,7 @@ get_fastuser_crypto(astgs_request_t r, krb5_enctype enctype,
 	goto out;
 
     ret = _kdc_db_fetch(r->context, r->config, fast_princ,
-			HDB_F_GET_CLIENT, NULL, NULL, &fast_user);
+			HDB_F_GET_FAST_COOKIE, NULL, NULL, &fast_user);
     krb5_free_principal(r->context, fast_princ);
     if (ret)
 	goto out;

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -71,6 +71,7 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
 #define HDB_F_PRECHECK		16384	/* check that the operation would succeed */
 #define HDB_F_DELAY_NEW_KEYS	32768	/* apply [hdb] new_service_key_delay */
 #define HDB_F_SYNTHETIC_OK	65536	/* synthetic principal for PKINIT OK */
+#define HDB_F_GET_FAST_COOKIE  131072	/* fetch the FX-COOKIE key (not a normal principal) */
 
 /* hdb_capability_flags */
 #define HDB_CAP_F_HANDLE_ENTERPRISE_PRINCIPAL 1


### PR DESCRIPTION
Samba uses the HDB flags extensively to separate out the different principal types, so it is helpful to indicate the FAST key lookup with a flag, and to supply the correct server name to lookup when looking for the krbtgt.