### PR TITLE
Allow _gss_string_to_oid() without HAVE_DLOPEN

### DIFF
--- a/lib/gssapi/mech/gss_mech_switch.c
+++ b/lib/gssapi/mech/gss_mech_switch.c
@@ -37,7 +37,6 @@ struct _gss_mech_switch_list _gss_mechs = { NULL, NULL } ;
 gss_OID_set _gss_mech_oids;
 static HEIMDAL_MUTEX _gss_mech_mutex = HEIMDAL_MUTEX_INITIALIZER;
 
-#ifdef HAVE_DLOPEN
 /*
  * Convert a string containing an OID in 'dot' form
  * (e.g. 1.2.840.113554.1.2.2) to a gss_OID.
@@ -160,7 +159,6 @@ _gss_string_to_oid(const char* s, gss_OID *oidp)
 
 	return (0);
 }
-#endif
 
 #define SYM(name)							\
 do {									\


### PR DESCRIPTION
This function became used outside the protection of
HAVE_DLOPEN (which Samba sets) with:

commit 5966c00701d9045fb5440a0d15c14a02cfd99f01
Author: Luke Howard <lukeh@padl.com>
Date:   Sun Aug 8 10:34:28 2021 +1000

    gss: add gss_mg_name_to_oid internal API

    Add a new function for future internal use, gss_mg_name_to_oid(), which takes
    either a dot-separated OID or a "short" mechanism name (such as
    "sanon-x25519"), and returns a mechanism OID.

Signed-off-by: Andrew Bartlett <abartlet@samba.org>