### PR TITLE
Import AS/TGS client from Apple Heimdal-597.121.1

### DIFF
--- a/README.fast
+++ b/README.fast
@@ -1,9 +1,6 @@
 
 -- in order of preference
 
-- client: support KRB5_PADATA_ENCRYPTED_CHALLENGE in lib/krb5/init_creds_pw.c
-- client: don't support ENC-TS in FAST
-
 - client: plugin support for fast plugins
 
 - kdc: plugin support for fast plugins
@@ -13,5 +10,3 @@
 -- using PK-INIT anonymous
 -- using host key
 
-- client: tgs-req fast support
-- kdc: tgs-req fast support

--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -334,7 +334,6 @@ _kdc_fast_mk_error(astgs_request_t r,
 		   time_t *csec, int *cusec,
 		   krb5_data *error_msg)
 {
-    krb5_context context = r->context;
     krb5_error_code ret;
     krb5_data e_data;
     size_t size;
@@ -365,7 +364,7 @@ _kdc_fast_mk_error(astgs_request_t r,
 
 	/* first add the KRB-ERROR to the fast errors */
 
-	ret = krb5_mk_error(context,
+	ret = krb5_mk_error(r->context,
 			    outer_error,
 			    e_text,
 			    NULL,
@@ -377,7 +376,7 @@ _kdc_fast_mk_error(astgs_request_t r,
 	if (ret)
 	    return ret;
 
-	ret = krb5_padata_add(context, error_method,
+	ret = krb5_padata_add(r->context, error_method,
 			      KRB5_PADATA_FX_ERROR,
 			      e_data.data, e_data.length);
 	if (ret) {
@@ -394,14 +393,14 @@ _kdc_fast_mk_error(astgs_request_t r,
 	csec = 0;
 	cusec = 0;
 
-	ret = _kdc_fast_mk_response(context, armor_crypto,
+	ret = _kdc_fast_mk_response(r->context, armor_crypto,
 				    error_method, NULL, NULL,
 				    req_body->nonce, &e_data);
 	free_METHOD_DATA(error_method);
 	if (ret)
 	    return ret;
 
-	ret = krb5_padata_add(context, error_method,
+	ret = krb5_padata_add(r->context, error_method,
 			      KRB5_PADATA_FX_FAST,
 			      e_data.data, e_data.length);
 	if (ret)
@@ -416,7 +415,7 @@ _kdc_fast_mk_error(astgs_request_t r,
 	heim_assert(size == e_data.length, "internal asn.1 encoder error");
     }
 
-    ret = krb5_mk_error(context,
+    ret = krb5_mk_error(r->context,
 			outer_error,
 			e_text,
 			(e_data.length ? &e_data : NULL),

--- a/kdc/kdc-tester.c
+++ b/kdc/kdc-tester.c
@@ -269,6 +269,8 @@ eval_kinit(heim_dict_t o)
 	ret = krb5_init_creds_set_fast_ccache(kdc_context, ctx, fast_cc);
 	if (ret)
 	    krb5_err(kdc_context, 1, ret, "krb5_init_creds_set_fast_ccache");
+
+	fast_cc = NULL;
     }
     
     if (password) {

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -93,6 +93,13 @@ struct astgs_request_desc {
     krb5_timestamp pa_endtime;
     krb5_timestamp pa_max_life;
 
+    krb5_keyblock strengthen_key;
+    const Key *ticket_key;
+
+    /* only valid for tgs-req */
+    unsigned int rk_is_subkey : 1;
+    unsigned int fast_asserted : 1;
+
     krb5_crypto armor_crypto;
 
     KDCFastState fast;

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -2417,7 +2417,8 @@ out:
 				 r->armor_crypto,
 				 &req->req_body,
 				 ret, r->e_text,
-				 NULL, NULL,
+				 ticket != NULL ? ticket->client : NULL,
+				 ticket != NULL ? ticket->server : NULL,
 				 csec, cusec,
 				 data);
 	free_METHOD_DATA(&error_method);

--- a/kdc/windc.c
+++ b/kdc/windc.c
@@ -198,7 +198,6 @@ check(krb5_context context, const void *plug, void *plugctx, void *userctx)
 krb5_error_code
 _kdc_check_access(astgs_request_t r, KDC_REQ *req, METHOD_DATA *method_data)
 {
-    krb5_context context = r->context;
     krb5_error_code ret = KRB5_PLUGIN_NO_HANDLE;
     struct check_uc uc;
 
@@ -211,7 +210,7 @@ _kdc_check_access(astgs_request_t r, KDC_REQ *req, METHOD_DATA *method_data)
         uc.req = req;
         uc.method_data = method_data;
 
-        ret = _krb5_plugin_run_f(context, &windc_plugin_data,
+        ret = _krb5_plugin_run_f(r->context, &windc_plugin_data,
                                  0, &uc, check);
     }
 

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -1077,6 +1077,18 @@ get_new_tickets(krb5_context context,
 	goto out;
     }
 
+    ret = krb5_init_creds_store_config(context, ctx, tempccache);
+    if (ret) {
+	krb5_warn(context, ret, "krb5_init_creds_store_config");
+	goto out;
+    }
+
+    ret = krb5_init_creds_warn_user(context, ctx);
+    if (ret) {
+	krb5_warn(context, ret, "krb5_init_creds_warn_user");
+	goto out;
+    }
+
     krb5_init_creds_free(context, ctx);
     ctx = NULL;
 

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -81,6 +81,7 @@ int pk_use_enckey	= 0;
 int pk_anon_fast_armor	= 0;
 char *gss_preauth_mech	= NULL;
 char *gss_preauth_name	= NULL;
+char *kdc_hostname	= NULL;
 static int canonicalize_flag = 0;
 static int enterprise_flag = 0;
 static int ok_as_delegate_flag = 0;
@@ -196,6 +197,9 @@ static struct getargs args[] = {
 
     { "gss-name",   0,	arg_string, &gss_preauth_name,
       NP_("use distinct GSS identity for pre-authentication", ""), NULL },
+
+    { "kdc-hostname",	0,  arg_string, &kdc_hostname,
+      NP_("KDC host name", ""), "hostname" },
 
 #ifndef NO_NTLM
     { "ntlm-domain",	0,  arg_string, &ntlm_domain,
@@ -920,6 +924,14 @@ get_new_tickets(krb5_context context,
 	ret = krb5_init_creds_set_service(context, ctx, server_str);
 	if (ret) {
 	    krb5_warn(context, ret, "krb5_init_creds_set_service");
+	    goto out;
+	}
+    }
+
+    if (kdc_hostname) {
+	ret = krb5_init_creds_set_kdc_hostname(context, ctx, kdc_hostname);
+	if (ret) {
+	    krb5_warn(context, ret, "krb5_init_creds_set_kdc_hostname");
 	    goto out;
 	}
     }

--- a/lib/asn1/krb5.asn1
+++ b/lib/asn1/krb5.asn1
@@ -207,6 +207,9 @@ AUTHDATA-TYPE ::= INTEGER {
 	KRB5-AUTHDATA-OSF-DCE(64),
 	KRB5-AUTHDATA-SESAME(65),
 	KRB5-AUTHDATA-OSF-DCE-PKI-CERTID(66),
+	KRB5-AUTHDATA-AUTHENTICATION-STRENGTH(70),
+	KRB5-AUTHDATA-FX-FAST-ARMOR(71),
+	KRB5-AUTHDATA-FX-FAST-USED(72),
 	KRB5-AUTHDATA-WIN2K-PAC(128),
 	KRB5-AUTHDATA-GSS-API-ETYPE-NEGOTIATION(129), -- Authenticator only
 	KRB5-AUTHDATA-SIGNTICKET-OLDER(-17),
@@ -843,10 +846,11 @@ PA-FX-FAST-REPLY ::= CHOICE {
 }
 
 KDCFastFlags ::= BIT STRING {
-	use_reply_key(0),
-	reply_key_used(1),
-	reply_key_replaced(2),
-	kdc_verfied(3)
+	use-reply-key(0),
+	reply-key-used(1),
+	reply-key-replaced(2),
+	kdc-verified(3),
+	requested-hidden-names(4)
 }
 
 -- KDCFastState is stored in FX_COOKIE

--- a/lib/base/heim_err.et
+++ b/lib/base/heim_err.et
@@ -22,6 +22,9 @@ error_code TOO_BIG,		"Offset too large"
 error_code BAD_HDBENT_ENCODING,	"Invalid HDB entry encoding"
 error_code RANDOM_OFFLINE,	"No random source available"
 error_code CONFIG_BADFORMAT,    "Improper format of configuration file"
+error_code PA_CONTINUE_NEEDED,  "Need to continue preauth stepping"
+error_code PA_CANT_CONTINUE,    "Can't continue with this preauth"
+error_code NO_MORE_PA_MECHS,    "No more PA mechanisms available"
 
 index 64
 prefix HEIM_PKINIT

--- a/lib/base/heimbasepriv.h
+++ b/lib/base/heimbasepriv.h
@@ -64,6 +64,7 @@ enum {
     HEIM_TID_ERROR = 133,
     HEIM_TID_DATA = 134,
     HEIM_TID_DB = 135,
+    HEIM_TID_PA_AUTH_MECH = 136,
     HEIM_TID_USER = 255
 
 };

--- a/lib/gss_preauth/pa_client.c
+++ b/lib/gss_preauth/pa_client.c
@@ -81,6 +81,7 @@ static krb5_error_code KRB5_LIB_CALL
 pa_gss_step(krb5_context context,
             krb5_gss_init_ctx gssic,
             const krb5_creds *kcred,
+            gss_ctx_id_t *ctx,
             KDCOptions flags,
             krb5_data *enc_as_req,
             krb5_data *in,
@@ -91,7 +92,6 @@ pa_gss_step(krb5_context context,
 
     OM_uint32 major, minor;
     gss_cred_id_t cred;
-    gss_ctx_id_t ctx;
     gss_name_t target_name = GSS_C_NO_NAME;
     OM_uint32 req_flags = GSS_C_MUTUAL_FLAG;
     OM_uint32 ret_flags;
@@ -113,8 +113,6 @@ pa_gss_step(krb5_context context,
         _krb5_init_creds_set_gss_cred(context, gssic, cred);
     }
 
-    ctx = (gss_ctx_id_t)_krb5_init_creds_get_gss_context(context, gssic);
-
     ret = krb5_make_principal(context, &tgs_name, kcred->server->realm,
                               KRB5_TGS_NAME, kcred->server->realm, NULL);
     if (ret)
@@ -129,7 +127,7 @@ pa_gss_step(krb5_context context,
 
     major = gss_init_sec_context(&minor,
                                  cred,
-                                 &ctx,
+                                 ctx,
                                  target_name,
                                  (gss_OID)_krb5_init_creds_get_gss_mechanism(context, gssic),
                                  req_flags,
@@ -140,8 +138,6 @@ pa_gss_step(krb5_context context,
                                  &output_token,
                                  &ret_flags,
                                  NULL);
-
-    _krb5_init_creds_set_gss_context(context, gssic, ctx);
 
     _krb5_gss_buffer_to_data(&output_token, out);
 
@@ -166,6 +162,7 @@ static krb5_error_code KRB5_LIB_CALL
 pa_gss_finish(krb5_context context,
               krb5_gss_init_ctx gssic,
               const krb5_creds *kcred,
+              gss_ctx_id_t ctx,
               krb5int32 nonce,
               krb5_enctype enctype,
               krb5_principal *client_p,
@@ -177,7 +174,6 @@ pa_gss_finish(krb5_context context,
 
     OM_uint32 major, minor;
     gss_name_t initiator_name = GSS_C_NO_NAME;
-    gss_ctx_id_t ctx = (gss_ctx_id_t)_krb5_init_creds_get_gss_context(context, gssic);
 
     *client_p = NULL;
     *reply_key_p = NULL;

--- a/lib/gss_preauth/pa_common.c
+++ b/lib/gss_preauth/pa_common.c
@@ -50,7 +50,7 @@ _krb5_gss_map_error(OM_uint32 major, OM_uint32 minor)
         ret = 0;
         break;
     case GSS_S_CONTINUE_NEEDED:
-        ret = KRB5_KDC_ERR_MORE_PREAUTH_DATA_REQUIRED;
+        ret = HEIM_ERR_PA_CONTINUE_NEEDED;
         break;
     case GSS_S_BAD_NAME:
     case GSS_S_BAD_NAMETYPE:

--- a/lib/krb5/deprecated.c
+++ b/lib/krb5/deprecated.c
@@ -539,7 +539,7 @@ krb5_get_cred_from_kdc_opt(krb5_context context,
 {
     krb5_kdc_flags f;
     f.i = flags;
-    return _krb5_get_cred_kdc_any(context, f, ccache,
+    return _krb5_get_cred_kdc_any(context, f, ccache, NULL,
 				  in_creds, NULL, NULL,
 				  out_creds, ret_tgts);
 }

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -862,6 +862,8 @@ EXPORTS
 	krb5_init_creds_set_sitename
 	krb5_init_creds_step
 	krb5_init_creds_store
+	krb5_init_creds_store_config
+	krb5_init_creds_warn_user
 	krb5_process_last_request
 
 	; testing

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -607,6 +607,8 @@ EXPORTS
 	krb5_sendto_ctx_set_type
 	krb5_sendto_kdc
 	krb5_sendto_kdc_flags
+	krb5_sendto_set_hostname
+	krb5_sendto_set_sitename
 	krb5_set_config
 	krb5_set_config_files
 	krb5_set_debug_dest
@@ -799,9 +801,12 @@ EXPORTS
 	_krb5_init_creds_get_gss_mechanism
 	_krb5_init_creds_set_gss_cred
 	_krb5_init_creds_get_gss_cred
-	_krb5_init_creds_set_gss_context
-	_krb5_init_creds_get_gss_context
 	_krb5_init_creds_init_gss
+
+	; Private init_creds API
+	_krb5_init_creds_get_cred_starttime
+	_krb5_init_creds_get_cred_endtime
+	_krb5_init_creds_get_cred_client
 
 	; Shared with libkadm5
 	_krb5_load_plugins
@@ -834,6 +839,8 @@ EXPORTS
 	_krb5_HMAC_MD5_checksum
 	_krb5_crypto_set_flags
 	_krb5_expand_path_tokens	;!
+	_krb5_make_pa_enc_challenge
+	_krb5_validate_pa_enc_challenge
 
         ; kinit helper
 	krb5_get_init_creds_opt_set_pkinit_user_certs
@@ -842,14 +849,17 @@ EXPORTS
 	krb5_auth_con_getsendsubkey
 	krb5_init_creds_free
 	krb5_init_creds_get
+	krb5_init_creds_get_as_reply_key
 	krb5_init_creds_get_creds
 	krb5_init_creds_get_error
 	krb5_init_creds_init
 	krb5_init_creds_set_fast_anon_pkinit
 	krb5_init_creds_set_fast_ccache
 	krb5_init_creds_set_keytab
+	krb5_init_creds_set_kdc_hostname
 	krb5_init_creds_set_password
 	krb5_init_creds_set_service
+	krb5_init_creds_set_sitename
 	krb5_init_creds_step
 	krb5_init_creds_store
 	krb5_process_last_request

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -850,7 +850,9 @@ HEIMDAL_KRB5_2.0 {
 		krb5_init_creds_set_sitename;
 		krb5_init_creds_step;
 		krb5_init_creds_store;
+		krb5_init_creds_store_config;
 		krb5_init_creds_free;
+		krb5_init_creds_warn_user;
 
 		# testing
 		krb5_time_abs;

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -600,6 +600,8 @@ HEIMDAL_KRB5_2.0 {
 		krb5_sendto_ctx_set_type;
 		krb5_sendto_kdc;
 		krb5_sendto_kdc_flags;
+		krb5_sendto_set_hostname;
+		krb5_sendto_set_sitename;
 		krb5_set_config;
 		krb5_set_config_files;
 		krb5_set_debug_dest;
@@ -791,9 +793,12 @@ HEIMDAL_KRB5_2.0 {
 		_krb5_init_creds_get_gss_mechanism;
 		_krb5_init_creds_set_gss_cred;
 		_krb5_init_creds_get_gss_cred;
-		_krb5_init_creds_set_gss_context;
-		_krb5_init_creds_get_gss_context;
 		_krb5_init_creds_init_gss;
+
+		# Private init_creds API
+		_krb5_init_creds_get_cred_starttime;
+		_krb5_init_creds_get_cred_endtime;
+		_krb5_init_creds_get_cred_client;
 
 		# Shared with libkadm5
 		_krb5_load_plugins;
@@ -824,6 +829,8 @@ HEIMDAL_KRB5_2.0 {
 		_krb5_s4u2self_to_checksumdata;
 		_krb5_HMAC_MD5_checksum;
 		_krb5_crypto_set_flags;
+		_krb5_make_pa_enc_challenge;
+		_krb5_validate_pa_enc_challenge;
 
 		# kinit helper
 		krb5_get_init_creds_opt_set_pkinit_user_certs;
@@ -834,10 +841,13 @@ HEIMDAL_KRB5_2.0 {
 		krb5_init_creds_set_fast_anon_pkinit;
 		krb5_init_creds_set_fast_ccache;
 		krb5_init_creds_set_keytab;
+		krb5_init_creds_set_kdc_hostname;
 		krb5_init_creds_get;
+		krb5_init_creds_get_as_reply_key;
 		krb5_init_creds_get_creds;
 		krb5_init_creds_get_error;
 		krb5_init_creds_set_password;
+		krb5_init_creds_set_sitename;
 		krb5_init_creds_step;
 		krb5_init_creds_store;
 		krb5_init_creds_free;


### PR DESCRIPTION
This PR extends #796 with a merge of Apple's Heimdal open source drop 597.121.1.

Clearly it would have been better to build GSS pre-authentication on top of this, but, here we are. I would suggest reviewing and integrating #796 and #797 first.

The tests pass.

There is a lot of churn but, I have minimised it somewhat by not aggressively integrating some of the Apple features (e.g. completely rewritten TGS client). I am in the process of carefully comparing with the original to check for regressions.

The advantages of integrating this are:

- support for PA-ENC-CHALLENGE
- FAST reply key strengthening
- FAST support in TGS-REQ path (including for errors which the Apple code did not implement), both in libkrb5 and KDC
- refactored pre-authentication client that makes adding new mechanisms easy
- allow KDC hostname and AD site name to be pinned in `get_[_init]creds()` APIs

I've also fixed a bunch of bugs in the Apple code, e.g. it would not optimistic PA mechanisms, it could crash with Win2K PKINIT responses, etc.