### PR TITLE
kuser: --fast-armor-anon-pkinit option for kinit

### DIFF
--- a/lib/hx509/hx509.h
+++ b/lib/hx509/hx509.h
@@ -182,6 +182,9 @@ typedef enum {
 #define HX509_CMS_VS_ALLOW_ZERO_SIGNER			0x04
 #define HX509_CMS_VS_NO_VALIDATE			0x08
 
+/* flags from hx509_cms_verify_signed_ext (out verify_flags) */
+#define HX509_CMS_VSE_VALIDATED				0x01
+
 /* selectors passed to hx509_crypto_select and hx509_crypto_available */
 #define HX509_SELECT_ALL 0
 #define HX509_SELECT_DIGEST 1

--- a/lib/hx509/libhx509-exports.def
+++ b/lib/hx509/libhx509-exports.def
@@ -150,6 +150,7 @@ EXPORTS
 	hx509_cms_unenvelope
 	hx509_cms_unwrap_ContentInfo
 	hx509_cms_verify_signed
+	hx509_cms_verify_signed_ext
 	hx509_cms_wrap_ContentInfo
 	hx509_context_free
 	hx509_context_init

--- a/lib/hx509/version-script.map
+++ b/lib/hx509/version-script.map
@@ -137,6 +137,7 @@ HEIMDAL_X509_1.2 {
 		hx509_cms_unenvelope;
 		hx509_cms_unwrap_ContentInfo;
 		hx509_cms_verify_signed;
+		hx509_cms_verify_signed_ext;
 		hx509_cms_wrap_ContentInfo;
 		hx509_context_free;
 		hx509_context_init;

--- a/lib/krb5/krb5_locl.h
+++ b/lib/krb5/krb5_locl.h
@@ -354,6 +354,7 @@ struct krb5_pk_identity {
     hx509_revoke_ctx revokectx;
     int flags;
 #define PKINIT_BTMM 1
+#define PKINIT_NO_KDC_ANCHOR 2
 };
 
 enum krb5_pk_type {
@@ -380,6 +381,7 @@ struct krb5_pk_init_ctx_data {
     unsigned int require_hostname_match:1;
     unsigned int trustedCertifiers:1;
     unsigned int anonymous:1;
+    unsigned int kdc_verified:1;
 };
 
 #endif /* PKINIT */

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -828,6 +828,7 @@ EXPORTS
 	krb5_init_creds_get_creds
 	krb5_init_creds_get_error
 	krb5_init_creds_init
+	krb5_init_creds_set_fast_anon_pkinit
 	krb5_init_creds_set_fast_ccache
 	krb5_init_creds_set_keytab
 	krb5_init_creds_set_password

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -814,6 +814,7 @@ HEIMDAL_KRB5_2.0 {
 		krb5_process_last_request;
 		krb5_init_creds_init;
 		krb5_init_creds_set_service;
+		krb5_init_creds_set_fast_anon_pkinit;
 		krb5_init_creds_set_fast_ccache;
 		krb5_init_creds_set_keytab;
 		krb5_init_creds_get;


### PR DESCRIPTION
Add the ` --pk-anon-fast-armor` option to kinit, which acquires a temporary anonymous PKINIT TGT to use as a FAST armor key.  The KDC certificate is not authenticated, per RFC 6113 5.4.1.1.