### PR TITLE
kdc: make it possible to disable the principal based referral detection

### DIFF
--- a/kdc/default_config.c
+++ b/kdc/default_config.c
@@ -92,6 +92,7 @@ krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
     c->preauth_use_strongest_session_key = FALSE;
     c->svc_use_strongest_session_key = FALSE;
     c->use_strongest_server_key = TRUE;
+    c->autodetect_referrals = TRUE;
     c->check_ticket_addresses = TRUE;
     c->warn_ticket_addresses = FALSE;
     c->allow_null_ticket_addresses = TRUE;

--- a/kdc/kdc.h
+++ b/kdc/kdc.h
@@ -62,6 +62,12 @@ typedef struct krb5_kdc_configuration {
 
     krb5_boolean encode_as_rep_as_tgs_rep; /* bug compatibility */
 
+    /*
+     * For Samba's AD DC, which will set to FALSE
+     * to turn off principal base referral auto-detection
+     */
+    krb5_boolean autodetect_referrals;
+
     krb5_boolean tgt_use_strongest_session_key;
     krb5_boolean preauth_use_strongest_session_key;
     krb5_boolean svc_use_strongest_session_key;

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1766,7 +1766,9 @@ server_lookup:
 	Realm req_rlm;
 	krb5_realm *realms;
 
-	if ((req_rlm = get_krbtgt_realm(&sp->name)) != NULL) {
+	if (!config->autodetect_referrals) {
+		/* noop */
+	} else if ((req_rlm = get_krbtgt_realm(&sp->name)) != NULL) {
             if (capath == NULL) {
                 /* With referalls, hierarchical capaths are always enabled */
                 ret2 = _krb5_find_capath(context, tgt->crealm, our_realm,


### PR DESCRIPTION
This, from @metze-samba and @cryptomilk is the KDC side of Samba BUG: https://bugzilla.samba.org/show_bug.cgi?id=12554 and I suspect is significantly so that we can both match Windows and trigger the behaviour we see there in the tests of our client code.

Either way, I'm trying to upstream as much as we can of our lorikeet-heimdal patches, at least for comment.

I know this will collide/conflict with #787 but I'll happily rebase that if this lands first, but this was the location that was requested for weird compatibility flags for Samba.