### PR TITLE
krb5: skip cache check in S4U2Proxy requests

### DIFF
--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -1067,7 +1067,7 @@ get_cred_kdc_referral(krb5_context context,
 	char *referral_realm;
 
 	/* Use cache if we are not doing impersonation or contrained deleg */
-	if (impersonate_principal == NULL || flags.b.cname_in_addl_tkt) {
+	if (impersonate_principal == NULL && !flags.b.cname_in_addl_tkt) {
 	    krb5_cc_clear_mcred(&mcreds);
 	    mcreds.server = referral.server;
 	    krb5_timeofday(context, &mcreds.times.endtime);
@@ -1621,13 +1621,15 @@ next_rule:
 	goto out;
     }
 
-    ret = check_cc(context, options, ccache, &in_creds, res_creds);
-    if (ret == 0) {
-	*out_creds = res_creds;
-        res_creds = NULL;
-	goto out;
-    } else if (ret != KRB5_CC_END) {
-	goto out;
+    if ((options & KRB5_GC_CONSTRAINED_DELEGATION) == 0) {
+	ret = check_cc(context, options, ccache, &in_creds, res_creds);
+	if (ret == 0) {
+	    *out_creds = res_creds;
+	    res_creds = NULL;
+	    goto out;
+	} else if (ret != KRB5_CC_END) {
+	    goto out;
+	}
     }
     if (options & KRB5_GC_CACHED)
 	goto next_rule;

--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -865,11 +865,14 @@ ${kinit} --cache=${icache} --forwardable --password-file=${objdir}/barpassword b
         { ec=1 ; eval "${testfailed}"; }
 ${kgetcred} --cache=${icache} --out-cache=${ocache} ${ps} || \
 	{ ec=1 ; eval "${testfailed}"; }
+# Bug #816 have a regular ticket in ${cache} for ${server} see that it isn't used
+${kgetcred} ${server}@${R} || { ec=1 ; eval "${testfailed}"; }
 ${kgetcred} \
 	--out-cache=${o2cache} \
 	--delegation-credential-cache=${ocache} \
 	${server}@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
+klist -c $o2cache | grep "Default principal: bar@${R}" || { ec=1 ; eval "${testfailed}"; }
 echo "  try using the credential"
 ${test_ap_req} ${server}@${R} ${keytab} ${o2cache} || \
 	{ ec=1 ; eval "${testfailed}"; }
@@ -892,6 +895,7 @@ ${kgetcred} \
 	--delegation-credential-cache=${ocache} \
 	${server}@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
+klist -c $o2cache | grep "Default principal: foo@${R2}" || { ec=1 ; eval "${testfailed}"; }
 echo "  try using the credential"
 ${test_ap_req} ${server}@${R} ${keytab} ${o2cache} || \
 	{ ec=1 ; eval "${testfailed}"; }
@@ -933,6 +937,7 @@ ${kgetcred} \
 	--delegation-credential-cache=${ocache} \
 	${server}@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
+klist -c $o2cache | grep "Default principal: bar@${R}" || { ec=1 ; eval "${testfailed}"; }
 ${test_ap_req} ${server}@${R} ${keytab} ${o2cache} || \
 	{ ec=1 ; eval "${testfailed}"; }
 


### PR DESCRIPTION
Fix for #816, turns out there was one more place that needed changing, as the tests show they both needed.