### PR TITLE
Teach krb5_get_creds_opt about expiry times.

### DIFF
--- a/lib/krb5/Makefile.am
+++ b/lib/krb5/Makefile.am
@@ -14,6 +14,7 @@ noinst_PROGRAMS =				\
 	test_crypto				\
 	test_forward				\
 	test_get_addrs				\
+	test_get_creds				\
 	test_gic				\
 	test_kuserok				\
 	test_renew				\
@@ -284,6 +285,7 @@ ALL_OBJECTS += $(test_alname_OBJECTS)
 ALL_OBJECTS += $(test_crypto_OBJECTS)
 ALL_OBJECTS += $(test_forward_OBJECTS)
 ALL_OBJECTS += $(test_get_addrs_OBJECTS)
+ALL_OBJECTS += $(test_get_creds_OBJECTS)
 ALL_OBJECTS += $(test_gic_OBJECTS)
 ALL_OBJECTS += $(test_kuserok_OBJECTS)
 ALL_OBJECTS += $(test_renew_OBJECTS)

--- a/lib/krb5/NTMakefile
+++ b/lib/krb5/NTMakefile
@@ -469,6 +469,7 @@ test_binaries =				\
 	$(OBJ)\test_crypto_wrapping.exe	\
 	$(OBJ)\test_forward.exe		\
 	$(OBJ)\test_get_addrs.exe	\
+	$(OBJ)\test_get_creds.exe	\
 	$(OBJ)\test_hostname.exe	\
 	$(OBJ)\test_keytab.exe		\
 	$(OBJ)\test_kuserok.exe		\

--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -1688,6 +1688,7 @@ struct krb5_get_creds_opt_data {
     krb5_flags options;
     krb5_enctype enctype;
     Ticket *ticket;
+    krb5_deltat lifetime;
 };
 
 
@@ -1775,6 +1776,13 @@ krb5_get_creds_opt_set_ticket(krb5_context context,
     return 0;
 }
 
