### PR TITLE
Fix calling convention for libasn1

### DIFF
--- a/lib/asn1/der.c
+++ b/lib/asn1/der.c
@@ -99,7 +99,7 @@ get_type(const char *name, const char *list[], unsigned len)
 
 #define SIZEOF_ARRAY(a) (sizeof((a))/sizeof((a)[0]))
 
-const char *
+const char * ASN1CALL
 der_get_class_name(unsigned num)
 {
     if (num >= SIZEOF_ARRAY(class_names))
@@ -107,13 +107,13 @@ der_get_class_name(unsigned num)
     return class_names[num];
 }
 
-int
+int ASN1CALL
 der_get_class_num(const char *name)
 {
     return get_type(name, class_names, SIZEOF_ARRAY(class_names));
 }
 
-const char *
+const char * ASN1CALL
 der_get_type_name(unsigned num)
 {
     if (num >= SIZEOF_ARRAY(type_names))
@@ -121,13 +121,13 @@ der_get_type_name(unsigned num)
     return type_names[num];
 }
 
-int
+int ASN1CALL
 der_get_type_num(const char *name)
 {
     return get_type(name, type_names, SIZEOF_ARRAY(type_names));
 }
 
-const char *
+const char * ASN1CALL
 der_get_tag_name(unsigned num)
 {
     if (num >= SIZEOF_ARRAY(tag_names))
@@ -135,7 +135,7 @@ der_get_tag_name(unsigned num)
     return tag_names[num];
 }
 
