### PR TITLE
Add placeholder for gss_acquire_cred_impersonate_name().

### DIFF
--- a/lib/gssapi/Makefile.am
+++ b/lib/gssapi/Makefile.am
@@ -85,6 +85,7 @@ mechsrc = \
 	mech/gss_accept_sec_context.c \
 	mech/gss_acquire_cred.c \
 	mech/gss_acquire_cred_from.c \
+	mech/gss_acquire_cred_impersonate_name.c \
 	mech/gss_acquire_cred_with_password.c \
 	mech/gss_add_cred.c \
 	mech/gss_add_cred_from.c \

--- a/lib/gssapi/NTMakefile
+++ b/lib/gssapi/NTMakefile
@@ -100,6 +100,7 @@ mechsrc = \
 	mech/gss_accept_sec_context.c \
 	mech/gss_acquire_cred.c \
 	mech/gss_acquire_cred_from.c \
+	mech/gss_acquire_cred_impersonate_name.c \
 	mech/gss_acquire_cred_with_password.c \
 	mech/gss_add_cred.c \
 	mech/gss_add_cred_from.c \
@@ -386,6 +387,7 @@ libgssapi_OBJs = \
 	$(OBJ)\mech/gss_accept_sec_context.obj \
 	$(OBJ)\mech/gss_acquire_cred.obj \
 	$(OBJ)\mech/gss_acquire_cred_from.obj \
+	$(OBJ)\mech/gss_acquire_cred_impersonate_name.obj \
 	$(OBJ)\mech/gss_acquire_cred_with_password.obj \
 	$(OBJ)\mech/gss_add_cred.obj \
 	$(OBJ)\mech/gss_add_cred_from.obj \

