### PR TITLE
Avoid -Werror=address by skipping pointless _mg_buffer_zero()

### DIFF
--- a/lib/gssapi/preauth/pa_client.c
+++ b/lib/gssapi/preauth/pa_client.c
@@ -145,7 +145,6 @@ pa_gss_step(krb5_context context,
     _krb5_init_creds_set_gss_context(context, gssic, ctx);
 
     _krb5_gss_buffer_to_data(&output_token, out);
-    _mg_buffer_zero(&output_token);
 
     if (major == GSS_S_COMPLETE) {
         if ((ret_flags & GSS_C_MUTUAL_FLAG) == 0)
@@ -159,7 +158,6 @@ pa_gss_step(krb5_context context,
 
 out:
     gss_release_name(&minor, &target_name);
-    gss_release_buffer(&minor, &output_token);
     krb5_free_principal(context, tgs_name);
 
     return ret;


### PR DESCRIPTION
We do not need to zero out the local variable output_token
if we do not later call gss_release_buffer() on it.

This aovids a -Werror=address compile failure under the
strict compiler options Samba uses when compiled on Ubuntu
20.04 with gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)

In file included from ../../source4/heimdal/lib/gssapi/preauth/pa_client.c:34:
../../source4/heimdal/lib/gssapi/preauth/pa_client.c:148:21: error: the address of ‘output_token’ will always evaluate as ‘true’ [-Werror=address]
  148 |     _mg_buffer_zero(&output_token);
      |                     ^
../../source4/heimdal/lib/gssapi/mech/mech_locl.h:72:7: note: in definition of macro ‘_mg_buffer_zero’
   72 |   if (buffer) {   \
      |       ^~~~~~

Signed-off-by: Andrew Bartlett <abartlet@samba.org>