-int
+int ASN1CALL
 der_get_tag_num(const char *name)
 {
     return get_type(name, tag_names, SIZEOF_ARRAY(tag_names));

--- a/lib/asn1/der_cmp.c
+++ b/lib/asn1/der_cmp.c
@@ -33,7 +33,7 @@
 
 #include "der_locl.h"
 
-int
+int ASN1CALL
 der_heim_oid_cmp(const heim_oid *p, const heim_oid *q)
 {
     int c;
@@ -58,7 +58,7 @@ der_heim_oid_cmp(const heim_oid *p, const heim_oid *q)
     return c;
 }
 
-int
+int ASN1CALL
 der_heim_octet_string_cmp(const heim_octet_string *p,
 			  const heim_octet_string *q)
 {
@@ -76,21 +76,21 @@ der_heim_octet_string_cmp(const heim_octet_string *p,
     return c;
 }
 
-int
+int ASN1CALL
 der_printable_string_cmp(const heim_printable_string *p,
 			 const heim_printable_string *q)
 {
     return der_heim_octet_string_cmp(p, q);
 }
 
-int
+int ASN1CALL
 der_ia5_string_cmp(const heim_ia5_string *p,
 		   const heim_ia5_string *q)
 {
     return der_heim_octet_string_cmp(p, q);
 }
 
-int
+int ASN1CALL
 der_heim_bit_string_cmp(const heim_bit_string *p,
 			const heim_bit_string *q)
 {
@@ -112,7 +112,7 @@ der_heim_bit_string_cmp(const heim_bit_string *p,
     return r1 - r2;
 }
 
-int
+int ASN1CALL
 der_heim_integer_cmp(const heim_integer *p,
 		     const heim_integer *q)
 {
@@ -123,7 +123,7 @@ der_heim_integer_cmp(const heim_integer *p,
     return memcmp(p->data, q->data, p->length);
 }
 
-int
+int ASN1CALL
 der_heim_bmp_string_cmp(const heim_bmp_string *p, const heim_bmp_string *q)
 {
     int c;
@@ -140,7 +140,7 @@ der_heim_bmp_string_cmp(const heim_bmp_string *p, const heim_bmp_string *q)
     return c;
 }
 
-int
+int ASN1CALL
 der_heim_universal_string_cmp(const heim_universal_string *p,
 			      const heim_universal_string *q)
 {

--- a/lib/asn1/der_copy.c
+++ b/lib/asn1/der_copy.c
@@ -37,7 +37,7 @@
 
 RCSID("$Id$");
 
-int
+int ASN1CALL
 der_copy_general_string (const heim_general_string *from,
 			 heim_general_string *to)
 {
@@ -47,55 +47,55 @@ der_copy_general_string (const heim_general_string *from,
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_integer (const int *from, int *to)
 {
     *to = *from;
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_integer64 (const int64_t *from, int64_t *to)
 {
     *to = *from;
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_unsigned (const unsigned *from, unsigned *to)
 {
     *to = *from;
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_unsigned64 (const uint64_t *from, uint64_t *to)
 {
     *to = *from;
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_generalized_time (const time_t *from, time_t *to)
 {
     *to = *from;
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_utctime (const time_t *from, time_t *to)
 {
     *to = *from;
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_utf8string (const heim_utf8_string *from, heim_utf8_string *to)
 {
     return der_copy_general_string(from, to);
 }
 
-int
+int ASN1CALL
 der_copy_printable_string (const heim_printable_string *from,
 		       heim_printable_string *to)
 {
@@ -108,14 +108,14 @@ der_copy_printable_string (const heim_printable_string *from,
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_ia5_string (const heim_ia5_string *from,
 		     heim_ia5_string *to)
 {
     return der_copy_printable_string(from, to);
 }
 
-int
+int ASN1CALL
 der_copy_bmp_string (const heim_bmp_string *from, heim_bmp_string *to)
 {
     to->length = from->length;
@@ -126,7 +126,7 @@ der_copy_bmp_string (const heim_bmp_string *from, heim_bmp_string *to)
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_universal_string (const heim_universal_string *from,
 			   heim_universal_string *to)
 {
@@ -138,14 +138,14 @@ der_copy_universal_string (const heim_universal_string *from,
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_visible_string (const heim_visible_string *from,
 			 heim_visible_string *to)
 {
     return der_copy_general_string(from, to);
 }
 
-int
+int ASN1CALL
 der_copy_octet_string (const heim_octet_string *from, heim_octet_string *to)
 {
     to->length = from->length;
@@ -156,7 +156,7 @@ der_copy_octet_string (const heim_octet_string *from, heim_octet_string *to)
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_heim_integer (const heim_integer *from, heim_integer *to)
 {
     to->length = from->length;
@@ -168,7 +168,7 @@ der_copy_heim_integer (const heim_integer *from, heim_integer *to)
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_oid (const heim_oid *from, heim_oid *to)
 {
     to->length     = from->length;
@@ -180,7 +180,7 @@ der_copy_oid (const heim_oid *from, heim_oid *to)
     return 0;
 }
 
-int
+int ASN1CALL
 der_copy_bit_string (const heim_bit_string *from, heim_bit_string *to)
 {
     size_t len;

--- a/lib/asn1/der_format.c
+++ b/lib/asn1/der_format.c
@@ -36,7 +36,7 @@
 
 RCSID("$Id$");
 
-int
+int ASN1CALL
 der_parse_hex_heim_integer (const char *p, heim_integer *data)
 {
     ssize_t len;
@@ -84,7 +84,7 @@ der_parse_hex_heim_integer (const char *p, heim_integer *data)
     return 0;
 }
 
-int
+int ASN1CALL
 der_print_hex_heim_integer (const heim_integer *data, char **p)
 {
     ssize_t len;
@@ -104,7 +104,7 @@ der_print_hex_heim_integer (const heim_integer *data, char **p)
     return 0;
 }
 
-int
+int ASN1CALL
 der_print_heim_oid (const heim_oid *oid, char delim, char **str)
 {
     struct rk_strpool *p = NULL;
@@ -129,7 +129,7 @@ der_print_heim_oid (const heim_oid *oid, char delim, char **str)
     return 0;
 }
 
-int
+int ASN1CALL
 der_parse_heim_oid (const char *str, const char *sep, heim_oid *data)
 {
     char *s, *w, *brkt, *endptr;

--- a/lib/asn1/der_free.c
+++ b/lib/asn1/der_free.c
@@ -37,70 +37,70 @@
 
 RCSID("$Id$");
 
-void
+void ASN1CALL
 der_free_general_string (heim_general_string *str)
 {
     free(*str);
     *str = NULL;
 }
 
-void
+void ASN1CALL
 der_free_integer (int *i)
 {
     *i = 0;
 }
 
-void
+void ASN1CALL
 der_free_integer64 (int64_t *i)
 {
     *i = 0;
 }
 
-void
+void ASN1CALL
 der_free_unsigned (unsigned *u)
 {
     *u = 0;
 }
 
-void
+void ASN1CALL
 der_free_unsigned64 (uint64_t *u)
 {
     *u = 0;
 }
 
-void
+void ASN1CALL
 der_free_generalized_time(time_t *t)
 {
     *t = 0;
 }
 
-void
+void ASN1CALL
 der_free_utctime(time_t *t)
 {
     *t = 0;
 }
 
 
-void
+void ASN1CALL
 der_free_utf8string (heim_utf8_string *str)
 {
     free(*str);
     *str = NULL;
 }
 
-void
+void ASN1CALL
 der_free_printable_string (heim_printable_string *str)
 {
     der_free_octet_string(str);
 }
 
-void
+void ASN1CALL
 der_free_ia5_string (heim_ia5_string *str)
 {
     der_free_octet_string(str);
 }
 
-void
+void ASN1CALL
 der_free_bmp_string (heim_bmp_string *k)
 {
     free(k->data);
@@ -108,7 +108,7 @@ der_free_bmp_string (heim_bmp_string *k)
     k->length = 0;
 }
 
-void
+void ASN1CALL
 der_free_universal_string (heim_universal_string *k)
 {
     free(k->data);
@@ -116,14 +116,14 @@ der_free_universal_string (heim_universal_string *k)
     k->length = 0;
 }
 
-void
+void ASN1CALL
 der_free_visible_string (heim_visible_string *str)
 {
     free(*str);
     *str = NULL;
 }
 
-void
+void ASN1CALL
 der_free_octet_string (heim_octet_string *k)
 {
     free(k->data);
@@ -131,7 +131,7 @@ der_free_octet_string (heim_octet_string *k)
     k->length = 0;
 }
 
-void
+void ASN1CALL
 der_free_heim_integer (heim_integer *k)
 {
     free(k->data);
@@ -139,7 +139,7 @@ der_free_heim_integer (heim_integer *k)
     k->length = 0;
 }
 
-void
+void ASN1CALL
 der_free_oid (heim_oid *k)
 {
     free(k->components);
@@ -147,7 +147,7 @@ der_free_oid (heim_oid *k)
     k->length = 0;
 }
 
-void
+void ASN1CALL
 der_free_bit_string (heim_bit_string *k)
 {
     free(k->data);

--- a/lib/asn1/der_length.c
+++ b/lib/asn1/der_length.c
@@ -144,7 +144,7 @@ len_oid (const heim_oid *oid)
     return ret;
 }
 
-size_t
+size_t ASN1CALL
 der_length_len (size_t len)
 {
     if (len < 128)
@@ -159,7 +159,7 @@ der_length_len (size_t len)
     }
 }
 
-size_t
+size_t ASN1CALL
 der_length_tag(unsigned int tag)
 {
     size_t len = 0;
@@ -173,85 +173,85 @@ der_length_tag(unsigned int tag)
     return len + 1;
 }
 
-size_t
+size_t ASN1CALL
 der_length_integer (const int *data)
 {
     return _heim_len_int (*data);
 }
 
-size_t
+size_t ASN1CALL
 der_length_integer64 (const int64_t *data)
 {
     return _heim_len_int64 (*data);
 }
 
-size_t
+size_t ASN1CALL
 der_length_unsigned (const unsigned *data)
 {
     return _heim_len_unsigned(*data);
 }
 
-size_t
+size_t ASN1CALL
 der_length_unsigned64 (const uint64_t *data)
 {
     return _heim_len_unsigned64(*data);
 }
 
-size_t
+size_t ASN1CALL
 der_length_enumerated (const unsigned *data)
 {
   return _heim_len_int (*data);
 }
 
-size_t
+size_t ASN1CALL
 der_length_general_string (const heim_general_string *data)
 {
     return strlen(*data);
 }
 
-size_t
+size_t ASN1CALL
 der_length_utf8string (const heim_utf8_string *data)
 {
     return strlen(*data);
 }
 
-size_t
+size_t ASN1CALL
 der_length_printable_string (const heim_printable_string *data)
 {
     return data->length;
 }
 
-size_t
+size_t ASN1CALL
 der_length_ia5_string (const heim_ia5_string *data)
 {
     return data->length;
 }
 
-size_t
+size_t ASN1CALL
 der_length_bmp_string (const heim_bmp_string *data)
 {
     return data->length * 2;
 }
 
-size_t
+size_t ASN1CALL
 der_length_universal_string (const heim_universal_string *data)
 {
     return data->length * 4;
 }
 
-size_t
+size_t ASN1CALL
 der_length_visible_string (const heim_visible_string *data)
 {
     return strlen(*data);
 }
 
-size_t
+size_t ASN1CALL
 der_length_octet_string (const heim_octet_string *k)
 {
     return k->length;
 }
 
-size_t
+size_t ASN1CALL
 der_length_heim_integer (const heim_integer *k)
 {
     if (k->length == 0)
@@ -262,13 +262,13 @@ der_length_heim_integer (const heim_integer *k)
 	return k->length + ((((unsigned char *)k->data)[0] & 0x80) ? 1 : 0);
 }
 
-size_t
+size_t ASN1CALL
 der_length_oid (const heim_oid *k)
 {
     return len_oid (k);
 }
 
-size_t
+size_t ASN1CALL
 der_length_generalized_time (const time_t *t)
 {
     heim_octet_string k;
@@ -280,7 +280,7 @@ der_length_generalized_time (const time_t *t)
     return ret;
 }
 
-size_t
+size_t ASN1CALL
 der_length_utctime (const time_t *t)
 {
     heim_octet_string k;
@@ -292,13 +292,13 @@ der_length_utctime (const time_t *t)
     return ret;
 }
 
-size_t
+size_t ASN1CALL
 der_length_boolean (const int *k)
 {
     return 1;
 }
 
-size_t
+size_t ASN1CALL
 der_length_bit_string (const heim_bit_string *k)
 {
     return (k->length + 7) / 8 + 1;

--- a/lib/asn1/der_print.c
+++ b/lib/asn1/der_print.c
@@ -38,19 +38,19 @@
 
 RCSID("$Id$");
 
-char *
+char * ASN1CALL
 der_print_general_string(const heim_general_string *str, int flags)
 {
     return strdup(*str);
 }
 
-char *
+char * ASN1CALL
 der_print_boolean(const int *i, int flags)
 {
     return *i ? strdup("true") : strdup("false");
 }
 
-char *
+char * ASN1CALL
 der_print_integer(const int *i, int flags)
 {
     char *s = NULL;
@@ -60,7 +60,7 @@ der_print_integer(const int *i, int flags)
     return s;
 }
 
-char *
+char * ASN1CALL
 der_print_integer64(const int64_t *i, int flags)
 {
     char *s = NULL;
@@ -70,7 +70,7 @@ der_print_integer64(const int64_t *i, int flags)
     return s;
 }
 
-char *
+char * ASN1CALL
 der_print_unsigned(const unsigned *u, int flags)
 {
     char *s = NULL;
@@ -80,7 +80,7 @@ der_print_unsigned(const unsigned *u, int flags)
     return s;
 }
 
-char *
+char * ASN1CALL
 der_print_unsigned64(const uint64_t *u, int flags)
 {
     char *s = NULL;
@@ -90,7 +90,7 @@ der_print_unsigned64(const uint64_t *u, int flags)
     return s;
 }
 
-char *
+char * ASN1CALL
 der_print_generalized_time(const time_t *t, int flags)
 {
     struct tm tms;
@@ -107,7 +107,7 @@ der_print_generalized_time(const time_t *t, int flags)
     return strdup(str);
 }
 
-char *
+char * ASN1CALL
 der_print_utctime(const time_t *t, int flags)
 {
     struct tm tms;
@@ -125,43 +125,43 @@ der_print_utctime(const time_t *t, int flags)
 }
 
 
-char *
+char * ASN1CALL
 der_print_utf8string(const heim_utf8_string *str, int flags)
 {
     return strdup(*str);
 }
 
-char *
+char * ASN1CALL
 der_print_printable_string(const heim_printable_string *str, int flags)
 {
     return strndup(str->data, str->length);
 }
 
-char *
+char * ASN1CALL
 der_print_ia5_string(const heim_ia5_string *str, int flags)
 {
     return strndup(str->data, str->length);
 }
 
-char *
+char * ASN1CALL
 der_print_bmp_string(const heim_bmp_string *k, int flags)
 {
     return strdup("<BMPString-not-supported>");
 }
 
-char *
+char * ASN1CALL
 der_print_universal_string(const heim_universal_string *k, int flags)
 {
     return strdup("<UniversalString-not-supported>");
 }
 
-char *
+char * ASN1CALL
 der_print_visible_string(const heim_visible_string *str, int flags)
 {
     return strdup(*str);
 }
 
-char *
+char * ASN1CALL
 der_print_octet_string(const heim_octet_string *k, int flags)
 {
     char *s = NULL;
@@ -170,7 +170,7 @@ der_print_octet_string(const heim_octet_string *k, int flags)
     return s;
 }
 
-char *
+char * ASN1CALL
 der_print_heim_integer(const heim_integer *k, int flags)
 {
     char *s = NULL;
@@ -179,7 +179,7 @@ der_print_heim_integer(const heim_integer *k, int flags)
     return s;
 }
 
-char *
+char * ASN1CALL
 der_print_oid(const heim_oid *k, int flags)
 {
     struct rk_strpool *r = NULL;
@@ -215,7 +215,7 @@ der_print_oid(const heim_oid *k, int flags)
     return rk_strpoolcollect(r);
 }
 
-char *
+char * ASN1CALL
 der_print_bit_string(const heim_bit_string *k, int flags)
 {
     char *s2 = NULL;

--- a/lib/asn1/der_put.c
+++ b/lib/asn1/der_put.c
@@ -43,7 +43,7 @@ RCSID("$Id$");
  * The return value is 0 or an error.
  */
 
-int
+int ASN1CALL
 der_put_unsigned (unsigned char *p, size_t len, const unsigned *v, size_t *size)
 {
     unsigned char *base = p;
@@ -75,7 +75,7 @@ der_put_unsigned (unsigned char *p, size_t len, const unsigned *v, size_t *size)
     }
 }
 
-int
+int ASN1CALL
 der_put_unsigned64 (unsigned char *p, size_t len, const uint64_t *v, size_t *size)
 {
     unsigned char *base = p;
@@ -107,7 +107,7 @@ der_put_unsigned64 (unsigned char *p, size_t len, const uint64_t *v, size_t *siz
     }
 }
 
-int
+int ASN1CALL
 der_put_integer (unsigned char *p, size_t len, const int *v, size_t *size)
 {
     unsigned char *base = p;
@@ -147,7 +147,7 @@ der_put_integer (unsigned char *p, size_t len, const int *v, size_t *size)
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_integer64 (unsigned char *p, size_t len, const int64_t *v, size_t *size)
 {
     unsigned char *base = p;
@@ -188,7 +188,7 @@ der_put_integer64 (unsigned char *p, size_t len, const int64_t *v, size_t *size)
 }
 
 
-int
+int ASN1CALL
 der_put_length (unsigned char *p, size_t len, size_t val, size_t *size)
 {
     if (len < 1)
@@ -215,7 +215,7 @@ der_put_length (unsigned char *p, size_t len, size_t val, size_t *size)
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_boolean(unsigned char *p, size_t len, const int *data, size_t *size)
 {
     if(len < 1)
@@ -228,7 +228,7 @@ der_put_boolean(unsigned char *p, size_t len, const int *data, size_t *size)
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_general_string (unsigned char *p, size_t len,
 			const heim_general_string *str, size_t *size)
 {
@@ -242,28 +242,28 @@ der_put_general_string (unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_utf8string (unsigned char *p, size_t len,
 		    const heim_utf8_string *str, size_t *size)
 {
     return der_put_general_string(p, len, str, size);
 }
 
-int
+int ASN1CALL
 der_put_printable_string (unsigned char *p, size_t len,
 			  const heim_printable_string *str, size_t *size)
 {
     return der_put_octet_string(p, len, str, size);
 }
 
-int
+int ASN1CALL
 der_put_ia5_string (unsigned char *p, size_t len,
 		    const heim_ia5_string *str, size_t *size)
 {
     return der_put_octet_string(p, len, str, size);
 }
 
-int
+int ASN1CALL
 der_put_bmp_string (unsigned char *p, size_t len,
 		    const heim_bmp_string *data, size_t *size)
 {
@@ -280,7 +280,7 @@ der_put_bmp_string (unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_universal_string (unsigned char *p, size_t len,
 			  const heim_universal_string *data, size_t *size)
 {
@@ -299,14 +299,14 @@ der_put_universal_string (unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_visible_string (unsigned char *p, size_t len,
 			 const heim_visible_string *str, size_t *size)
 {
     return der_put_general_string(p, len, str, size);
 }
 
-int
+int ASN1CALL
 der_put_octet_string (unsigned char *p, size_t len,
 		      const heim_octet_string *data, size_t *size)
 {
@@ -318,7 +318,7 @@ der_put_octet_string (unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_heim_integer (unsigned char *p, size_t len,
 		     const heim_integer *data, size_t *size)
 {
@@ -371,7 +371,7 @@ der_put_heim_integer (unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_generalized_time (unsigned char *p, size_t len,
 			  const time_t *data, size_t *size)
 {
@@ -391,7 +391,7 @@ der_put_generalized_time (unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_utctime (unsigned char *p, size_t len,
 		 const time_t *data, size_t *size)
 {
@@ -411,7 +411,7 @@ der_put_utctime (unsigned char *p, size_t len,
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_oid (unsigned char *p, size_t len,
 	     const heim_oid *data, size_t *size)
 {
@@ -447,7 +447,7 @@ der_put_oid (unsigned char *p, size_t len,
  * This is used in the implementation of IMPLICIT tags in generated decoder
  * functions.
  */
-int
+int ASN1CALL
 der_replace_tag(const unsigned char *p, size_t len,
                 unsigned char **out, size_t *outlen,
                 Der_class class, Der_type type,
@@ -491,7 +491,7 @@ der_replace_tag(const unsigned char *p, size_t len,
 }
 
 #if 0
-int
+int ASN1CALL
 der_encode_implicit(unsigned char *p, size_t len,
                     asn1_generic_encoder_f encoder,
                     void *obj, size_t *size,
@@ -539,7 +539,7 @@ der_encode_implicit(unsigned char *p, size_t len,
 }
 #endif
 
-int
+int ASN1CALL
 der_put_tag (unsigned char *p, size_t len, Der_class class, Der_type type,
 	     unsigned int tag, size_t *size)
 {
@@ -570,7 +570,7 @@ der_put_tag (unsigned char *p, size_t len, Der_class class, Der_type type,
     return 0;
 }
 
-int
+int ASN1CALL
 der_put_length_and_tag (unsigned char *p, size_t len, size_t len_val,
 			Der_class class, Der_type type,
 			unsigned int tag, size_t *size)
@@ -624,7 +624,7 @@ _heim_time2generalizedtime (time_t t, heim_octet_string *s, int gtimep)
      return 0;
 }
 
-int
+int ASN1CALL
 der_put_bit_string (unsigned char *p, size_t len,
 		    const heim_bit_string *data, size_t *size)
 {

--- a/lib/asn1/extra.c
+++ b/lib/asn1/extra.c
@@ -40,14 +40,14 @@
 
 RCSID("$Id$");
 
-int
+int ASN1CALL
 encode_heim_any(unsigned char *p, size_t len,
 		const heim_any *data, size_t *size)
 {
     return der_put_octet_string (p, len, data, size);
 }
 
-int
+int ASN1CALL
 decode_heim_any(const unsigned char *p, size_t len,
 		heim_any *data, size_t *size)
 {
@@ -86,13 +86,13 @@ decode_heim_any(const unsigned char *p, size_t len,
     return 0;
 }
 
-void
+void ASN1CALL
 free_heim_any(heim_any *data)
 {
     der_free_octet_string(data);
 }
 
-char *
+char * ASN1CALL
 print_heim_any(const heim_any *data, int flags)
 {
     char *s2 = NULL;
@@ -110,39 +110,39 @@ print_heim_any(const heim_any *data, int flags)
     return s;
 }
 
-size_t
+size_t ASN1CALL
 length_heim_any(const heim_any *data)
 {
     return data->length;
 }
 
-int
+int ASN1CALL
 copy_heim_any(const heim_any *from, heim_any *to)
 {
     return der_copy_octet_string(from, to);
 }
 
-int
+int ASN1CALL
 encode_HEIM_ANY(unsigned char *p, size_t len,
 		const heim_any *data, size_t *size)
 {
     return encode_heim_any(p, len, data, size);
 }
 
-int
+int ASN1CALL
 decode_HEIM_ANY(const unsigned char *p, size_t len,
 		heim_any *data, size_t *size)
 {
     return decode_heim_any(p, len, data, size);
 }
 
-void
+void ASN1CALL
 free_HEIM_ANY(heim_any *data)
 {
     der_free_octet_string(data);
 }
 
-char *
+char * ASN1CALL
 print_HEIM_ANY(const heim_any *data, int flags)
 {
     char *s2 = NULL;
@@ -160,39 +160,39 @@ print_HEIM_ANY(const heim_any *data, int flags)
     return s;
 }
 
-size_t
+size_t ASN1CALL
 length_HEIM_ANY(const heim_any *data)
 {
     return data->length;
 }
 
-int
+int ASN1CALL
 copy_HEIM_ANY(const heim_any *from, heim_any *to)
 {
     return der_copy_octet_string(from, to);
 }
 
-int
+int ASN1CALL
 encode_heim_any_set(unsigned char *p, size_t len,
 		    const heim_any_set *data, size_t *size)
 {
     return der_put_octet_string (p, len, data, size);
 }
 
-int
+int ASN1CALL
 decode_heim_any_set(const unsigned char *p, size_t len,
 		heim_any_set *data, size_t *size)
 {
     return der_get_octet_string(p, len, data, size);
 }
 
-void
+void ASN1CALL
 free_heim_any_set(heim_any_set *data)
 {
     der_free_octet_string(data);
 }
 
-char *
+char * ASN1CALL
 print_heim_any_set(const heim_any_set *data, int flags)
 {
     char *s2 = NULL;
@@ -210,45 +210,45 @@ print_heim_any_set(const heim_any_set *data, int flags)
     return s;
 }
 
-size_t
+size_t ASN1CALL
 length_heim_any_set(const heim_any *data)
 {
     return data->length;
 }
 
-int
+int ASN1CALL
 copy_heim_any_set(const heim_any_set *from, heim_any_set *to)
 {
     return der_copy_octet_string(from, to);
 }
 
-int
+int ASN1CALL
 heim_any_cmp(const heim_any_set *p, const heim_any_set *q)
 {
     return der_heim_octet_string_cmp(p, q);
 }
 
-int
+int ASN1CALL
 encode_HEIM_ANY_SET(unsigned char *p, size_t len,
 		    const heim_any_set *data, size_t *size)
 {
     return encode_heim_any_set(p, len, data, size);
 }
 
-int
+int ASN1CALL
 decode_HEIM_ANY_SET(const unsigned char *p, size_t len,
                     heim_any_set *data, size_t *size)
 {
     return decode_heim_any_set(p, len, data, size);
 }
 
-void
+void ASN1CALL
 free_HEIM_ANY_SET(heim_any_set *data)
 {
     der_free_octet_string(data);
 }
 
-char *
+char * ASN1CALL
 print_HEIM_ANY_SET(const heim_any_set *data, int flags)
 {
     char *s2 = NULL;
@@ -266,19 +266,19 @@ print_HEIM_ANY_SET(const heim_any_set *data, int flags)
     return s;
 }
 
-size_t
+size_t ASN1CALL
 length_HEIM_ANY_SET(const heim_any *data)
 {
     return data->length;
 }
 
-int
+int ASN1CALL
 copy_HEIM_ANY_SET(const heim_any_set *from, heim_any_set *to)
 {
     return der_copy_octet_string(from, to);
 }
 
-int
+int ASN1CALL
 HEIM_ANY_cmp(const heim_any_set *p, const heim_any_set *q)
 {
     return der_heim_octet_string_cmp(p, q);

--- a/lib/asn1/heim_asn1.h
+++ b/lib/asn1/heim_asn1.h
@@ -34,38 +34,38 @@
 #ifndef __HEIM_ANY_H__
 #define __HEIM_ANY_H__ 1
 
-int	encode_heim_any(unsigned char *, size_t, const heim_any *, size_t *);
-int	decode_heim_any(const unsigned char *, size_t, heim_any *, size_t *);
-void	free_heim_any(heim_any *);
-char   *print_heim_any(const heim_any *, int);
-size_t	length_heim_any(const heim_any *);
-int	copy_heim_any(const heim_any *, heim_any *);
+int	ASN1CALL encode_heim_any(unsigned char *, size_t, const heim_any *, size_t *);
+int	ASN1CALL decode_heim_any(const unsigned char *, size_t, heim_any *, size_t *);
+void	ASN1CALL free_heim_any(heim_any *);
+char   *ASN1CALL print_heim_any(const heim_any *, int);
+size_t	ASN1CALL length_heim_any(const heim_any *);
+int	ASN1CALL copy_heim_any(const heim_any *, heim_any *);
 
-int	encode_heim_any_set(unsigned char *, size_t,
+int	ASN1CALL encode_heim_any_set(unsigned char *, size_t,
 			    const heim_any_set *, size_t *);
-int	decode_heim_any_set(const unsigned char *, size_t,
+int	ASN1CALL decode_heim_any_set(const unsigned char *, size_t,
 			    heim_any_set *,size_t *);
-void	free_heim_any_set(heim_any_set *);
-char   *print_heim_any_set(const heim_any_set *, int);
-size_t	length_heim_any_set(const heim_any_set *);
-int	copy_heim_any_set(const heim_any_set *, heim_any_set *);
-int	heim_any_cmp(const heim_any_set *, const heim_any_set *);
+void	ASN1CALL free_heim_any_set(heim_any_set *);
+char   *ASN1CALL print_heim_any_set(const heim_any_set *, int);
+size_t	ASN1CALL length_heim_any_set(const heim_any_set *);
+int	ASN1CALL copy_heim_any_set(const heim_any_set *, heim_any_set *);
+int	ASN1CALL heim_any_cmp(const heim_any_set *, const heim_any_set *);
 
-int	encode_HEIM_ANY(unsigned char *, size_t, const heim_any *, size_t *);
-int	decode_HEIM_ANY(const unsigned char *, size_t, heim_any *, size_t *);
-void	free_HEIM_ANY(heim_any *);
-char   *print_HEIM_ANY(const heim_any *, int);
-size_t	length_HEIM_ANY(const heim_any *);
-int	copy_HEIM_ANY(const heim_any *, heim_any *);
+int	ASN1CALL encode_HEIM_ANY(unsigned char *, size_t, const heim_any *, size_t *);
+int	ASN1CALL decode_HEIM_ANY(const unsigned char *, size_t, heim_any *, size_t *);
+void	ASN1CALL free_HEIM_ANY(heim_any *);
+char   *ASN1CALL print_HEIM_ANY(const heim_any *, int);
+size_t	ASN1CALL length_HEIM_ANY(const heim_any *);
+int	ASN1CALL copy_HEIM_ANY(const heim_any *, heim_any *);
 
-int	encode_HEIM_ANY_SET(unsigned char *, size_t,
+int	ASN1CALL encode_HEIM_ANY_SET(unsigned char *, size_t,
 			    const heim_any_set *, size_t *);
-int	decode_HEIM_ANY_SET(const unsigned char *, size_t,
+int	ASN1CALL decode_HEIM_ANY_SET(const unsigned char *, size_t,
 			    heim_any_set *,size_t *);
-void	free_HEIM_ANY_SET(heim_any_set *);
-char   *print_HEIM_ANY_SET(const heim_any_set *, int);
-size_t	length_HEIM_ANY_SET(const heim_any_set *);
-int	copy_HEIM_ANY_SET(const heim_any_set *, heim_any_set *);
-int	heim_any_cmp(const heim_any_set *, const heim_any_set *);
+void	ASN1CALL free_HEIM_ANY_SET(heim_any_set *);
+char   *ASN1CALL print_HEIM_ANY_SET(const heim_any_set *, int);
+size_t	ASN1CALL length_HEIM_ANY_SET(const heim_any_set *);
+int	ASN1CALL copy_HEIM_ANY_SET(const heim_any_set *, heim_any_set *);
+int	ASN1CALL heim_any_cmp(const heim_any_set *, const heim_any_set *);
 
 #endif /* __HEIM_ANY_H__ */

--- a/lib/asn1/oid_resolution.c
+++ b/lib/asn1/oid_resolution.c
@@ -196,7 +196,7 @@ fix_oid_name(const char **namep, char **freeme)
     return 0;
 }
 
-int
+int ASN1CALL
 der_find_heim_oid_by_name(const char *str, const heim_oid **oid)
 {
     size_t right = num_sym_oids - 1;
@@ -235,7 +235,7 @@ der_find_heim_oid_by_name(const char *str, const heim_oid **oid)
     return -1;
 }
 
-int
+int ASN1CALL
 der_find_or_parse_heim_oid(const char *str, const char *sep, heim_oid *oid)
 {
     const heim_oid *found = NULL;
@@ -247,7 +247,7 @@ der_find_or_parse_heim_oid(const char *str, const char *sep, heim_oid *oid)
     }
 }
 
-int
+int ASN1CALL
 der_find_heim_oid_by_oid(const heim_oid *oid, const char **name)
 {
     size_t right = num_sym_oids;
@@ -279,7 +279,7 @@ der_find_heim_oid_by_oid(const heim_oid *oid, const char **name)
     return -1;
 }
 
-int
+int ASN1CALL
 der_match_heim_oid_by_name(const char *str, int *c, const heim_oid **oid)
 {
     size_t i;
@@ -313,7 +313,7 @@ der_match_heim_oid_by_name(const char *str, int *c, const heim_oid **oid)
 
 /* Warning: der_print_heim_oid_sym() will not round-trip */
 
-int
+int ASN1CALL
 der_print_heim_oid_sym(const heim_oid *oid, char delim, char **strp)
 {
     const char *sym;


### PR DESCRIPTION
The calling convention for all exported libasn1 functions must be ASN1CALL.   On Windows, ASN1CALL is _stdcall and without it its _cdecl.   Calling a _cdecl function with -stdcall convention results in the ESP register not being preserved properly.  The asn1 tests crash when compiled with /RTCs.