### PR TITLE
kdc: Fix ‘header_key’ may be used uninitialized in this function

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -2297,7 +2297,7 @@ _kdc_tgs_rep(astgs_request_t r)
     krb5_error_code ret;
     int i = 0;
     const PA_DATA *tgs_req;
-    Key *header_key;
+    Key *header_key = NULL;
 
     hdb_entry_ex *krbtgt = NULL;
     krb5_ticket *ticket = NULL;


### PR DESCRIPTION
krb5tgs.c: In function ‘_kdc_tgs_rep’:
krb5tgs.c:1785:25: warning: ‘header_key’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1785 |       &tkey_check->key, &tkey_check->key, tgt, &kdc_issued, &mspac);
      |                         ^~~~~~~~~~~~~~~~
krb5tgs.c:2302:10: note: ‘header_key’ was declared here
 2302 |     Key *header_key;
      |          ^~~~~~~~~~

On Ubuntu 20.04 in a default Heimdal build with
gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)

The compiler doesn't trust that *header_key = tkey; is always
executed in tgs_parse_request() for ret == 0.

Signed-off-by: Andrew Bartlett <abartlet@samba.org>