### PR TITLE
Fix #696 - Find python as part of the configure process

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ dnl Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CPP
+AM_PATH_PYTHON
 AC_CHECK_PROG(CLANG_FORMAT, clang-format, [clang-format], [no])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/lib/wind/Makefile.am
+++ b/lib/wind/Makefile.am
@@ -89,8 +89,6 @@ idn_lookup_SOURCES = idn-lookup.c
 
 LDADD = libwind.la $(LIB_roken)
 
-PYTHON = python
-
 if !MAINTAINER_MODE
 skip_python = test -f $@ ||
 endif


### PR DESCRIPTION
Replaces #706