### PR TITLE
kdc: allow TGS requests from synthetic clients

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1010,6 +1010,23 @@ log_patypes(astgs_request_t r, METHOD_DATA *padata)
 }
 
 /*
+ * Add a placeholder authorization data indicating we validated
+ * the use of a synthetic client.
+ */
+static krb5_error_code
+add_synthetic_client_ad(astgs_request_t r)
+{
+    krb5_data data;
+
+    krb5_data_zero(&data);
+
+    return _kdc_tkt_add_if_relevant_ad(r->context,
+				       &r->et,
+				       KRB5_AUTHDATA_SYNTHETIC_CLIENT,
+				       &data);
+}
+
+/*
  *
  */
 
@@ -2506,6 +2523,9 @@ _kdc_as_rep(astgs_request_t r)
     if (send_pac_p(context, req) && !r->et.flags.anonymous) {
 	generate_pac(r, skey);
     }
+
+    if (r->client->entry.flags.synthetic)
+	add_synthetic_client_ad(r);
 
     _kdc_log_timestamp(r, "AS-REQ", r->et.authtime,
 		       r->et.starttime, r->et.endtime,

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -2014,21 +2014,13 @@ server_lookup:
     }
 
     {
-        krb5_data verified_cas;
+        krb5_data synthetic_client;
 
-        /*
-         * If the client doesn't exist in the HDB but has a TGT and it's
-         * obtained with PKINIT then we assume it's a synthetic client -- that
-         * is, a client whose name was vouched for by a CA using a PKINIT SAN,
-         * but which doesn't exist in the HDB proper.  We'll allow such a
-         * client to do TGT requests even though normally we'd reject all
-         * clients that don't exist in the HDB.
-         */
         ret = krb5_ticket_get_authorization_data_type(context, ticket,
-                                                      KRB5_AUTHDATA_INITIAL_VERIFIED_CAS,
-                                                      &verified_cas);
+                                                      KRB5_AUTHDATA_SYNTHETIC_CLIENT,
+                                                      &synthetic_client);
         if (ret == 0) {
-            krb5_data_free(&verified_cas);
+            krb5_data_free(&synthetic_client);
             flags |= HDB_F_SYNTHETIC_OK;
         }
     }

--- a/lib/asn1/krb5.asn1
+++ b/lib/asn1/krb5.asn1
@@ -219,11 +219,12 @@ AUTHDATA-TYPE ::= INTEGER {
         -- N.B. these assignments have not been confirmed yet.
         --
         -- DO NOT USE in production yet!
+	KRB5-AUTHDATA-SYNTHETIC-CLIENT(-18),  -- client synthesized by KDC
 	KRB5-AUTHDATA-ON-BEHALF-OF(580),      -- UTF8String princ name
 	KRB5-AUTHDATA-BEARER-TOKEN-JWT(581),  -- JWT token
 	KRB5-AUTHDATA-BEARER-TOKEN-SAML(582), -- SAML token
 	KRB5-AUTHDATA-BEARER-TOKEN-OIDC(583), -- OIDC token
-	KRB5-AUTHDATA-CSR-AUTHORIZED(584),     -- Proxy has authorized client
+	KRB5-AUTHDATA-CSR-AUTHORIZED(584),    -- Proxy has authorized client
                                               -- to requested exts in CSR
 	KRB5-AUTHDATA-GSS-COMPOSITE-NAME(655) -- gss_export_name_composite
 }


### PR DESCRIPTION
Previously the TGS allowed synthetic clients (that is, clients that do not exist in the HDB) only if PKINIT was used. Since the introduction of support for GSS-API pre-authentication, synthetic clients can be used without PKINIT.

To support these in the TGS, use a new authorization data element to indicate the AS validated the usage of a synthetic client.

Note: untested.