### PR TITLE
Fix spelling/grammar in various PKINIT messages

### DIFF
--- a/kdc/pkinit.c
+++ b/kdc/pkinit.c
@@ -404,7 +404,7 @@ _kdc_pk_rd_padata(astgs_request_t priv,
     *ret_params = NULL;
 
     if (!config->enable_pkinit) {
-	kdc_log(context, config, 0, "PK-INIT request but PK-INIT not enabled");
+	kdc_log(context, config, 0, "PKINIT request but PKINIT not enabled");
 	krb5_clear_error_message(context);
 	return 0;
     }
@@ -472,7 +472,7 @@ _kdc_pk_rd_padata(astgs_request_t priv,
 	if (_kdc_is_anonymous(context, client->entry.principal)) {
 	    ret = KRB5_KDC_ERR_PUBLIC_KEY_ENCRYPTION_NOT_SUPPORTED;
 	    krb5_set_error_message(context, ret,
-				   "Anon not supported in RSA mode");
+		"Anonymous client not supported in RSA mode");
 	    goto out;
 	}
 
@@ -651,7 +651,7 @@ _kdc_pk_rd_padata(astgs_request_t priv,
 	der_heim_oid_cmp(&eContentType, &asn1_oid_id_pkauthdata) != 0)
     {
 	ret = KRB5_BADMSGTYPE;
-	krb5_set_error_message(context, ret, "got wrong oid for pkauthdata");
+	krb5_set_error_message(context, ret, "got wrong oid for PK AuthData");
 	goto out;
     }
 
@@ -682,7 +682,7 @@ _kdc_pk_rd_padata(astgs_request_t priv,
 	if (ap.clientPublicValue) {
 	    ret = KRB5KRB_ERR_GENERIC;
 	    krb5_set_error_message(context, ret,
-				   "DH not supported for windows");
+				   "DH not supported for Win2k");
 	    goto out;
 	}
 	free_AuthPack_Win2k(&ap);
@@ -706,7 +706,7 @@ _kdc_pk_rd_padata(astgs_request_t priv,
 	    free_AuthPack(&ap);
 	    ret = KRB5_KDC_ERR_PUBLIC_KEY_ENCRYPTION_NOT_SUPPORTED;
 	    krb5_set_error_message(context, ret,
-				   "Anon not supported in RSA mode");
+		"Anonymous client not supported in RSA mode");
 	    goto out;
 	}
 
@@ -733,7 +733,8 @@ _kdc_pk_rd_padata(astgs_request_t priv,
                                           &cp->u.ecdh.public_key);
 	    } else {
 		ret = KRB5_BADMSGTYPE;
-		krb5_set_error_message(context, ret, "PKINIT unknown DH mechanism");
+		krb5_set_error_message(context, ret,
+		    "PKINIT unknown DH mechanism");
 	    }
 	    if (ret) {
 		free_AuthPack(&ap);
@@ -771,7 +772,7 @@ _kdc_pk_rd_padata(astgs_request_t priv,
     } else
 	krb5_abortx(context, "internal pkinit error");
 
-    kdc_log(context, config, 0, "PK-INIT request of type %s", type);
+    kdc_log(context, config, 0, "PKINIT request of type %s", type);
 
 out:
     if (ret)
@@ -1327,7 +1328,8 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 				   &kx, &size, ret);
 		free_EncryptedData(&kx);
 		if (ret) {
-		    krb5_set_error_message(context, ret, "encoding of PKINIT-KX failed %d", ret);
+		    krb5_set_error_message(context, ret,
+				"encoding of PKINIT-KX failed %d", ret);
 		    free_PA_PK_AS_REP(&rep);
 		    goto out;
 		}
@@ -1369,7 +1371,7 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 	if (len != size)
 	    krb5_abortx(context, "Internal ASN.1 encoder error");
 
