### PR TITLE
Avoid -Werror=strict-overflow on in rk_dns_srv_order()

### DIFF
--- a/lib/roken/resolve.c
+++ b/lib/roken/resolve.c
@@ -629,14 +629,17 @@ rk_dns_srv_order(struct rk_dns_reply *r)
     struct rk_resource_record **srvs, **ss, **headp;
     struct rk_resource_record *rr;
     int num_srv = 0;
+    unsigned int srv_found = FALSE;
 
     rk_random_init();
 
     for(rr = r->head; rr; rr = rr->next)
-	if(rr->type == rk_ns_t_srv)
+	if(rr->type == rk_ns_t_srv) {
 	    num_srv++;
+	    srv_found = TRUE;
+	}
 
-    if(num_srv == 0)
+    if(srv_found == FALSE)
 	return;
 
     srvs = malloc(num_srv * sizeof(*srvs));


### PR DESCRIPTION
In a strict Samba build with -Werror=strict-overflow on Ubuntu 18.04
with gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)
we see

../../source4/heimdal/lib/roken/resolve.c: In function ‘rk_dns_srv_order’:
../../source4/heimdal/lib/roken/resolve.c:639:7: error: assuming signed overflow does not occur when simplifying conditional to constant [-Werror=strict-overflow]
     if(num_srv == 0)
       ^
cc1: all warnings being treated as errors

This avoids the issue by additionally setting a distinct flag.

Signed-off-by: Andrew Bartlett <abartlet@samba.org>