### PR TITLE
plugin interface functions must specify calling convention

### DIFF
--- a/kdc/windc_plugin.h
+++ b/kdc/windc_plugin.h
@@ -53,11 +53,11 @@
 struct hdb_entry_ex;
 
 typedef krb5_error_code
-(*krb5plugin_windc_pac_generate)(void *, krb5_context,
+(KRB5_CALLCONV *krb5plugin_windc_pac_generate)(void *, krb5_context,
 				 struct hdb_entry_ex *, krb5_pac *);
 
 typedef krb5_error_code
-(*krb5plugin_windc_pac_verify)(void *, krb5_context,
+(KRB5_CALLCONV *krb5plugin_windc_pac_verify)(void *, krb5_context,
 			       const krb5_principal, /* new ticket client */
 			       const krb5_principal, /* delegation proxy */
 			       struct hdb_entry_ex *,/* client */
@@ -66,7 +66,7 @@ typedef krb5_error_code
 			       krb5_pac *);
 
 typedef krb5_error_code
-(*krb5plugin_windc_client_access)(
+(KRB5_CALLCONV *krb5plugin_windc_client_access)(
 	void *, krb5_context,
 	krb5_kdc_configuration *config,
 	hdb_entry_ex *, const char *, 
@@ -79,8 +79,8 @@ typedef krb5_error_code
 
 typedef struct krb5plugin_windc_ftable {
     int			minor_version;
-    krb5_error_code	(*init)(krb5_context, void **);
-    void		(*fini)(void *);
+    krb5_error_code	(KRB5_CALLCONV *init)(krb5_context, void **);
+    void		(KRB5_CALLCONV *fini)(void *);
     krb5plugin_windc_pac_generate	pac_generate;
     krb5plugin_windc_pac_verify		pac_verify;
     krb5plugin_windc_client_access	client_access;

--- a/lib/krb5/krb5-plugin.7
+++ b/lib/krb5/krb5-plugin.7
@@ -230,16 +230,16 @@ follows:
 #include <krb5/an2ln_plugin.h>
 
 /* Note that `context' here is actually a krb5_context value */
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 nouser_plug_init(heim_pcontext context, void **ctx)
 {
     *ctx = NULL;
     return 0;
 }
 
-static void nouser_plug_fini(void *ctx) { }
+static void KRB5_CALLCONV nouser_plug_fini(void *ctx) { }
 
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 nouser_plug_an2ln(void *plug_ctx, krb5_context context,
                   const char *rule,
                   krb5_const_principal aname,
@@ -297,16 +297,16 @@ there exists a built-in plugin with this functionality; see
 .Bd -literal -offset indent
 #include <krb5/kuserok_plugin.h>
 
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 reject_plug_init(heim_context context, void **ctx)
 {
     *ctx = NULL;
     return 0;
 }
 
-static void reject_plug_fini(void *ctx) { }
+static void KRB5_CALLCONV reject_plug_fini(void *ctx) { }
 
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 reject_plug_kuserok(void *plug_ctx, krb5_context context, const char *rule,
                     unsigned int flags, const char *k5login_dir,
                     const char *luser, krb5_const_principal principal,

--- a/lib/krb5/locate_plugin.h
+++ b/lib/krb5/locate_plugin.h
@@ -53,7 +53,8 @@ enum locate_service_type {
 };
 
 typedef krb5_error_code
-(*krb5plugin_service_locate_lookup) (void *, unsigned long, enum locate_service_type,
+(KRB5_CALLCONV *krb5plugin_service_locate_lookup)
+                                    (void *, unsigned long, enum locate_service_type,
 				     const char *, int, int,
 				     int (*)(void *,int,struct sockaddr *),
 				     void *);
@@ -61,7 +62,8 @@ typedef krb5_error_code
 #define KRB5_PLF_ALLOW_HOMEDIR	    1
 
 typedef krb5_error_code
-(*krb5plugin_service_locate_lookup_old) (void *, enum locate_service_type,
+(KRB5_CALLCONV *krb5plugin_service_locate_lookup_old)
+                                    (void *, enum locate_service_type,
 				     const char *, int, int,
 				     int (*)(void *,int,struct sockaddr *),
 				     void *);
@@ -69,8 +71,8 @@ typedef krb5_error_code
 
 typedef struct krb5plugin_service_locate_ftable {
     int			minor_version;
-    krb5_error_code	(*init)(krb5_context, void **);
-    void		(*fini)(void *);
+    krb5_error_code	(KRB5_CALLCONV *init)(krb5_context, void **);
+    void		(KRB5_CALLCONV *fini)(void *);
     krb5plugin_service_locate_lookup_old old_lookup;
     krb5plugin_service_locate_lookup lookup; /* version 2 */
 } krb5plugin_service_locate_ftable;

--- a/lib/krb5/send_to_kdc_plugin.h
+++ b/lib/krb5/send_to_kdc_plugin.h
@@ -45,14 +45,14 @@
 #define KRB5_PLUGIN_SEND_TO_KDC_VERSION KRB5_PLUGIN_SEND_TO_KDC_VERSION_2
 
 typedef krb5_error_code
-(*krb5plugin_send_to_kdc_func)(krb5_context,
+(KRB5_CALLCONV *krb5plugin_send_to_kdc_func)(krb5_context,
 			       void *,
 			       krb5_krbhst_info *,
 			       time_t timeout,
 			       const krb5_data *,
 			       krb5_data *);
 typedef krb5_error_code
-(*krb5plugin_send_to_realm_func)(krb5_context,
+(KRB5_CALLCONV *krb5plugin_send_to_realm_func)(krb5_context,
 				 void *,
 				 krb5_const_realm,
 				 time_t timeout,
@@ -62,8 +62,8 @@ typedef krb5_error_code
 
 typedef struct krb5plugin_send_to_kdc_ftable {
     int			minor_version;
-    krb5_error_code	(*init)(krb5_context, void **);
-    void		(*fini)(void *);
+    krb5_error_code	(KRB5_CALLCONV *init)(krb5_context, void **);
+    void		(KRB5_CALLCONV *fini)(void *);
     krb5plugin_send_to_kdc_func send_to_kdc;
     krb5plugin_send_to_realm_func send_to_realm; /* added in version 2 */
 } krb5plugin_send_to_kdc_ftable;

--- a/lib/krb5/test_plugin.c
+++ b/lib/krb5/test_plugin.c
@@ -34,19 +34,19 @@
 #include <krb5_locl.h>
 #include "locate_plugin.h"
 
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 resolve_init(krb5_context context, void **ctx)
 {
     *ctx = NULL;
     return 0;
 }
 
-static void
+static void KRB5_CALLCONV
 resolve_fini(void *ctx)
 {
 }
 
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 resolve_lookup(void *ctx,
 	       enum locate_service_type service,
 	       const char *realm,


### PR DESCRIPTION
The plugin interfaces were originally implemented for use on
Unix where KRB5_CALLCONV, HEIM_CALLCONV and similar are defined
as nothing.  However, on 32-bit Windows the calling convention
matters and executing a __stdcall function through a __cdecl
function pointer will result in failures.

This change updates the krb5plugin_windc, krb5plugin_service_locate,
krb5plugin_send_to_kdc plugins to specify the KRB5_CALLCONV for
functions.   This brings the plugins into compliance with the
heim_plugin_common interface requirement that init() and fini()
use the platform specified HEIM_CALLCONV.

The krb5-plugin(7) man page is updated and the lib/krb5/test_plugin
test is also fixed.

With this change all tests pass on 32-bit Windows.

Change-Id: Ic9d2e1285c9c179e3898dc9d071ed092bcddc406