-	kdc_log(context, config, 0, "PK-INIT using %s %s", type, other);
+	kdc_log(context, config, 0, "PKINIT using %s %s", type, other);
 
     } else if (cp->type == PKINIT_WIN2K) {
 	PA_PK_AS_REP_Win2k rep;
@@ -1378,7 +1380,7 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 	if (cp->keyex != USE_RSA) {
 	    ret = KRB5KRB_ERR_GENERIC;
 	    krb5_set_error_message(context, ret,
-				   "Windows PK-INIT doesn't support DH");
+				   "Win2k PKINIT doesn't support DH");
 	    goto out;
 	}
 
@@ -1436,7 +1438,7 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 	}
 
     } else
-	krb5_abortx(context, "PK-INIT internal error");
+	krb5_abortx(context, "PKINIT internal error");
 
 
     ret = krb5_padata_add(context, md, pa_type, buf, len);
@@ -1461,7 +1463,7 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 	    fd = open(config->pkinit_kdc_ocsp_file, O_RDONLY);
 	    if (fd < 0) {
 		kdc_log(context, config, 0,
-			"PK-INIT failed to open ocsp data file %d", errno);
+			"PKINIT failed to open ocsp data file %d", errno);
 		goto out_ocsp;
 	    }
 	    ret = fstat(fd, &sb);
@@ -1469,7 +1471,7 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 		ret = errno;
 		close(fd);
 		kdc_log(context, config, 0,
-			"PK-INIT failed to stat ocsp data %d", ret);
+			"PKINIT failed to stat ocsp data %d", ret);
 		goto out_ocsp;
 	    }
 
@@ -1477,7 +1479,7 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 	    if (ret) {
 		close(fd);
 		kdc_log(context, config, 0,
-			"PK-INIT failed to stat ocsp data %d", ret);
+			"PKINIT failed to stat ocsp data %d", ret);
 		goto out_ocsp;
 	    }
 	    ocsp.data.length = sb.st_size;
@@ -1485,7 +1487,7 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 	    close(fd);
 	    if (ret != sb.st_size) {
 		kdc_log(context, config, 0,
-			"PK-INIT failed to read ocsp data %d", errno);
+			"PKINIT failed to read ocsp data %d", errno);
 		goto out_ocsp;
 	    }
 
@@ -1497,7 +1499,7 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 				    &ocsp.expire);
 	    if (ret) {
 		kdc_log(context, config, 0,
-			"PK-INIT failed to verify ocsp data %d", ret);
+			"PKINIT failed to verify ocsp data %d", ret);
 		krb5_data_free(&ocsp.data);
 		ocsp.expire = 0;
 	    } else if (ocsp.expire > 180) {
@@ -1563,13 +1565,13 @@ match_rfc_san(krb5_context context,
 	if (ret) {
 	    const char *msg = krb5_get_error_message(context, ret);
 	    kdc_log(context, config, 0,
-		    "Decoding kerberos name in certificate failed: %s", msg);
+		    "Decoding Kerberos principal name in certificate failed: %s", msg);
 	    krb5_free_error_message(context, msg);
 	    break;
 	}
 	if (size != list.val[i].length) {
 	    kdc_log(context, config, 0,
-		    "Decoding kerberos name have extra bits on the end");
+		    "Decoded Kerberos principal name did not have expected length");
 	    return KRB5_KDC_ERR_CLIENT_NAME_MISMATCH;
 	}
 
@@ -1618,7 +1620,7 @@ match_ms_upn_san(krb5_context context,
 
     if (list.len != 1) {
 	kdc_log(context, config, 0,
-		"More then one PK-INIT MS UPN SAN");
+		"More than one PKINIT MS UPN SAN");
 	ret = KRB5_KDC_ERR_CLIENT_NAME_MISMATCH;
 	goto out;
     }
