### PR TITLE
Only #include <malloc.h> if it is available.

### DIFF
--- a/lib/gssapi/gss-token.c
+++ b/lib/gssapi/gss-token.c
@@ -31,7 +31,7 @@
 #include <errno.h>
 #ifdef __APPLE__
 #include <malloc/malloc.h>
-#else
+#elif HAVE_MALLOC_H
 #include <malloc.h>
 #endif
 #include <stdio.h>


### PR DESCRIPTION
e.g., OpenBSD does not provide this header.