### PR TITLE
Always cmp cmp (GCC bug 95189)

### DIFF
--- a/appl/dceutils/k5dcecon.c
+++ b/appl/dceutils/k5dcecon.c
@@ -163,8 +163,8 @@ int k5dcesession(luid, pname, tgt, ppag, tflags)
 /*
  * (but root has the ffffffff which we are not interested in)
  */
-    if (!strncmp(direntp->d_name,"dcecred_",8)
-         && (strlen(direntp->d_name) == 16)) {
+    if (strncmp(direntp->d_name,"dcecred_",8) == 0 &&
+        (strlen(direntp->d_name) == 16)) {
 
       /* looks like a cache name, lets do the stat, etc */
 
@@ -246,7 +246,7 @@ int k5dcematch(luid, pname, ccname, sizep, tgt)
 
   /* DEEDEBUG2("k5dcematch called: cache=%s\n",ccname+38); */
 
-  if (!strncmp(ccname,"FILE:",5)) {
+  if (strncmp(ccname,"FILE:",5) == 0) {
 
     strcpy(ccdata,ccname+5);
     strcat(ccdata,".data");
@@ -343,7 +343,7 @@ int k5dcegettgt(pcache, ccname, pname, tgt)
 
   DEEDEBUG2("Unparsed to \"%s\"\n", kusername);
   DEEDEBUG2("pname is \"%s\"\n", pname);
-  if (strcmp(kusername, pname)) {
+  if (strcmp(kusername, pname) != 0) {
    DEEDEBUG("Principals not equal\n");
    goto return1;
   }
@@ -574,7 +574,7 @@ int k5dcecreate(luid, luser, pname, krbtgt)
     }
 
 
-    if (!strcmp(urealm,defrealm)) {
+    if (strcmp(urealm,defrealm) == 0) {
         strcpy(username,pname);
     } else {
         strcpy(username,"/.../");

--- a/appl/kf/kf.c
+++ b/appl/kf/kf.c
@@ -277,7 +277,7 @@ proto (int sock, const char *hostname, const char *svc,
     }
     krb5_data_free (&data);
 
-    return(strcmp(message, "ok"));
+    return strcmp(message, "ok") != 0;
 }
 
 static int

--- a/kdc/bx509d.c
+++ b/kdc/bx509d.c
@@ -176,7 +176,7 @@ audit_trail(bx509_request_desc r, krb5_error_code ret)
     }
 
     /* Let's save a few bytes */
-    if (retname && !strncmp("KRB5KDC_", retname, sizeof("KRB5KDC_") - 1))
+    if (retname && strncmp("KRB5KDC_", retname, sizeof("KRB5KDC_") - 1) == 0)
         retname += sizeof("KRB5KDC_") - 1;
 #undef PREFIX
     heim_audit_trail((heim_svc_req_desc)r, ret, retname);
@@ -299,7 +299,7 @@ generate_key(hx509_context context,
     hx509_cert cert = NULL;
     int ret;
 
-    if (strcmp(gen_type, "rsa"))
+    if (strcmp(gen_type, "rsa") != 0)
         errx(1, "Only RSA keys are supported at this time");
 
     if (asprintf(fn, "PEM-FILE:%s/.%s_priv_key.pem",
@@ -1569,8 +1569,8 @@ bnegotiate_get_target(struct bx509_request_desc *r)
         return bad_403(r, EACCES,
                        "Redirect request without Referer header nor allowed");
 
-    if (strncmp(referer, "https://", sizeof("https://") - 1) ||
-        strncmp(redir, "https://", sizeof("https://") - 1))
+    if (strncmp(referer, "https://", sizeof("https://") - 1) != 0 ||
+        strncmp(redir, "https://", sizeof("https://") - 1) != 0)
         return bad_403(r, EACCES,
                        "Redirect requests permitted only for https referrers");
 
@@ -1590,7 +1590,7 @@ bnegotiate_get_target(struct bx509_request_desc *r)
     }
 
     /* Both must match */
-    if (strcasecmp(s1, s2)) {
+    if (strcasecmp(s1, s2) != 0) {
         free(s2);
         free(s1);
         return bad_403(r, EACCES, "Redirect request does not match referer");

--- a/kdc/httpkadmind.c
+++ b/kdc/httpkadmind.c
@@ -837,7 +837,7 @@ good_ext_keytab(kadmin_request_desc r)
     if (!r->keytab_name || !(p = strchr(r->keytab_name, ':')))
         return bad_503(r, EINVAL, "Internal error (no keytab produced)");
     p++;
-    if (strncmp(p, cache_dir, strlen(cache_dir)))
+    if (strncmp(p, cache_dir, strlen(cache_dir)) != 0)
         return bad_503(r, EINVAL, "Internal error");
     ret = rk_undumpdata(p, &body, &bodylen);
     if (ret)

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -446,7 +446,8 @@ fix_transited_encoding(krb5_context context,
      * If the realm of the presented tgt is neither the client nor the server
      * realm, it is a transit realm and must be added to transited set.
      */
-    if(strcmp(client_realm, tgt_realm) && strcmp(server_realm, tgt_realm)) {
+    if (strcmp(client_realm, tgt_realm) != 0 &&
+        strcmp(server_realm, tgt_realm) != 0) {
 	if (num_realms + 1 > UINT_MAX/sizeof(*realms)) {
 	    ret = ERANGE;
 	    goto free_realms;
@@ -465,7 +466,7 @@ fix_transited_encoding(krb5_context context,
 	num_realms++;
     }
     if(num_realms == 0) {
-	if(strcmp(client_realm, server_realm))
+	if (strcmp(client_realm, server_realm) != 0)
 	    kdc_log(context, config, 4,
 		    "cross-realm %s -> %s", client_realm, server_realm);
     } else {

--- a/kdc/mit_dump.c
+++ b/kdc/mit_dump.c
@@ -169,13 +169,13 @@ mit_prop_dump(void *arg, const char *file)
 	if(strncmp(line, "kdb5_util", strlen("kdb5_util")) == 0) {
 	    int major;
             q = nexttoken(&p);
-            if (strcmp(q, "kdb5_util"))
+            if (strcmp(q, "kdb5_util") != 0)
                 errx(1, "line %d: unknown version", lineno);
 	    q = nexttoken(&p); /* load_dump */
-	    if (strcmp(q, "load_dump"))
+	    if (strcmp(q, "load_dump") != 0)
 		errx(1, "line %d: unknown version", lineno);
 	    q = nexttoken(&p); /* load_dump */
-	    if (strcmp(q, "version"))
+	    if (strcmp(q, "version") != 0)
 		errx(1, "line %d: unknown version", lineno);
 	    q = nexttoken(&p); /* x.0 */
 	    if (sscanf(q, "%d", &major) != 1)

--- a/kdc/process.c
+++ b/kdc/process.c
@@ -164,7 +164,7 @@ _kdc_audit_trail(kdc_request_t r, krb5_error_code ret)
 
     /* Let's save a few bytes */
 #define PREFIX "KRB5KDC_"
-    if (retname && !strncmp(PREFIX, retname, strlen(PREFIX)))
+    if (retname && strncmp(PREFIX, retname, strlen(PREFIX)) == 0)
 	retname += strlen(PREFIX);
 #undef PREFIX
 

--- a/lib/asn1/asn1_print.c
+++ b/lib/asn1/asn1_print.c
@@ -471,7 +471,7 @@ dotype(unsigned char *buf, size_t len, char **argv, size_t *size)
                 ret = sorted_types[i].encode(der + (sz - 1), sz, v, &sz);
                 if (ret != 0)
                     errx(1, "Encoding failed");
-                if (memcmp(buf, der, sz))
+                if (memcmp(buf, der, sz) != 0)
                     errx(1, "Encoding did not round trip");
                 free(der);
             }
@@ -490,7 +490,7 @@ dotype(unsigned char *buf, size_t len, char **argv, size_t *size)
                     ret = sorted_types[i].encode(der + (sz - 1), sz, vcpy, &sz);
                     if (ret != 0)
                         errx(1, "Encoding of copy failed");
-                    if (memcmp(buf, der, sz))
+                    if (memcmp(buf, der, sz) != 0)
                         errx(1, "Encoding of copy did not round trip");
                     free(der);
                 }

--- a/lib/asn1/asn1parse.y
+++ b/lib/asn1/asn1parse.y
@@ -1945,7 +1945,7 @@ validate_object_set(IOSObjectSet *os)
         sort_object_set(os, cf, &objects, &nobjs);
         for (i = 0; i < nobjs; i++) {
             HEIM_TAILQ_FOREACH(of, objects[i]->objfields, objfields) {
-                if (strcmp(cf->name, of->name))
+                if (strcmp(cf->name, of->name) != 0)
                     continue;
                 if (!of->value)
                     errx(1, "Value not specified for required UNIQUE field %s of object %s",
@@ -1970,7 +1970,7 @@ validate_object_set(IOSObjectSet *os)
             int specified = 0;
 
             HEIM_TAILQ_FOREACH(of, o->objfields, objfields) {
-                if (strcmp(of->name, cf->name))
+                if (strcmp(of->name, cf->name) != 0)
                     continue;
                 if (of->value)
                     specified = 1;

--- a/lib/asn1/check-der.c
+++ b/lib/asn1/check-der.c
@@ -883,24 +883,24 @@ test_heim_oid_format_same(const char *str, const heim_oid *oid)
 	printf("fail to print oid: %s\n", str);
 	return 1;
     }
-    ret = strcmp(p, str);
-    if (ret) {
+
+    if (strcmp(p, str) != 0) {
 	printf("oid %s != formated oid %s\n", str, p);
 	free(p);
-	return ret;
+	return 1;
     }
 
     ret = der_parse_heim_oid(p, " ", &o2);
     if (ret) {
 	printf("failed to parse %s\n", p);
 	free(p);
-	return ret;
+	return 1;
     }
     free(p);
     ret = der_heim_oid_cmp(&o2, oid);
     der_free_oid(&o2);
 
-    return ret;
+    return 0;
 }
 
 static unsigned sha1_oid_tree[] = { 1, 3, 14, 3, 2, 26 };

--- a/lib/asn1/check-gen.c
+++ b/lib/asn1/check-gen.c
@@ -2367,7 +2367,7 @@ test_ios(void)
     s = print_Certificate(&c0, 0);
     if (!s)
         return 1;
-    if (strcmp(s, cert_json))
+    if (strcmp(s, cert_json) != 0)
         return 1;
     free(s);
 
@@ -2407,7 +2407,7 @@ test_ios(void)
         return 1;
     if (os.length != size || size != sizeof(encoded_sample))
         return 1;
-    if (memcmp(os.data, encoded_sample, os.length))
+    if (memcmp(os.data, encoded_sample, os.length) != 0)
         return 1;
     der_free_octet_string(&os);
 
@@ -2424,7 +2424,7 @@ test_ios(void)
         return 1;
     if (os.length != size || size != sizeof(encoded_sample))
         return 1;
-    if (memcmp(os.data, encoded_sample, os.length))
+    if (memcmp(os.data, encoded_sample, os.length) != 0)
         return 1;
     der_free_octet_string(&os);
 
@@ -2440,7 +2440,7 @@ test_ios(void)
         return 1;
     if (os.length != size || size != sizeof(encoded_sample))
         return 1;
-    if (memcmp(os.data, encoded_sample, os.length))
+    if (memcmp(os.data, encoded_sample, os.length) != 0)
         return 1;
     der_free_octet_string(&os);
 

--- a/lib/asn1/der_put.c
+++ b/lib/asn1/der_put.c
@@ -650,7 +650,7 @@ _heim_der_set_sort(const void *a1, const void *a2)
 
     ret = memcmp(s1->data, s2->data,
 		 s1->length < s2->length ? s1->length : s2->length);
-    if(ret)
+    if (ret != 0)
 	return ret;
     return (int)(s1->length - s2->length);
 }

--- a/lib/asn1/gen.c
+++ b/lib/asn1/gen.c
@@ -990,7 +990,7 @@ get_open_type_defn_fields(const Type *t,
     }
     /* Look for the type ID member identified in the previous loop */
     HEIM_TAILQ_FOREACH(m, t->members, members) {
-        if (!m->type->subtype || strcmp(m->name, idmembername))
+        if (!m->type->subtype || strcmp(m->name, idmembername) != 0)
             continue;
         if (m->type->constraint &&
             m->type->constraint->ctype == CT_TABLE_CONSTRAINT)
@@ -1040,7 +1040,7 @@ define_open_type(int level, const char *newbasename, const char *name, const cha
             newbasename);
     for (i = 0; i < nobjs; i++) {
         HEIM_TAILQ_FOREACH(of, objects[i]->objfields, objfields) {
-            if (strcmp(of->name, typeidfield->name))
+            if (strcmp(of->name, typeidfield->name) != 0)
                 continue;
             if (!of->value || !of->value->s)
                 errx(1, "Unknown value in value field %s of object %s",
@@ -1060,7 +1060,7 @@ define_open_type(int level, const char *newbasename, const char *name, const cha
         HEIM_TAILQ_FOREACH(of, objects[i]->objfields, objfields) {
             char *n = NULL;
 
-            if (strcmp(of->name, opentypefield->name))
+            if (strcmp(of->name, opentypefield->name) != 0)
                 continue;
             if (!of->type || (!of->type->symbol && of->type->type != TTag) ||
                 of->type->tag.tagclass != ASN1_C_UNIV) {
@@ -1631,7 +1631,8 @@ generate_type_header (const Symbol *s)
                 t = s->type->symbol->type;
         }
 
-        if (t->type == TType && t->symbol && strcmp(t->symbol->name, "HEIM_ANY")) {
+        if (t->type == TType && t->symbol &&
+            strcmp(t->symbol->name, "HEIM_ANY") != 0) {
             /*
              * This type is ultimately an alias of an imported type, so we don't
              * know its outermost tag here.

--- a/lib/asn1/gen_decode.c
+++ b/lib/asn1/gen_decode.c
@@ -530,7 +530,8 @@ decode_type(const char *name, const Type *t, int optional, struct value *defval,
                 (t->subtype->type == TSequence ||
                  t->subtype->type == TSet))
                 replace_tag = 1;
-            else if (t->subtype->symbol && strcmp(t->subtype->symbol->name, "HEIM_ANY"))
+            else if (t->subtype->symbol &&
+                     strcmp(t->subtype->symbol->name, "HEIM_ANY") != 0)
                 replace_tag = 1;
         } else if (t->tag.tagenv == TE_IMPLICIT && prim && t->subtype->symbol)
             replace_tag = is_tagged_type(t->subtype->symbol->type);

--- a/lib/asn1/gen_template.c
+++ b/lib/asn1/gen_template.c
@@ -370,7 +370,7 @@ tlist_cmp(const struct tlist *tl, const struct tlist *ql)
     if (tl == ql)
         return 0;
     ret = strcmp(tl->header, ql->header);
-    if (ret) return ret;
+    if (ret != 0) return ret;
 
     q = HEIM_TAILQ_FIRST(&ql->template);
     HEIM_TAILQ_FOREACH(t, &tl->template, members) {
@@ -378,13 +378,13 @@ tlist_cmp(const struct tlist *tl, const struct tlist *ql)
 
 	if (t->ptr == NULL || q->ptr == NULL) {
 	    ret = strcmp(t->line, q->line);
-	    if (ret) return ret;
+	    if (ret != 0) return ret;
 	} else {
 	    ret = strcmp(t->tt, q->tt);
-	    if (ret) return ret;
+	    if (ret != 0) return ret;
 
 	    ret = strcmp(t->offset, q->offset);
-	    if (ret) return ret;
+	    if (ret != 0) return ret;
 
 	    if ((ret = strcmp(t->ptr, q->ptr)) != 0 ||
 		(ret = tlist_cmp_name(t->ptr, q->ptr)) != 0)

--- a/lib/base/db.c
+++ b/lib/base/db.c
@@ -1327,7 +1327,7 @@ json_db_open(void *plug, const char *dbtype, const char *dbname,
 
     if (error)
 	*error = NULL;
-    if (dbtype && *dbtype && strcmp(dbtype, "json"))
+    if (dbtype && *dbtype && strcmp(dbtype, "json") != 0)
 	return HEIM_ERROR(error, EINVAL, (EINVAL, N_("Wrong DB type", "")));
     if (dbname && *dbname && strcmp(dbname, "MEMORY") != 0) {
 	char *ext = strrchr(dbname, '.');

--- a/lib/base/log.c
+++ b/lib/base/log.c
@@ -128,7 +128,7 @@ static struct s2i syslogvals[] = {
 static int
 find_value(const char *s, struct s2i *table)
 {
-    while (table->s && strcasecmp(table->s, s))
+    while (table->s && strcasecmp(table->s, s) != 0)
         table++;
     return table->val;
 }

--- a/lib/base/plugin.c
+++ b/lib/base/plugin.c
@@ -260,8 +260,8 @@ resolve_origin(const char *di, const char *module)
     const char *dname;
     char *path, *p;
 
-    if (strncmp(di, "$ORIGIN/", sizeof("$ORIGIN/") - 1) &&
-        strcmp(di, "$ORIGIN"))
+    if (strncmp(di, "$ORIGIN/", sizeof("$ORIGIN/") - 1) != 0 &&
+        strcmp(di, "$ORIGIN") != 0)
         return strdup(di);
 
     di += sizeof("$ORIGIN") - 1;
@@ -293,8 +293,8 @@ resolve_origin(const char *di, const char *module)
 #else
     char *s = NULL;
 
-    if (strncmp(di, "$ORIGIN/", sizeof("$ORIGIN/") - 1) &&
-        strcmp(di, "$ORIGIN"))
+    if (strncmp(di, "$ORIGIN/", sizeof("$ORIGIN/") - 1) != 0 &&
+        strcmp(di, "$ORIGIN") != 0)
         return strdup(di);
     if (asprintf(&s, LIBDIR "/plugin/%s", module) == -1)
         return NULL;
@@ -392,10 +392,10 @@ heim_load_plugins(heim_context context,
             {
                 char *ext;
 
-                if (strnicmp(n, plugin_prefix, plugin_prefix_len))
+                if (strnicmp(n, plugin_prefix, plugin_prefix_len) != 0)
                     continue;
                 ext = strrchr(n, '.');
-                if (ext == NULL || stricmp(ext, ".dll"))
+                if (ext == NULL || stricmp(ext, ".dll") != 0)
                      continue;
 
                 ret = asprintf(&path, "%s\\%s", dirname, n);

--- a/lib/base/test_base.c
+++ b/lib/base/test_base.c
@@ -494,7 +494,7 @@ dict_db_open(void *plug, const char *dbtype, const char *dbname,
 
     if (error)
 	*error = NULL;
-    if (dbtype && *dbtype && strcmp(dbtype, "dictdb"))
+    if (dbtype && *dbtype && strcmp(dbtype, "dictdb") != 0)
 	return EINVAL;
     if (dbname && *dbname && strcmp(dbname, "MEMORY") != 0)
 	return EINVAL;
@@ -646,12 +646,13 @@ test_db_iter(heim_data_t k, heim_data_t v, void *arg)
     vptr = heim_data_get_ptr(v);
     vlen = heim_data_get_length(v);
 
-    if (klen == strlen("msg") && !strncmp(kptr, "msg", strlen("msg")) &&
-	vlen == strlen("abc") && !strncmp(vptr, "abc", strlen("abc")))
+    if (klen == strlen("msg") && strncmp(kptr, "msg", strlen("msg")) == 0 &&
+	vlen == strlen("abc") && strncmp(vptr, "abc", strlen("abc")) == 0)
 	*ret &= ~(1);
     else if (klen == strlen("msg2") &&
-	!strncmp(kptr, "msg2", strlen("msg2")) &&
-	vlen == strlen("FooBar") && !strncmp(vptr, "FooBar", strlen("FooBar")))
+	strncmp(kptr, "msg2", strlen("msg2")) == 0 &&
+	vlen == strlen("FooBar") &&
+        strncmp(vptr, "FooBar", strlen("FooBar")) == 0)
 	*ret &= ~(2);
     else
 	*ret |= 4;

--- a/lib/gssapi/gss-token.c
+++ b/lib/gssapi/gss-token.c
@@ -272,7 +272,7 @@ read_token(gss_buffer_t in, int negotiate)
 
 	tmp = inbuf;
 	if (negotiate) {
-		if (strncasecmp("Negotiate ", inbuf, 10)) {
+		if (strncasecmp("Negotiate ", inbuf, 10) != 0) {
 			fprintf(stderr, "Token doesn't begin with "
 			    "\"Negotiate \"\n");
 			ret = -1;

--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -365,7 +365,7 @@ _gssapi_verify_mic_arcfour(OM_uint32 * minor_status,
 	return GSS_S_FAILURE;
     }
 
-    cmp = ct_memcmp(cksum_data, p + 8, 8);
+    cmp = (ct_memcmp(cksum_data, p + 8, 8) != 0);
     if (cmp) {
 	*minor_status = 0;
 	return GSS_S_BAD_MIC;
@@ -385,7 +385,7 @@ _gssapi_verify_mic_arcfour(OM_uint32 * minor_status,
     _gsskrb5_decode_be_om_uint32(SND_SEQ, &seq_number);
 
     if (context_handle->more_flags & LOCAL)
-	cmp = memcmp(&SND_SEQ[4], "\xff\xff\xff\xff", 4);
+	cmp = (memcmp(&SND_SEQ[4], "\xff\xff\xff\xff", 4) != 0);
     else
 	cmp = (memcmp(&SND_SEQ[4], "\x00\x00\x00\x00", 4) != 0);
 
@@ -656,7 +656,7 @@ OM_uint32 _gssapi_unwrap_arcfour(OM_uint32 *minor_status,
     _gsskrb5_decode_be_om_uint32(SND_SEQ, &seq_number);
 
     if (context_handle->more_flags & LOCAL)
-	cmp = memcmp(&SND_SEQ[4], "\xff\xff\xff\xff", 4);
+	cmp = (memcmp(&SND_SEQ[4], "\xff\xff\xff\xff", 4) != 0);
     else
 	cmp = (memcmp(&SND_SEQ[4], "\x00\x00\x00\x00", 4) != 0);
 
@@ -1274,7 +1274,7 @@ _gssapi_unwrap_iov_arcfour(OM_uint32 *minor_status,
     _gsskrb5_decode_be_om_uint32(snd_seq, &seq_number);
 
     if (ctx->more_flags & LOCAL) {
-	cmp = memcmp(&snd_seq[4], "\xff\xff\xff\xff", 4);
+	cmp = (memcmp(&snd_seq[4], "\xff\xff\xff\xff", 4) != 0);
     } else {
 	cmp = (memcmp(&snd_seq[4], "\x00\x00\x00\x00", 4) != 0);
     }
@@ -1351,8 +1351,8 @@ _gssapi_unwrap_iov_arcfour(OM_uint32 *minor_status,
 	return GSS_S_FAILURE;
     }
 
-    cmp = memcmp(cksum_data, p0 + 16, 8); /* SGN_CKSUM */
-    if (cmp != 0) {
+    cmp = (memcmp(cksum_data, p0 + 16, 8) != 0); /* SGN_CKSUM */
+    if (cmp) {
 	*minor_status = 0;
 	return GSS_S_BAD_MIC;
     }

--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -387,7 +387,7 @@ _gssapi_verify_mic_arcfour(OM_uint32 * minor_status,
     if (context_handle->more_flags & LOCAL)
 	cmp = memcmp(&SND_SEQ[4], "\xff\xff\xff\xff", 4);
     else
-	cmp = memcmp(&SND_SEQ[4], "\x00\x00\x00\x00", 4);
+	cmp = (memcmp(&SND_SEQ[4], "\x00\x00\x00\x00", 4) != 0);
 
     memset_s(SND_SEQ, sizeof(SND_SEQ), 0, sizeof(SND_SEQ));
     if (cmp != 0) {
@@ -658,7 +658,7 @@ OM_uint32 _gssapi_unwrap_arcfour(OM_uint32 *minor_status,
     if (context_handle->more_flags & LOCAL)
 	cmp = memcmp(&SND_SEQ[4], "\xff\xff\xff\xff", 4);
     else
-	cmp = memcmp(&SND_SEQ[4], "\x00\x00\x00\x00", 4);
+	cmp = (memcmp(&SND_SEQ[4], "\x00\x00\x00\x00", 4) != 0);
 
     if (cmp != 0) {
 	*minor_status = 0;
@@ -1276,7 +1276,7 @@ _gssapi_unwrap_iov_arcfour(OM_uint32 *minor_status,
     if (ctx->more_flags & LOCAL) {
 	cmp = memcmp(&snd_seq[4], "\xff\xff\xff\xff", 4);
     } else {
-	cmp = memcmp(&snd_seq[4], "\x00\x00\x00\x00", 4);
+	cmp = (memcmp(&snd_seq[4], "\x00\x00\x00\x00", 4) != 0);
     }
     if (cmp != 0) {
 	*minor_status = 0;

--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -1283,16 +1283,6 @@ _gssapi_unwrap_iov_arcfour(OM_uint32 *minor_status,
 	return GSS_S_BAD_MIC;
     }
 
-    if (ctx->more_flags & LOCAL) {
-	cmp = memcmp(&snd_seq[4], "\xff\xff\xff\xff", 4);
-    } else {
-	cmp = memcmp(&snd_seq[4], "\x00\x00\x00\x00", 4);
-    }
-    if (cmp != 0) {
-	*minor_status = 0;
-	return GSS_S_BAD_MIC;
-    }
-
     /* keyblock */
     Klocal.keytype = key->keytype;
     Klocal.keyvalue.data = Klocaldata;

--- a/lib/gssapi/mech/gss_compare_name.c
+++ b/lib/gssapi/mech/gss_compare_name.c
@@ -53,7 +53,7 @@ gss_compare_name(OM_uint32 *minor_status,
 			*name_equal = 0;
 		} else if (name1->gn_value.length != name2->gn_value.length ||
 		    memcmp(name1->gn_value.value, name2->gn_value.value,
-			name1->gn_value.length)) {
+			name1->gn_value.length) != 0) {
 			*name_equal = 0;
 		}
 	} else {

--- a/lib/gssapi/test_context.c
+++ b/lib/gssapi/test_context.c
@@ -362,7 +362,7 @@ loop(gss_OID mechoid,
             printf("localname: %.*s\n", (int)lname.length,
                    (char *)lname.value);
         if (lname.length != strlen(localname_string) ||
-            strncmp(localname_string, lname.value, lname.length))
+            strncmp(localname_string, lname.value, lname.length) != 0)
             errx(1, "localname: expected \"%s\", got \"%.*s\" (1)",
                  localname_string, (int)lname.length, (char *)lname.value);
         gss_release_buffer(&min_stat, &lname);
@@ -372,7 +372,7 @@ loop(gss_OID mechoid,
             errx(1, "localname: %s",
                  gssapi_err(maj_stat, min_stat, actual_mech_server));
         if (lname.length != strlen(localname_string) ||
-            strncmp(localname_string, lname.value, lname.length))
+            strncmp(localname_string, lname.value, lname.length) != 0)
             errx(1, "localname: expected \"%s\", got \"%.*s\" (2)",
                  localname_string, (int)lname.length, (char *)lname.value);
         gss_release_buffer(&min_stat, &lname);

--- a/lib/gssapi/test_oid.c
+++ b/lib/gssapi/test_oid.c
@@ -55,7 +55,7 @@ main(int argc, char **argv)
 
     ret = strncmp(data.value, "1 2 840 113554 1 2 2", data.length);
     gss_release_buffer(&maj_stat, &data);
-    if (ret)
+    if (ret != 0)
 	return 1;
 
     maj_stat = gss_oid_to_str(&minor_status, GSS_C_NT_EXPORT_NAME, &data);
@@ -64,7 +64,7 @@ main(int argc, char **argv)
 
     ret = strncmp(data.value, "1 3 6 1 5 6 4", data.length);
     gss_release_buffer(&maj_stat, &data);
-    if (ret)
+    if (ret != 0)
 	return 1;
 
     return 0;

--- a/lib/hdb/hdb-mdb.c
+++ b/lib/hdb/hdb-mdb.c
@@ -194,7 +194,7 @@ my_mdb_env_create_and_open(krb5_context context,
     HEIMDAL_MUTEX_lock(&keep_them_open_lock);
     locked = 1;
     for (p = keep_them_open; p; p = p->next) {
-        if (strcmp(p->path, path))
+        if (strcmp(p->path, path) != 0)
             continue;
         if (p->mapsize > mapsize)
             /* Always increase mapsize */
@@ -282,8 +282,8 @@ my_mdb_env_close(krb5_context context,
     for (p = keep_them_open; !refs_seen && p; ) {
         /* We're the last close */
         if (p->refs ||
-            strncmp(db_name, p->path, slen) ||
-            strcmp(p->path + slen, ".mdb")) {
+            strncmp(db_name, p->path, slen) != 0 ||
+            strcmp(p->path + slen, ".mdb") != 0) {
 
             /* Not us; this keep_it_open stays */
             prev = &p->next;

--- a/lib/hdb/test_namespace.c
+++ b/lib/hdb/test_namespace.c
@@ -626,7 +626,7 @@ fetch_entries(krb5_context context,
             dk.keyvalue.length)
             krb5_errx(context, 1, "key length mismatch!");
         if (memcmp(ep->entry.keys.val[0].key.keyvalue.data,
-                   dk.keyvalue.data, dk.keyvalue.length))
+                   dk.keyvalue.data, dk.keyvalue.length) != 0)
             krb5_errx(context, 1, "key mismatch!");
         if (memcmp(ep->entry.keys.val[0].key.keyvalue.data,
                    e[b + i - 1].entry.keys.val[0].key.keyvalue.data,
@@ -678,7 +678,7 @@ check_kvnos(krb5_context context)
                         keysets.val[m].keys.val[0].key.keyvalue.length ||
                         memcmp(ep->entry.keys.val[0].key.keyvalue.data,
                                keysets.val[m].keys.val[0].key.keyvalue.data,
-                               ep->entry.keys.val[0].key.keyvalue.length))
+                               ep->entry.keys.val[0].key.keyvalue.length) != 0)
                         krb5_errx(context, 1,
                                   "key mismatch for same princ & kvno");
                     match = 1;
@@ -712,7 +712,7 @@ check_kvnos(krb5_context context)
                             keysets.val[m].keys.val[0].key.keyvalue.length ||
                             memcmp(ep->entry.keys.val[0].key.keyvalue.data,
                                    keysets.val[m].keys.val[0].key.keyvalue.data,
-                                   ep->entry.keys.val[0].key.keyvalue.length))
+                                   ep->entry.keys.val[0].key.keyvalue.length) != 0)
                             krb5_errx(context, 1,
                                       "key mismatch for same princ & kvno");
                 }

--- a/lib/hx509/test_name.c
+++ b/lib/hx509/test_name.c
@@ -367,15 +367,15 @@ test_pkinit_san(hx509_context context, const char *p, const char *realm, ...)
         ret = decode_KRB5PrincipalName(gn.u.otherName.value.data,
                                        gn.u.otherName.value.length, &kn, &sz);
     if (ret)
-        return ret;
-    if (strcmp(realm, kn.realm))
-        return ret;
+        return 1;
+    if (strcmp(realm, kn.realm) != 0)
+        return 1;
 
     va_start(ap, realm);
     for (i = 0; i < kn.principalName.name_string.len; i++) {
         const char *s = va_arg(ap, const char *);
 
-        if (s == NULL || strcmp(kn.principalName.name_string.val[i], s))
+        if (s == NULL || strcmp(kn.principalName.name_string.val[i], s) != 0)
             return 1;
     }
     if (va_arg(ap, const char *) != NULL)
@@ -393,7 +393,7 @@ test_pkinit_san(hx509_context context, const char *p, const char *realm, ...)
     if (strncmp(round_trip, "otherName: 1.3.6.1.5.2.2 KerberosPrincipalName ",
                 sizeof("otherName: 1.3.6.1.5.2.2 KerberosPrincipalName ") - 1))
         return 1;
-    if (ret || strcmp(round_trip + sizeof("otherName: 1.3.6.1.5.2.2 KerberosPrincipalName ") - 1, p))
+    if (ret || strcmp(round_trip + sizeof("otherName: 1.3.6.1.5.2.2 KerberosPrincipalName ") - 1, p) != 0)
         return 1;
     free_KRB5PrincipalName(&kn);
     free_GeneralName(&gn);

--- a/lib/kadm5/modify_s.c
+++ b/lib/kadm5/modify_s.c
@@ -104,7 +104,7 @@ modify_principal(void *server_handle,
 
     if((mask & forbidden_mask))
 	return KADM5_BAD_MASK;
-    if((mask & KADM5_POLICY) && strcmp(princ->policy, "default"))
+    if((mask & KADM5_POLICY) && strcmp(princ->policy, "default") != 0)
 	return KADM5_UNK_POLICY;
 
     if (!context->keep_open) {

--- a/lib/krb5/acl.c
+++ b/lib/krb5/acl.c
@@ -119,7 +119,7 @@ acl_match_field(krb5_context context,
 		struct acl_field *field)
 {
     if(field->type == acl_string) {
-	return !strcmp(field->u.cstr, string);
+	return strcmp(field->u.cstr, string) == 0;
     } else if(field->type == acl_fnmatch) {
 	return !fnmatch(field->u.cstr, string, 0);
     } else if(field->type == acl_retval) {

--- a/lib/krb5/dcache.c
+++ b/lib/krb5/dcache.c
@@ -107,7 +107,7 @@ is_filename_cacheish(const char *name)
 {
     size_t i;
 
-    if (strncmp(name, "tkt", sizeof("tkt") - 1))
+    if (strncmp(name, "tkt", sizeof("tkt") - 1) != 0)
         return 0;
     for (i = sizeof("tkt") - 1; name[i]; i++)
         if (ISPATHSEP(name[i]))
@@ -318,7 +318,7 @@ get_default_dir(krb5_context context, char **res)
 
     if ((ret = dcc_get_default_name(context, &s)))
         return ret;
-    if (strncmp(s, "DIR:", sizeof("DIR:") - 1)) {
+    if (strncmp(s, "DIR:", sizeof("DIR:") - 1) != 0) {
         *res = s;
         s = NULL;
     } else if ((*res = strdup(s + sizeof("DIR:") - 1)) == NULL) {
@@ -780,7 +780,7 @@ dcc_get_default_name(krb5_context context, char **str)
                                        NULL);
 
     /* [libdefaults] default_cc_collection is for testing */
-    if (strncmp(def_cc_colname, "DIR:", sizeof("DIR:") - 1))
+    if (strncmp(def_cc_colname, "DIR:", sizeof("DIR:") - 1) != 0)
         def_cc_colname = KRB5_DEFAULT_CCNAME_DIR;
     return _krb5_expand_default_cc_name(context, def_cc_colname, str);
 }

--- a/lib/krb5/fcache.c
+++ b/lib/krb5/fcache.c
@@ -1210,7 +1210,7 @@ my_basename(const char *fn)
 {
     const char *base, *p;
 
-    if (strncmp(fn, "FILE:", sizeof("FILE:") - 1))
+    if (strncmp(fn, "FILE:", sizeof("FILE:") - 1) != 0)
         return "";
     fn += sizeof("FILE:") - 1;
     for (p = base = fn; *p; p++) {

--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -937,7 +937,7 @@ get_cred_kdc_capath(krb5_context context,
         try_realm = krb5_config_get_string(context, NULL, "capaths",
                                            client_realm, server_realm, NULL);
 
-        if (try_realm != NULL && strcmp(try_realm, client_realm)) {
+        if (try_realm != NULL && strcmp(try_realm, client_realm) != 0) {
             ret = get_cred_kdc_capath_worker(context, flags, ccache, in_creds,
                                              try_realm, impersonate_principal,
                                              second_ticket, out_creds, ret_tgts);

--- a/lib/krb5/kx509.c
+++ b/lib/krb5/kx509.c
@@ -426,7 +426,7 @@ gen_priv_key(krb5_context context,
     krb5_error_code ret;
 
     _krb5_debug(context, 1, "kx509: gen priv key");
-    if (strcmp(gen_type, "rsa")) {
+    if (strcmp(gen_type, "rsa") != 0) {
         krb5_set_error_message(context, ENOTSUP, "Key type %s is not "
                                "supported for kx509; only \"rsa\" is "
                                "supported for kx509 at this time",
@@ -967,7 +967,7 @@ rd_kx509_resp(krb5_context context,
     *chain = NULL;
 
     /* Strip `version_2_0' prefix */
-    if (rep->length < hdr_len || memcmp(rep->data, version_2_0, hdr_len)) {
+    if (rep->length < hdr_len || memcmp(rep->data, version_2_0, hdr_len) != 0) {
         krb5_set_error_message(context, ENOTSUP,
                                "KDC does not support kx509 protocol");
         return ENOTSUP; /* XXX */

--- a/lib/krb5/pac.c
+++ b/lib/krb5/pac.c
@@ -725,8 +725,7 @@ verify_logonname(krb5_context context,
 	return ret;
     }
 
-    ret = strcmp(logon_string, principal_string);
-    if (ret != 0) {
+    if (strcmp(logon_string, principal_string) != 0) {
 	ret = EINVAL;
 	krb5_set_error_message(context, ret, "PAC logon name [%s] mismatch principal name [%s]",
 			       logon_string, principal_string);

--- a/lib/krb5/recvauth.c
+++ b/lib/krb5/recvauth.c
@@ -138,7 +138,7 @@ krb5_recvauth_match_version(krb5_context context,
 	len = ntohl(len);
 	if (len != sizeof(her_version)
 	    || krb5_net_read (context, p_fd, her_version, len) != len
-	    || strncmp (version, her_version, len)) {
+	    || strncmp (version, her_version, len) != 0) {
 	    repl = 1;
 	    krb5_net_write (context, p_fd, &repl, 1);
 	    krb5_clear_error_message (context);

--- a/lib/krb5/replay.c
+++ b/lib/krb5/replay.c
@@ -58,7 +58,7 @@ krb5_rc_resolve_type(krb5_context context,
 		     const char *type)
 {
     *id = NULL;
-    if(strcmp(type, "FILE")) {
+    if (strcmp(type, "FILE") != 0) {
 	krb5_set_error_message (context, KRB5_RC_TYPE_NOTFOUND,
 				N_("replay cache type %s not supported", ""),
 				type);
@@ -82,7 +82,7 @@ krb5_rc_resolve_full(krb5_context context,
 
     *id = NULL;
 
-    if(strncmp(string_name, "FILE:", 5)) {
+    if (strncmp(string_name, "FILE:", 5) != 0) {
 	krb5_set_error_message(context, KRB5_RC_TYPE_NOTFOUND,
 			       N_("replay cache type %s not supported", ""),
 			       string_name);

--- a/lib/krb5/test_expand_toks.c
+++ b/lib/krb5/test_expand_toks.c
@@ -95,7 +95,7 @@ main(int argc, char **argv)
 #define EXPANDED_SHOULD_BE "/tmp/abc/dcefgh/x"
 #endif
 
-    if (strcmp(expanded, EXPANDED_SHOULD_BE))
+    if (strcmp(expanded, EXPANDED_SHOULD_BE) != 0)
         krb5_errx(context, 1, "Token expansion incorrect");
 
     krb5_free_context(context);

--- a/lib/krb5/test_princ.c
+++ b/lib/krb5/test_princ.c
@@ -59,7 +59,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_parse_name");
 
-    if (strcmp(princ, princ_unparsed)) {
+    if (strcmp(princ, princ_unparsed) != 0) {
 	krb5_errx(context, 1, "%s != %s", princ, princ_unparsed);
     }
 
@@ -71,7 +71,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_parse_name");
 
-    if (strcmp(princ_short, princ_unparsed))
+    if (strcmp(princ_short, princ_unparsed) != 0)
 	krb5_errx(context, 1, "%s != %s", princ_short, princ_unparsed);
     free(princ_unparsed);
 
@@ -101,7 +101,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_parse_name");
 
-    if (strcmp(princ_short, princ_unparsed))
+    if (strcmp(princ_short, princ_unparsed) != 0)
 	krb5_errx(context, 1, "'%s' != '%s'", princ_short, princ_unparsed);
     free(princ_unparsed);
 
@@ -117,7 +117,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_parse_name");
 
-    if (strcmp(princ, princ_unparsed))
+    if (strcmp(princ, princ_unparsed) != 0)
 	krb5_errx(context, 1, "'%s' != '%s'", princ, princ_unparsed);
     free(princ_unparsed);
 
@@ -156,7 +156,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_parse_name");
 
-    if (strcmp(princ, princ_unparsed))
+    if (strcmp(princ, princ_unparsed) != 0)
 	krb5_errx(context, 1, "'%s' != '%s'", princ, princ_unparsed);
     free(princ_unparsed);
 
@@ -176,7 +176,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_unparse_name_short");
 
-    if (strcmp(princ, princ_unparsed))
+    if (strcmp(princ, princ_unparsed) != 0)
 	krb5_errx(context, 1, "'%s' != '%s'", princ, princ_unparsed);
     free(princ_unparsed);
 
@@ -200,7 +200,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_unparse_name_norealm");
 
-    if (strcmp(princ_short, princ_unparsed))
+    if (strcmp(princ_short, princ_unparsed) != 0)
 	krb5_errx(context, 1, "'%s' != '%s'", princ_short, princ_unparsed);
     free(princ_unparsed);
 
@@ -227,7 +227,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_unparse_name_norealm");
 
-    if (strcmp(princ_short, princ_unparsed))
+    if (strcmp(princ_short, princ_unparsed) != 0)
 	krb5_errx(context, 1, "'%s' != '%s'", princ_short, princ_unparsed);
     free(princ_unparsed);
 
@@ -246,7 +246,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_unparse_name_flags");
 
-    if (strcmp(princ, princ_unparsed))
+    if (strcmp(princ, princ_unparsed) != 0)
 	krb5_errx(context, 1, "q '%s' != '%s'", princ, princ_unparsed);
     free(princ_unparsed);
 
@@ -255,7 +255,7 @@ test_princ(krb5_context context)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_unparse_name_flags");
 
-    if (strcmp(noquote, princ_unparsed))
+    if (strcmp(noquote, princ_unparsed) != 0)
 	krb5_errx(context, 1, "nq '%s' != '%s'", noquote, princ_unparsed);
     free(princ_unparsed);
 

--- a/lib/krb5/verify_krb5_conf.c
+++ b/lib/krb5/verify_krb5_conf.c
@@ -291,7 +291,7 @@ static struct s2i syslogvals[] = {
 static int
 find_value(const char *s, struct s2i *table)
 {
-    while(table->s && strcasecmp(table->s, s))
+    while (table->s && strcasecmp(table->s, s) != 0)
 	table++;
     return table->val;
 }

--- a/lib/roken/dirent-test.c
+++ b/lib/roken/dirent-test.c
@@ -146,7 +146,7 @@ int teardown_test(void)
 
         (len = strlen(dirname)) > sizeof(TESTDIR)/sizeof(char) &&
 
-        !strcmp(dirname + len + 1 - sizeof(TESTDIR)/sizeof(char), TESTDIR)) {
+        strcmp(dirname + len + 1 - sizeof(TESTDIR)/sizeof(char), TESTDIR) == 0) {
 
         /* fallthrough */
 
@@ -215,12 +215,12 @@ int check_list(const char * filespec, const char ** list, int n, int expect_dot_
         n_found ++;
 
         if (expect_dot_and_dotdot &&
-            (!strcmp(e->d_name, ".") ||
-             !strcmp(e->d_name, "..")))
+            (strcmp(e->d_name, ".") == 0 ||
+             strcmp(e->d_name, "..") == 0))
             continue;
 
         for (i=0; i < n; i++) {
-            if (!strcmp(list[i], e->d_name))
+            if (strcmp(list[i], e->d_name) == 0)
                 break;
         }
 

--- a/lib/roken/getifaddrs.c
+++ b/lib/roken/getifaddrs.c
@@ -759,7 +759,7 @@ rk_getifaddrs(struct ifaddrs **ifap)
 	  }
 	  if (ifamap.address_len != ifamap.local_len ||
 	      (ifamap.address != NULL &&
-	       memcmp(ifamap.address, ifamap.local, ifamap.address_len))) {
+	       memcmp(ifamap.address, ifamap.local, ifamap.address_len) != 0)) {
 	    /* p2p; address is peer and local is ours */
 	    ifamap.broadcast = ifamap.address;
 	    ifamap.broadcast_len = ifamap.address_len;

--- a/lib/roken/setprogname.c
+++ b/lib/roken/setprogname.c
@@ -74,7 +74,7 @@ setprogname(const char *argv0)
 
         strlwr(fn);
         ext = strrchr(fn, '.');
-        if (ext != NULL && !strcmp(ext, ".exe"))
+        if (ext != NULL && strcmp(ext, ".exe") == 0)
             *ext = '\0';
 
         __progname = fn;

--- a/lib/roken/snprintf.c
+++ b/lib/roken/snprintf.c
@@ -557,7 +557,7 @@ rk_snprintf (char *str, size_t sz, const char *format, ...)
 	va_start(args, format);
 	ret2 = vsprintf (tmp, format, args);
 	va_end(args);
-	if (ret != ret2 || strcmp(str, tmp))
+	if (ret != ret2 || strcmp(str, tmp) != 0)
 	    abort ();
 	free (tmp);
     }
@@ -589,7 +589,7 @@ rk_asprintf (char **ret, const char *format, ...)
 	va_start(args, format);
 	ret2 = vsprintf (tmp, format, args);
 	va_end(args);
-	if (val != ret2 || strcmp(*ret, tmp))
+	if (val != ret2 || strcmp(*ret, tmp) != 0)
 	    abort ();
 	free (tmp);
     }
@@ -618,7 +618,7 @@ rk_asnprintf (char **ret, size_t max_sz, const char *format, ...)
 	    abort ();
 
 	ret2 = vsprintf (tmp, format, args);
-	if (val != ret2 || strcmp(*ret, tmp))
+	if (val != ret2 || strcmp(*ret, tmp) != 0)
 	    abort ();
 	free (tmp);
     }

--- a/lib/roken/test-detach.c
+++ b/lib/roken/test-detach.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
     pid_t parent = getpid();
     pid_t child;
 
-    if (argc == 2 && strcmp(argv[1], "--reexec"))
+    if (argc == 2 && strcmp(argv[1], "--reexec") != 0)
         errx(1, "Usage: test-detach [--reexec] [--daemon-child FD]");
     if (argc == 3 || argc == 4) {
         parent = getppid();

--- a/lib/roken/test-mini_inetd.c
+++ b/lib/roken/test-mini_inetd.c
@@ -195,7 +195,7 @@ test_simple_echo_socket(void)
 				getprogname(), srv, rv);
 		}
 
-		if (!strcmp(buf, "exit")) {
+		if (strcmp(buf, "exit") == 0) {
 		    fprintf(stderr, "[%s] Exiting...\n", prog);
 		    shutdown(s, SD_SEND);
 		    rk_closesocket(s);
@@ -234,7 +234,7 @@ test_simple_echo(void)
 	    while (gets(buf)) {
 		fprintf(stderr, "[%s] Received [%s]\n", prog, buf);
 
-		if (!strcmp(buf, "exit"))
+		if (strcmp(buf, "exit") == 0)
 		    return 0;
 
 		/* simple echo */

--- a/lib/sl/slc-gram.y
+++ b/lib/sl/slc-gram.y
@@ -254,7 +254,7 @@ check(struct assignment *as)
     struct assignment *a;
     int ret = 0;
     for(a = as; a != NULL; a = a->next) {
-	if(strcmp(a->name, "command")) {
+	if (strcmp(a->name, "command") != 0) {
 	    fprintf(stderr, "unknown type %s line %d\n", a->name, a->lineno);
 	    ret++;
 	    continue;


### PR DESCRIPTION
Because of:

http://r6.ca/blog/20200929T023701Z.html
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189

this is bad:

```
    if (strcmp(a, b) || !strcmp(c, d)) ...
```

so this patch changes that to:

```
    if (strcmp(a, b) != 0 || strcmp(c, d)) == 0
```

for all C library cmp functions and related:

 - strcmp(), strncmp()
 - strcasecmp(), strncasecmp()
 - stricmp(), strnicmp()
 - memcmp()