+KRB5_LIB_FUNCTION void KRB5_LIB_CALL
+krb5_get_creds_opt_set_lifetime(krb5_context context,
+				krb5_get_creds_opt opt,
+				krb5_deltat lifetime)
+{
+    opt->lifetime = lifetime;
+}
 
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_get_creds(krb5_context context,
@@ -1793,6 +1801,7 @@ krb5_get_creds(krb5_context context,
     krb5_const_principal try_princ = NULL;
     krb5_name_canon_iterator name_canon_iter = NULL;
     krb5_name_canon_rule_options rule_opts;
+    krb5_timestamp now;
     int i;
     int type;
     const char *comp;
@@ -1841,6 +1850,12 @@ krb5_get_creds(krb5_context context,
     if (opt && opt->enctype) {
 	in_creds.session.keytype = opt->enctype;
 	options |= KRB5_TC_MATCH_KEYTYPE;
+    }
+
+    if (opt && opt->lifetime > 0) {
+	krb5_timeofday(context, &now);
+	in_creds.times.endtime = now + opt->lifetime;
+	options |= KRB5_TC_MATCH_TIMES;
     }
 
     ret = krb5_name_canon_iterator_start(context, in_creds.server,

--- a/lib/krb5/krb5_get_creds.3
+++ b/lib/krb5/krb5_get_creds.3
@@ -41,6 +41,7 @@
 .Nm krb5_get_creds_opt_free ,
 .Nm krb5_get_creds_opt_set_enctype ,
 .Nm krb5_get_creds_opt_set_impersonate ,
+.Nm krb5_get_creds_opt_set_lifetime ,
 .Nm krb5_get_creds_opt_set_options ,
 .Nm krb5_get_creds_opt_set_ticket
 .Nd get credentials from the KDC
@@ -83,6 +84,12 @@ Kerberos 5 Library (libkrb5, -lkrb5)
 .Fa "krb5_context context"
 .Fa "krb5_get_creds_opt opt"
 .Fa "krb5_const_principal self"
+.Fc
+.Ft void
+.Fo krb5_get_creds_opt_set_lifetime
+.Fa "krb5_context context"
+.Fa "krb5_get_creds_opt opt"
+.Fa "krb5_deltat lifetime"
 .Fc
 .Ft void
 .Fo krb5_get_creds_opt_set_options
@@ -164,6 +171,15 @@ sets the principal to impersonate., Returns a ticket that have the
 impersonation principal as a client and the requestor as the
 service. Note that the requested principal have to be the same as the
 client principal in the krbtgt.
+.Pp
+.Fn krb5_get_creds_opt_set_lifetime
+sets the desired lifetime of the ticket, measured from the time of the call to
+.Fn krb5_get_creds .
+The KDC may provide a ticket with a shorter life, as determined by the policy of
+the realm or target principal. If a ticket is present in the
+.Fa ccache
+for the desired principal and the cached ticket has a lifetime that equals or
+exceeds the requested length, the cached ticket will be returned.
 .Pp
 .Fn krb5_get_creds_opt_set_ticket
 sets the extra ticket used in user-to-user or contrained delegation use case.

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -327,6 +327,7 @@ EXPORTS
 	krb5_get_creds_opt_free
 	krb5_get_creds_opt_set_enctype
 	krb5_get_creds_opt_set_impersonate
+	krb5_get_creds_opt_set_lifetime
 	krb5_get_creds_opt_set_options
 	krb5_get_creds_opt_set_ticket
 	krb5_get_default_config_files

--- a/lib/krb5/test_get_creds.c
+++ b/lib/krb5/test_get_creds.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2021, Dr Robert Harvey Crowston. <crowston@protonmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "krb5_locl.h"
+#include <err.h>
+#include <getarg.h>
+#include <string.h>
+#include <time.h>
+
+static int usage_flag;
+static char *service_name, *ccache_name;
+static struct getargs args[] = {
+    { "service",	's',	arg_string,	&service_name,	NULL,	NULL },
+    { "ccache",		'c',	arg_string,	&ccache_name,	NULL,	NULL },
+    { "version",	0,	arg_flag,	&usage_flag,	NULL,	NULL },
+    { "help",		0,	arg_flag,	&usage_flag,	NULL,	NULL }
+};
+static int const num_args = sizeof(args) / sizeof(args[0]);
+
+static krb5_error_code
+get_service_ticket(
+    krb5_context context,
+    krb5_ccache cc,
+    krb5_principal service,
+    krb5_deltat req_lifetime,
+    int cache_only,
+    krb5_creds **out)
+{
+    krb5_error_code ret;
+    krb5_get_creds_opt opt;
+
+    ret = krb5_get_creds_opt_alloc(context, &opt);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_get_creds_opt_alloc");
+
+    if (req_lifetime > 0)
+	krb5_get_creds_opt_set_lifetime(context, opt, req_lifetime);
+
+    if (cache_only)
+	krb5_get_creds_opt_set_options(context, opt, KRB5_GC_CACHED);
+
+    ret = krb5_get_creds(context, opt, cc, service, out);
+
+    krb5_get_creds_opt_free(context, opt);
+
+    return ret;
+}
+
+static void
+test_tgs_lifetime(
+    krb5_context context,
+    krb5_ccache cc,
+    krb5_principal service,
+    krb5_deltat req_lifetime,
+    int expect_cached)
+{
+    krb5_error_code ret;
+    krb5_creds *out = NULL;
+    krb5_timestamp now;
+    time_t earliest_expected_expiry;
+    krb5_deltat const slop = 60; /* for tolerance */
+
+    /* First, check ccache. */
+    ret = get_service_ticket(context, cc, service, req_lifetime, 1, &out);
+
+    if (expect_cached && ret == KRB5_CC_NOTFOUND)
+	krb5_errx(context, 1, "Expected to find ticket in ccache.");
+    else if (!expect_cached && ret == KRB5_CC_NOTFOUND)
+	; /* This is as expected. */
+    else if (!expect_cached && !ret)
+	krb5_errx(context, 1, "Did not expect to find ticket in ccache.");
+    else if (ret)
+	krb5_err(context, 1, ret, "krb5_get_creds");
+
+    /* If necessary, go to TGS. */
+    if (ret == KRB5_CC_NOTFOUND)
+	ret = get_service_ticket(context, cc, service, req_lifetime, 0,
+	    &out);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_get_creds");
+
+    ret = krb5_timeofday(context, &now);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_timeofday");
+
+    earliest_expected_expiry = now + req_lifetime - slop;
+    if (req_lifetime > 0 && out->times.endtime < earliest_expected_expiry) {
+	krb5_errx(context, 1, "Service ticket expires at\n\t%ld\nexpected\n"
+	    "\t%ld\nor later for lifetime request %ld s (%ld s tolerance).",
+	    out->times.endtime, earliest_expected_expiry, req_lifetime, slop);
+    }
+
+    krb5_free_creds(context, out);
+}
+
+static void
+test_harness()
+{
+    krb5_error_code ret;
+    krb5_context context;
+    krb5_ccache cc;
+    krb5_principal service_princ;
+
+    ret = krb5_init_context(&context);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_init_context");
+
+    ret = krb5_parse_name(context, service_name, &service_princ);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_parse_name");
+
+    if (ccache_name != NULL) {
+	ret = krb5_cc_resolve(context, ccache_name, &cc);
+	if (ret)
+	    krb5_err(context, 1, ret, "krb5_cc_resolve");
+    } else {
+	ret = krb5_cc_default(context, &cc);
+	if (ret)
+	    krb5_err(context, 1, ret, "krb5_cc_default");
+    }
+
+    /* First, get a ticket with a ten minute expiry. */
+    test_tgs_lifetime(context, cc, service_princ, 600, 0);
+
+    /* Requesting a ticket with five minute expiry, should find in ccache. */
+    test_tgs_lifetime(context, cc, service_princ, 300, 1);
+
+    /* Requesting a ticket with unspecified expiry should also use ccache. */
+    test_tgs_lifetime(context, cc, service_princ, 0, 1);
+
+    /* Requesting a ticket with one hour expiry requires new TGS req. */
+    test_tgs_lifetime(context, cc, service_princ, 3600, 0);
+
+    krb5_cc_close(context, cc);
+    krb5_free_principal(context, service_princ);
+    krb5_free_context(context);
+}
+
+static void
+usage(int exit_code)
+{
+    arg_printusage(args, num_args, NULL, NULL);
+    exit(exit_code);
+}
+
+int
+main(int argc, char *argv[])
+{
+    int optidx;
+
+    setprogname(argv[0]);
+
+    if (getarg(args, num_args, argc, argv, &optidx))
+	usage(1);
+
+    if (usage_flag)
+	usage(0);
+
+    if (service_name == NULL)
+	usage(1);
+
+    test_harness();
+
+    return 0;
+}
+

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -323,6 +323,7 @@ HEIMDAL_KRB5_2.0 {
 		krb5_get_creds_opt_free;
 		krb5_get_creds_opt_set_enctype;
 		krb5_get_creds_opt_set_impersonate;
+		krb5_get_creds_opt_set_lifetime;
 		krb5_get_creds_opt_set_options;
 		krb5_get_creds_opt_set_ticket;
 		krb5_get_default_config_files;

--- a/tests/bin/setup-env.in
+++ b/tests/bin/setup-env.in
@@ -60,6 +60,7 @@ test_set_kvno0="${TESTS_ENVIRONMENT} ${top_builddir}/lib/krb5/test_set_kvno0"
 test_alname="${TESTS_ENVIRONMENT} ${top_builddir}/lib/krb5/test_alname"
 test_kuserok="${TESTS_ENVIRONMENT} ${top_builddir}/lib/krb5/test_kuserok"
 test_mkforwardable="${TESTS_ENVIRONMENT} ${top_builddir}/lib/krb5/test_mkforwardable"
+test_get_creds="${TESTS_ENVIRONMENT} ${top_builddir}/lib/krb5/test_get_creds"
 
 # misc apps
 have_db="${top_builddir}/tests/db/have-db"

--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -104,6 +104,7 @@ kgetcred_imp="${kgetcred} -c $cache --out-cache=${ocache}"
 kdestroy="${kdestroy} -c $cache ${afs_no_unlog}"
 kimpersonate="${kimpersonate} -k ${keytab} --ccache=${ocache}"
 test_set_kvno0="${test_set_kvno0} -c $cache"
+test_get_creds="${test_get_creds} -c $cache"
 
 rm -f ${keytabfile}
 rm -f current-db*
@@ -1087,6 +1088,12 @@ ${rkpty} ${kinitpty} ${kinit} pw-expired@${R}|| \
 
 ${kdestroy}
 
+echo "Checking krb5_get_creds()"; > messages.log
+${kinit} --password-file=${objdir}/foopassword foo@$R || \
+	{ ec=1 ; eval "${testfailed}"; }
+${test_get_creds} --service=${server}@${R} || \
+	{ ec=1 ; eval "${testfailed}"; }
+${kdestroy}
 
 echo "killing kdc (${kdcpid}) kpasswdd (${kpasswddpid})"
 sh ${leaks_kill} kdc $kdcpid || exit 1


### PR DESCRIPTION
Allow callers of krb5_get_creds() to request tickets with non-default
expiry times, through an extension to the krb5_get_creds_opt struct and
a new public function, krb5_get_creds_opt_set_lifetime().

This is needed for the gssapi S4U extensions: it seems easier to teach
krb5_get_creds() about expiry times than to teach krb5_get_credentials()
about impersonation.

Also, add a test for krb5_get_creds(), since we don't seem to have an
explicit test for it yet.