### PR TITLE
Check CLANG_FORMAT is executable.

### DIFF
--- a/cf/Makefile.am.common
+++ b/cf/Makefile.am.common
@@ -147,7 +147,7 @@ SUFFIXES += .x .z .hx
 # clang-format styles is to sort includes, but in many cases in-tree we really
 # don't want to do that.
 .x.c:
-	@if [ -z "$(CLANG_FORMAT)" ]; then \
+	@if [ ! -x "$(CLANG_FORMAT)" ]; then \
 	    cmp -s $< $@ 2> /dev/null || cp $< $@; \
 	else \
 	    cp $< $@.tmp.c; \


### PR DESCRIPTION
If clang-format is not available, AC_CHECK_PROG sets CLANG_FORMAT=no,
not empty string. This results in an error at build time for those
without clang-format installed. Instead check if the program is
executable.