### PR TITLE
Export krb5_init_creds_* functions

### DIFF
--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -393,6 +393,9 @@ HEIMDAL_KRB5_2.0 {
 		krb5_hmac;
 		krb5_init_context;
 		krb5_init_ets;
+		krb5_init_creds_init;
+		krb5_init_creds_get_error;
+		krb5_init_creds_free;
 		krb5_initlog;
 		krb5_is_config_principal;
 		krb5_is_enctype_weak;


### PR DESCRIPTION
@cryptomilk made this change in Samba which I would like to inquire about getting this upstream.

I see 6dd66df5946fd7809cde3241dbc6a40ec7931a70 adding this to libkrb5-exports.def.in but I don't understand how this and the version-script.map files interact.

The function krb5_get_init_creds_opt_get_error() is deprecated and
krb5_init_creds_init() and krb5_init_creds_get_error() should be used
now.

Signed-off-by: Andreas Schneider <asn@samba.org>
Reviewed-by: Andrew Bartlett <abartlet@samba.org>
(cherry picked from Samba commit e4f82de7716e91a1c512a8c37ca768b591029a4a)