### PR TITLE
kdc: validate sname in TGS-REQ

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1668,7 +1668,7 @@ tgs_build_reply(krb5_context context,
 	r = adtkt.crealm;
     } else if (s == NULL) {
 	ret = KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN;
-	_kdc_set_e_text(r, "No server in request");
+	_kdc_set_e_text(priv, "No server in request");
 	goto out;
     }
 

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1666,6 +1666,10 @@ tgs_build_reply(krb5_context context,
 
 	s = &adtkt.cname;
 	r = adtkt.crealm;
+    } else if (s == NULL) {
+	ret = KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN;
+	_kdc_set_e_text(r, "No server in request");
+	goto out;
     }
 
     _krb5_principalname2krb5_principal(context, &sp, *s, r);


### PR DESCRIPTION
For #849 
In tgs_build_reply(), validate the server name in the TGS-REQ is present before
dereferencing.