@@ -1715,7 +1717,7 @@ _kdc_pk_check_client(astgs_request_t r,
 	return ret;
 
     kdc_log(context, config, 0,
-	    "Trying to authorize PK-INIT subject DN %s",
+	    "Trying to authorize PKINIT subject DN %s",
 	    *subject_name);
 
     ret = hdb_entry_get_pkinit_cert(&client->entry, &pc);
@@ -1734,7 +1736,7 @@ _kdc_pk_check_client(astgs_request_t r,
 	    hx509_cert_free(cert);
 	    if (ret == 0) {
 		kdc_log(context, config, 5,
-			"Found matching PK-INIT cert in hdb");
+			"Found matching PKINIT cert in hdb");
 		return 0;
 	    }
 	}
@@ -1748,7 +1750,7 @@ _kdc_pk_check_client(astgs_request_t r,
 			    client->entry.principal);
 	if (ret == 0) {
 	    kdc_log(context, config, 5,
-		    "Found matching PK-INIT SAN in certificate");
+		    "Found matching PKINIT SAN in certificate");
 	    return 0;
 	}
 	ret = match_ms_upn_san(context, config,
@@ -1780,7 +1782,7 @@ _kdc_pk_check_client(astgs_request_t r,
 		continue;
 
 	    kdc_log(context, config, 5,
-		    "Found matching PK-INIT database ACL");
+		    "Found matching PKINIT database ACL");
 	    return 0;
 	}
     }
@@ -1796,7 +1798,7 @@ _kdc_pk_check_client(astgs_request_t r,
 	if (strcmp(principal_mappings.val[i].subject, *subject_name) != 0)
 	    continue;
 	kdc_log(context, config, 5,
-		"Found matching PK-INIT FILE ACL");
+		"Found matching PKINIT FILE ACL");
 	return 0;
     }
 
