### PR TITLE
krb5: KRB5_KRBHST_TKTBRIDGEAP

### DIFF
--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -844,6 +844,7 @@ typedef struct krb5_krbhst_data *krb5_krbhst_handle;
 #define KRB5_KRBHST_KRB524		4
 #define KRB5_KRBHST_KCA			5
 #define KRB5_KRBHST_READONLY_ADMIN	6
+#define KRB5_KRBHST_TKTBRIDGEAP		7
 
 typedef struct krb5_krbhst_info {
     enum { KRB5_KRBHST_UDP,

--- a/lib/krb5/krbhst.c
+++ b/lib/krb5/krbhst.c
@@ -1017,6 +1017,13 @@ krb5_krbhst_init_flags(krb5_context context,
         srv_label = "kpasswd";
 	service = "change_password";
 	break;
+    case KRB5_KRBHST_TKTBRIDGEAP:
+	next = kdc_get_next;
+	def_port = ntohs(krb5_getportbyname(context, "kerberos", "tcp", 88));
+        config_param = "tktbridgeap";
+        srv_label = "kerberos-tkt-bridge";
+	service = "kdc";
+	break;
     default:
 	krb5_set_error_message(context, ENOTTY,
 			       N_("unknown krbhst type (%u)", ""), type);


### PR DESCRIPTION
Add a new krbhst type, KRB5_KRBHST_TKTBRIDGEAP to krb5_krbhst_init_flags(), that looks for the DNS SRV record kerberos-tkt-bridge. This is to support a new PADL project.