### PR TITLE
yyerror: update to POSIX standard

### DIFF
--- a/lib/asn1/asn1parse.y
+++ b/lib/asn1/asn1parse.y
@@ -65,6 +65,7 @@ static void validate_object_set(IOSObjectSet *);
 static struct constraint_spec *new_constraint_spec(enum ctype);
 static Type *new_tag(int tagclass, int tagvalue, int tagenv, Type *oldtype);
 void yyerror (const char *);
+#define yyerror yyerror
 static struct objid *new_objid(const char *label, int value);
 static void add_oid_to_tail(struct objid *, struct objid *);
 static void fix_labels(Symbol *s);

--- a/lib/com_err/parse.y
+++ b/lib/com_err/parse.y
@@ -35,7 +35,8 @@
 #include "compile_et.h"
 #include "lex.h"
 
-void yyerror (char *s);
+void yyerror (const char *s);
+#define yyerror yyerror
 static long name2number(const char *str);
 
 extern char *yytext;
@@ -168,7 +169,7 @@ name2number(const char *str)
 }
 
 void
-yyerror (char *s)
+yyerror (const char *s)
 {
      _lex_error_message ("%s\n", s);
 }

--- a/lib/sl/slc-lex.l
+++ b/lib/sl/slc-lex.l
@@ -78,7 +78,7 @@ error_message (const char *format, ...)
 }
 
 void
-yyerror (char *s)
+yyerror (const char *s)
 {
     error_message("%s\n", s);
 }

--- a/lib/sl/slc.h
+++ b/lib/sl/slc.h
@@ -51,5 +51,6 @@ extern char *filename;
 extern int error_flag;
 void error_message (const char *format, ...);
 int yylex(void);
-void yyerror (char *s);
+void yyerror (const char *s);
+#define yyerror yyerror
 extern unsigned lineno;


### PR DESCRIPTION
To comply with the latest POSIX standard, in Yacc compatibility mode
(options `-y`/`--yacc`) Bison now generates prototypes for yyerror and
yylex.  In some situations, this is breaking compatibility: if the user
has already declared these functions but with some differences (e.g., to
declare them as static, or to use specific attributes), the generated
parser will fail to compile.  To disable these prototypes, #define yyerror
(to `yyerror`), and likewise for yylex.

refer: https://git.savannah.gnu.org/cgit/bison.git/tree/NEWS

GNU Bison 3.8

in addition update `yyerror` to match the templated function with `const`

Reference #830 

tested with both 7.7.0 and master.