### PR TITLE
kdc: add krb5plugin_windc_pac_pk_generate() hook

### DIFF
--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -79,6 +79,7 @@ struct astgs_request_desc {
     EncKDCRepPart ek;
 
     /* PA methods can affect both the reply key and the session key (pkinit) */
+    krb5_preauthtype validated_pa_type;
     krb5_enctype sessionetype;
     krb5_keyblock reply_key;
     krb5_keyblock session_key;

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1938,12 +1938,17 @@ server_lookup:
 	    if (mspac) {
 		krb5_pac_free(context, mspac);
 		mspac = NULL;
-		ret = _kdc_pac_generate(context, s4u2self_impersonated_client, &mspac);
-		if (ret) {
-		    kdc_log(context, config, 4, "PAC generation failed for -- %s",
-			    tpn);
-		    goto out;
-		}
+	    }
+	    ret = _kdc_pac_generate(context,
+				    s4u2self_impersonated_client,
+				    server,
+				    NULL,
+				    NULL,
+				    &mspac);
+	    if (ret) {
+		kdc_log(context, config, 4, "PAC generation failed for -- %s",
+			tpn);
+		goto out;
 	    }
 
 	    /*

--- a/kdc/windc.c
+++ b/kdc/windc.c
@@ -71,7 +71,10 @@ krb5_kdc_windc_init(krb5_context context)
 
 struct generate_uc {
     hdb_entry_ex *client;
+    hdb_entry_ex *server;
+    const krb5_keyblock *pk_reply_key;
     krb5_pac *pac;
+    const krb5_boolean *pac_request;
 };
 
 static krb5_error_code KRB5_LIB_CALL
@@ -82,13 +85,22 @@ generate(krb5_context context, const void *plug, void *plugctx, void *userctx)
 
     if (ft->pac_generate == NULL)
 	return KRB5_PLUGIN_NO_HANDLE;
-    return ft->pac_generate((void *)plug, context, uc->client, uc->pac);
+
+    return ft->pac_generate((void *)plug, context,
+			    uc->client,
+			    uc->server,
+			    uc->pk_reply_key,
+			    uc->pac_request,
+			    uc->pac);
 }
 
 
 krb5_error_code
 _kdc_pac_generate(krb5_context context,
 		  hdb_entry_ex *client,
+		  hdb_entry_ex *server,
+		  const krb5_keyblock *pk_reply_key,
+		  const krb5_boolean *pac_request,
 		  krb5_pac *pac)
 {
     krb5_error_code ret = 0;
@@ -104,7 +116,10 @@ _kdc_pac_generate(krb5_context context,
     if (have_plugin) {
 
 	uc.client = client;
+	uc.server = server;
+	uc.pk_reply_key = pk_reply_key;
 	uc.pac = pac;
+	uc.pac_request = pac_request;
 
 	ret = _krb5_plugin_run_f(context, &windc_plugin_data,
 				 0, &uc, generate);

--- a/kdc/windc_plugin.h
+++ b/kdc/windc_plugin.h
@@ -54,7 +54,11 @@ struct hdb_entry_ex;
 
 typedef krb5_error_code
 (KRB5_CALLCONV *krb5plugin_windc_pac_generate)(void *, krb5_context,
-				 struct hdb_entry_ex *, krb5_pac *);
+					       struct hdb_entry_ex *, /* client */
+					       struct hdb_entry_ex *, /* server */
+					       const krb5_keyblock *, /* pk_replykey */
+					       const krb5_boolean *, /* pac_request */
+					       krb5_pac *);
 
 typedef krb5_error_code
 (KRB5_CALLCONV *krb5plugin_windc_pac_verify)(void *, krb5_context,
@@ -74,7 +78,7 @@ typedef krb5_error_code
 	KDC_REQ *, METHOD_DATA *);
 
 
-#define KRB5_WINDC_PLUGIN_MINOR			6
+#define KRB5_WINDC_PLUGIN_MINOR			7
 #define KRB5_WINDC_PLUGING_MINOR KRB5_WINDC_PLUGIN_MINOR
 
 typedef struct krb5plugin_windc_ftable {

--- a/tests/plugin/windc.c
+++ b/tests/plugin/windc.c
@@ -20,10 +20,19 @@ windc_fini(void *ctx)
 
 static krb5_error_code
 pac_generate(void *ctx, krb5_context context,
-	     struct hdb_entry_ex *client, krb5_pac *pac)
+	     struct hdb_entry_ex *client,
+	     struct hdb_entry_ex *server,
+	     const krb5_keyblock *pk_replykey,
+	     const krb5_boolean *pac_request,
+	     krb5_pac *pac)
 {
     krb5_error_code ret;
     krb5_data data;
+
+    if (pac_request != NULL && *pac_request == FALSE) {
+	    *pac = NULL;
+	    return 0;
+    }
 
     krb5_warnx(context, "pac generate");
 


### PR DESCRIPTION
This allows PAC_CRENDENTIAL_INFO to be added to the PAC
when using PKINIT. In that case PAC_CRENDENTIAL_INFO contains
an encrypted PAC_CRENDENTIAL_DATA.

BUG: https://bugzilla.samba.org/show_bug.cgi?id=11441

Signed-off-by: Stefan Metzmacher <metze@samba.org>

(similar to Samba commit 0022ea9efb0e7809fa2d060b294320eb0479cdd2)