@@ -1991,7 +1993,7 @@ krb5_kdc_pk_initialize(krb5_context context,
 		if (ret == 0) {
 		    hx509_name_to_string(name, &str);
 		    krb5_warnx(context, "WARNING Found KDC certificate (%s)"
-			       "is missing the PK-INIT KDC EKU, this is bad for "
+			       "is missing the PKINIT KDC EKU, this is bad for "
 			       "interoperability.", str);
 		    hx509_name_free(&name);
 		    free(str);
@@ -2000,7 +2002,7 @@ krb5_kdc_pk_initialize(krb5_context context,
 	    hx509_cert_free(cert);
 	} else
 	    krb5_warnx(context, "PKINIT: failed to find a signing "
-		       "certifiate with a public key");
+		       "certificate with a public key");
     }
 
     if (krb5_config_get_bool_default(context,

--- a/lib/hx509/ca.c
+++ b/lib/hx509/ca.c
@@ -224,12 +224,12 @@ hx509_ca_tbs_template_units(void)
 }
 
 /**
- * Initialize the to-be-signed certificate object from a template certifiate.
+ * Initialize the to-be-signed certificate object from a template certificate.
  *
  * @param context A hx509 context.
  * @param tbs object to be signed.
  * @param flags bit field selecting what to copy from the template
- * certifiate.
+ * certificate.
  * @param cert template certificate.
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -1294,7 +1294,8 @@ hx509_ca_tbs_add_san_hardwareModuleName_string(hx509_context context,
     p = strchr(freeme, ':');
     if (!p) {
         hx509_set_error_string(context, 0, EINVAL,
-                               "Invalid HardwareModuleName string (should be \"<oid>:<serial>\")",
+                               "Invalid HardwareModuleName string (should be "
+                               "\"<oid>:<serial>\")",
                                oidstr);
         free(freeme);
         return EINVAL;
@@ -1739,7 +1740,7 @@ ca_sign(hx509_context context,
     /* signature            AlgorithmIdentifier, */
     ret = copy_AlgorithmIdentifier(sigalg, &tbsc->signature);
     if (ret) {
-	hx509_set_error_string(context, 0, ret, "Failed to copy sigature alg");
+	hx509_set_error_string(context, 0, ret, "Failed to copy signature alg");
 	goto out;
     }
     /* issuer               Name, */
@@ -2568,11 +2569,11 @@ get_cf(hx509_context context,
         ret = 0;
     if (ret) {
         heim_log_msg(context->hcontext, logf, 3, NULL,
-                     "No configuration for %s %s certificates realm "
+                     "No configuration for %s %s certificate's realm "
                      "-> %s -> kx509 -> %s%s%s", def, label, realm, label,
                      svc ? " -> " : "", svc ? svc : "");
         hx509_set_error_string(context, 0, EACCES,
-                "No configuration for %s %s certificates realm "
+                "No configuration for %s %s certificate's realm "
                 "-> %s -> kx509 -> %s%s%s", def, label, realm, label,
                 svc ? " -> " : "", svc ? svc : "");
     }

--- a/lib/hx509/cert.c
+++ b/lib/hx509/cert.c
@@ -981,7 +981,7 @@ check_key_usage(hx509_context context, const Certificate *cert,
 	if (req_present) {
 	    hx509_set_error_string(context, 0, HX509_KU_CERT_MISSING,
 				   "Required extension key "
-				   "usage missing from certifiate");
+				   "usage missing from certificate");
 	    return HX509_KU_CERT_MISSING;
 	}
 	return 0;
@@ -999,7 +999,7 @@ check_key_usage(hx509_context context, const Certificate *cert,
 	_hx509_unparse_Name(&cert->tbsCertificate.subject, &name);
 	hx509_set_error_string(context, 0, HX509_KU_CERT_MISSING,
 			       "Key usage %s required but missing "
-			       "from certifiate %s", buf,
+			       "from certificate %s", buf,
                                name ? name : "<unknown>");
 	free(name);
 	return HX509_KU_CERT_MISSING;
@@ -1578,8 +1578,8 @@ hx509_cert_get_base_subject(hx509_context context, hx509_cert c,
     if (is_proxy_cert(context, c->data, NULL) == 0) {
 	int ret = HX509_PROXY_CERTIFICATE_NOT_CANONICALIZED;
 	hx509_set_error_string(context, 0, ret,
-			       "Proxy certificate have not been "
-			       "canonicalize yet, no base name");
+			       "Proxy certificate has not been "
+			       "canonicalized yet: no base name");
 	return ret;
     }
     return _hx509_name_from_Name(&c->data->tbsCertificate.subject, name);
@@ -1752,7 +1752,7 @@ get_x_unique_id(hx509_context context, const char *name,
 
     if (cert == NULL) {
 	ret = HX509_EXTENSION_NOT_FOUND;
-	hx509_set_error_string(context, 0, ret, "%s unique id doesn't exists", name);
+	hx509_set_error_string(context, 0, ret, "%s unique id doesn't exist", name);
 	return ret;
     }
     ret = der_copy_bit_string(cert, subject);
@@ -2173,7 +2173,7 @@ check_name_constraints(hx509_context context,
 	    /* allow null subjectNames, they wont matches anything */
 	    if (match == 0 && !subject_null_p(c)) {
 		hx509_set_error_string(context, 0, HX509_VERIFY_CONSTRAINTS,
-				       "Error verify constraints, "
+				       "Error verifying constraints: "
 				       "certificate didn't match any "
 				       "permitted subtree");
 		return HX509_VERIFY_CONSTRAINTS;
@@ -2188,7 +2188,7 @@ check_name_constraints(hx509_context context,
 	    }
 	    if (match) {
 		hx509_set_error_string(context, 0, HX509_VERIFY_CONSTRAINTS,
-				       "Error verify constraints, "
+				       "Error verifying constraints: "
 				       "certificate included in excluded "
 				       "subtree");
 		return HX509_VERIFY_CONSTRAINTS;
@@ -2245,7 +2245,7 @@ hx509_verify_path(hx509_context context,
 	ret = HX509_PROXY_CERT_INVALID;
 	hx509_set_error_string(context, 0, ret,
 			       "Proxy certificate is not allowed as an EE "
-			       "certificae if proxy certificate is disabled");
+			       "certificate if proxy certificate is disabled");
 	return ret;
     }
 
@@ -2346,7 +2346,7 @@ hx509_verify_path(hx509_context context,
 		    ret = HX509_PATH_TOO_LONG;
 		    hx509_set_error_string(context, 0, ret,
 					   "Proxy certificate chain "
-					   "longer then allowed");
+					   "longer than allowed");
 		    goto out;
 		}
 		/* XXX MUST check info.proxyPolicy */
@@ -2356,7 +2356,7 @@ hx509_verify_path(hx509_context context,
 		if (find_extension(c, &asn1_oid_id_x509_ce_subjectAltName, &j)) {
 		    ret = HX509_PROXY_CERT_INVALID;
 		    hx509_set_error_string(context, 0, ret,
-					   "Proxy certificate have explicitly "
+					   "Proxy certificate has explicitly "
 					   "forbidden subjectAltName");
 		    goto out;
 		}
@@ -2365,7 +2365,7 @@ hx509_verify_path(hx509_context context,
 		if (find_extension(c, &asn1_oid_id_x509_ce_issuerAltName, &j)) {
 		    ret = HX509_PROXY_CERT_INVALID;
 		    hx509_set_error_string(context, 0, ret,
-					   "Proxy certificate have explicitly "
+					   "Proxy certificate has explicitly "
 					   "forbidden issuerAltName");
 		    goto out;
 		}
@@ -3453,7 +3453,7 @@ hx509_query_unparse_stats(hx509_context context, int printtype, FILE *out)
 	return;
     f = fopen(context->querystat, "r");
     if (f == NULL) {
-	fprintf(out, "No statistic file %s: %s.\n",
+	fprintf(out, "No statistics file %s: %s.\n",
 		context->querystat, strerror(errno));
 	return;
     }

--- a/lib/hx509/revoke.c
+++ b/lib/hx509/revoke.c
@@ -40,7 +40,7 @@
  * revocation for destroyed private keys too (smartcard broken), but
  * that should not be a problem.
  *
- * CRL is a list of certifiates that have expired.
+ * CRL is a list of certificates that have expired.
  *
  * OCSP is an online checking method where the requestor sends a list
  * of certificates to the OCSP server to return a signed reply if they
@@ -217,7 +217,7 @@ verify_ocsp(hx509_context context,
 	ret = _hx509_cert_is_parent_cmp(s, p, 0);
 	if (ret != 0) {
 	    ret = HX509_PARENT_NOT_CA;
-	    hx509_set_error_string(context, 0, ret, "Revoke OCSP signer is "
+	    hx509_set_error_string(context, 0, ret, "Revoke OCSP signer "
 				   "doesn't have CA as signer certificate");
 	    goto out;
 	}
@@ -550,7 +550,7 @@ verify_crl(hx509_context context,
 	signer = crl_parent;
 	if (ret) {
 	    hx509_set_error_string(context, HX509_ERROR_APPEND, ret,
-				   "Failed to verify revoke "
+				   "Failed to verify revocation "
 				   "status of CRL signer");
 	    goto out;
 	}
@@ -647,7 +647,7 @@ hx509_revoke_add_crl(hx509_context context,
 
     if (strncmp(path, "FILE:", 5) != 0) {
 	hx509_set_error_string(context, 0, HX509_UNSUPPORTED_OPERATION,
-			       "unsupport type in %s", path);
+			       "unsupported type in %s", path);
 	return HX509_UNSUPPORTED_OPERATION;
     }
 
@@ -879,8 +879,7 @@ hx509_revoke_verify(hx509_context context,
 	return 0;
     hx509_set_error_string(context, HX509_ERROR_APPEND,
 			   HX509_REVOKE_STATUS_MISSING,
-			   "No revoke status found for "
-			   "certificates");
+			   "No revocation status found for certificates");
     return HX509_REVOKE_STATUS_MISSING;
 }
 


### PR DESCRIPTION
Only error messages and code comments touched.

* Consensus seems to be "PKINIT" over "PK-INIT".
* Clarify some instances of Windows vs Win2k.
* `s/certifiates/certificates/g`
* Some other nits