--- a/lib/gssapi/gssapi/gssapi.h
+++ b/lib/gssapi/gssapi/gssapi.h
@@ -1243,6 +1243,23 @@ gss_destroy_cred(OM_uint32 *minor_status,
 GSSAPI_LIB_FUNCTION uintptr_t GSSAPI_CALLCONV
 gss_get_instance(const char *libname);
 
+/*
+ * S4UProxy and S4USelf extensions.
+ */
+
+GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_CALLCONV
+gss_acquire_cred_impersonate_name(
+    OM_uint32 * /* minor_status */,
+    gss_const_cred_id_t /* icred */,
+    gss_const_name_t /* desired_name */,
+    OM_uint32 /* time_req */,
+    gss_OID_set /* desired_mechs */,
+    gss_cred_usage_t /* cred_usage */,
+    gss_cred_id_t * /* output_cred */,
+    gss_OID_set * /* actual_mechs */,
+    OM_uint32 * /* time_rec */
+    );
+
 GSSAPI_CPP_END
 
 #if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))

--- a/lib/gssapi/gssapi_mech.h
+++ b/lib/gssapi/gssapi_mech.h
@@ -450,6 +450,17 @@ _gss_acquire_cred_from_t(OM_uint32 *minor_status,
 			 OM_uint32 *time_rec);
 
 typedef OM_uint32 GSSAPI_CALLCONV
+_gss_acquire_cred_impersonate_name_t(OM_uint32 *minor_status,
+				     gss_const_cred_id_t icred,
+				     gss_const_name_t desired_name,
+				     OM_uint32 time_req,
+				     gss_OID_set desired_mechs,
+				     gss_cred_usage_t cred_usage,
+				     gss_cred_id_t *output_cred_handle,
+				     gss_OID_set *actual_mechs,
+				     OM_uint32 *time_rec);
+
+typedef OM_uint32 GSSAPI_CALLCONV
 _gss_add_cred_from_t(OM_uint32 *minor_status,
 		     gss_cred_id_t input_cred_handle,
 		     gss_const_name_t desired_name,
@@ -601,6 +612,7 @@ typedef struct gssapi_mech_interface_desc {
 	_gss_export_cred_t		*gm_export_cred;
 	_gss_import_cred_t		*gm_import_cred;
 	_gss_acquire_cred_from_t	*gm_acquire_cred_from; /* was acquire_cred_ext */
+	_gss_acquire_cred_impersonate_name_t	*gm_acquire_cred_impersonate_name;
 	_gss_iter_creds_t		*gm_iter_creds;
 	_gss_destroy_cred_t		*gm_destroy_cred;
 	_gss_cred_hold_t		*gm_cred_hold;

--- a/lib/gssapi/krb5/external.c
+++ b/lib/gssapi/krb5/external.c
@@ -372,6 +372,7 @@ static gssapi_mech_interface_desc krb5_mech = {
     _gsskrb5_export_cred,
     _gsskrb5_import_cred,
     _gsskrb5_acquire_cred_from,
+    NULL, /* gm_acquire_cred_impersonate_name */
     NULL,
     NULL,
     NULL,

--- a/lib/gssapi/libgssapi-exports.def
+++ b/lib/gssapi/libgssapi-exports.def
@@ -11,6 +11,7 @@ EXPORTS
         __gss_c_attr_local_login_user           DATA
 	gss_accept_sec_context
 	gss_acquire_cred
+	gss_acquire_cred_impersonate_name
 	gss_acquire_cred_from
 	gss_acquire_cred_with_password
 	gss_add_buffer_set_member

--- a/lib/gssapi/mech/gss_acquire_cred_impersonate_name.c
+++ b/lib/gssapi/mech/gss_acquire_cred_impersonate_name.c
@@ -1,0 +1,51 @@
+/*-
+ * Copyright 2021, Dr Robert Harvey Crowston. <crowston@protonmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "mech_locl.h"
+
+GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
+gss_acquire_cred_impersonate_name(
+    OM_uint32 *minor_status,
+    gss_const_cred_id_t icred_handle,
+    gss_const_name_t desired_name,
+    OM_uint32 time_req,
+    gss_OID_set desired_mechs,
+    gss_cred_usage_t cred_usage,
+    gss_cred_id_t *ocred_handle,
+    gss_OID_set *actual_mechs,
+    OM_uint32 *time_rec)
+{
+    *minor_status = 0;
+
+    if (ocred_handle == NULL)
+	return GSS_S_CALL_INACCESSIBLE_WRITE;
+
+    *ocred_handle = GSS_C_NO_CREDENTIAL;
+
+    /* Not implemented. */
+    return GSS_S_UNAVAILABLE;
+}
+

--- a/lib/gssapi/mech/gss_mech_switch.c
+++ b/lib/gssapi/mech/gss_mech_switch.c
@@ -395,6 +395,7 @@ _gss_load_mech(void)
 		OPTSYM(export_cred);
 		OPTSYM(import_cred);
 		OPTSYM(acquire_cred_from);
+		OPTSYM(acquire_cred_impersonate_name);
 #if 0
 		OPTSYM(iter_creds);
 		OPTSYM(destroy_cred);

--- a/lib/gssapi/netlogon/external.c
+++ b/lib/gssapi/netlogon/external.c
@@ -81,6 +81,7 @@ static gssapi_mech_interface_desc netlogon_mech = {
     NULL, /* gm_export_cred */
     NULL, /* gm_import_cred */
     NULL, /* gm_acquire_cred_from */
+    NULL, /* gm_acquire_cred_impersonate_name */
     NULL, /* gm_iter_creds */
     NULL, /* gm_destroy_cred */
     NULL, /* gm_cred_hold */

--- a/lib/gssapi/ntlm/external.c
+++ b/lib/gssapi/ntlm/external.c
@@ -106,6 +106,7 @@ static gssapi_mech_interface_desc ntlm_mech = {
     NULL,
     NULL,
     _gss_ntlm_acquire_cred_from,
+    NULL, /* gm_acquire_cred_impersonate_name */
     _gss_ntlm_iter_creds_f,
     _gss_ntlm_destroy_cred,
     NULL,

--- a/lib/gssapi/sanon/external.c
+++ b/lib/gssapi/sanon/external.c
@@ -236,6 +236,7 @@ static gssapi_mech_interface_desc sanon_mech = {
     _gss_sanon_export_cred,
     _gss_sanon_import_cred,
     _gss_sanon_acquire_cred_from,
+    NULL, /* gm_acquire_cred_impersonate_name */
     NULL,
     NULL,
     NULL,

--- a/lib/gssapi/spnego/external.c
+++ b/lib/gssapi/spnego/external.c
@@ -130,6 +130,7 @@ static gssapi_mech_interface_desc spnego_mech = {
     NULL, /* gm_export_cred */
     NULL, /* gm_import_cred */
     NULL, /* gm_acquire_cred_from */
+    NULL, /* gm_acquire_cred_impersonate_name */
     NULL,
     NULL,
     NULL,

--- a/lib/gssapi/version-script.map
+++ b/lib/gssapi/version-script.map
@@ -16,6 +16,7 @@ HEIMDAL_GSS_2.0 {
 		gss_accept_sec_context;
 		gss_acquire_cred;
 		gss_acquire_cred_from;
+		gss_acquire_cred_impersonate_name;
 		gss_acquire_cred_with_password;
 		gss_add_buffer_set_member;
 		gss_add_cred;


### PR DESCRIPTION
Add placeholder and prototype for `gss_acquire_cred_impersonate_name()`.

The prototype for `gss_acquire_cred_impersonate_name()` is patterned off the [MIT implementation](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/gssapi.html#constrained-delegation-s4u). No functional changes are intended in this patch.

 See issue #4.
