### PR TITLE
Use UTF-8 in KTH copyright notice

### DIFF
--- a/cf/maybe-valgrind.sh
+++ b/cf/maybe-valgrind.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2006 - 2007 Kungliga Tekniska Högskolan
+# Copyright (c) 2006 - 2007 Kungliga Tekniska HÃ¶gskolan
 # (Royal Institute of Technology, Stockholm, Sweden). 
 # All rights reserved. 
 #

--- a/kcm/sessions.c
+++ b/kcm/sessions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/kdc/digest-service.c
+++ b/kdc/digest-service.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006 - 2007 Kungliga Tekniska Högskolan
+ * Copyright (c) 2006 - 2007 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/asn1/asn1-template.h
+++ b/lib/asn1/asn1-template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997 - 2006 Kungliga Tekniska Högskolan
+ * Copyright (c) 1997 - 2006 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/asn1/gen_template.c
+++ b/lib/asn1/gen_template.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997 - 2005 Kungliga Tekniska Högskolan
+ * Copyright (c) 1997 - 2005 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/mech/gss_store_cred.c
+++ b/lib/gssapi/mech/gss_store_cred.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/netlogon/accept_sec_context.c
+++ b/lib/gssapi/netlogon/accept_sec_context.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/netlogon/canonicalize_name.c
+++ b/lib/gssapi/netlogon/canonicalize_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/netlogon/context_time.c
+++ b/lib/gssapi/netlogon/context_time.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/netlogon/display_status.c
+++ b/lib/gssapi/netlogon/display_status.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/netlogon/export_name.c
+++ b/lib/gssapi/netlogon/export_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/netlogon/iter_cred.c
+++ b/lib/gssapi/netlogon/iter_cred.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/netlogon/process_context_token.c
+++ b/lib/gssapi/netlogon/process_context_token.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/ntlm/inquire_sec_context_by_oid.c
+++ b/lib/gssapi/ntlm/inquire_sec_context_by_oid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006 Kungliga Tekniska Högskolan
+ * Copyright (c) 2006 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/ntlm/iter_cred.c
+++ b/lib/gssapi/ntlm/iter_cred.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006 Kungliga Tekniska Högskolan
+ * Copyright (c) 2006 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/gssapi/ntlm/set_sec_context_option.c
+++ b/lib/gssapi/ntlm/set_sec_context_option.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006 Kungliga Tekniska Högskolan
+ * Copyright (c) 2006 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/hcrypto/ec.c
+++ b/lib/hcrypto/ec.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/hcrypto/ec.h
+++ b/lib/hcrypto/ec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2016 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009-2016 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/hcrypto/ecdh.h
+++ b/lib/hcrypto/ecdh.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/hcrypto/ecdsa.h
+++ b/lib/hcrypto/ecdsa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/hdb/hdb-keytab.c
+++ b/lib/hdb/hdb-keytab.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/hdb/hdb-sqlite.c
+++ b/lib/hdb/hdb-sqlite.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/hx509/data/static-file
+++ b/lib/hx509/data/static-file
@@ -2,7 +2,7 @@ This is a static file don't change the content, it is used in the test
 
 #!/bin/sh
 #
-# Copyright (c) 2005 Kungliga Tekniska Högskolan
+# Copyright (c) 2005 Kungliga Tekniska HÃ¶gskolan
 # (Royal Institute of Technology, Stockholm, Sweden). 
 # All rights reserved. 
 #

--- a/lib/ipc/client.c
+++ b/lib/ipc/client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/common.c
+++ b/lib/ipc/common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/heim-ipc.h
+++ b/lib/ipc/heim-ipc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/heim_ipc.defs
+++ b/lib/ipc/heim_ipc.defs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/heim_ipc_async.defs
+++ b/lib/ipc/heim_ipc_async.defs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/heim_ipc_reply.defs
+++ b/lib/ipc/heim_ipc_reply.defs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/heim_ipc_types.h
+++ b/lib/ipc/heim_ipc_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/hi_locl.h
+++ b/lib/ipc/hi_locl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/server.c
+++ b/lib/ipc/server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/tc.c
+++ b/lib/ipc/tc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/ts-http.c
+++ b/lib/ipc/ts-http.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/ipc/ts.c
+++ b/lib/ipc/ts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/krb5/deprecated.c
+++ b/lib/krb5/deprecated.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997 - 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 1997 - 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *

--- a/lib/krb5/test_gic.c
+++ b/lib/krb5/test_gic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *


### PR DESCRIPTION
Samba is starting to protect against bi-di attacks and the starting point
is to require that input files be fully UTF-8.  In 2021 this is a reasonable
starting point anyway.

Signed-off-by: Andrew Bartlett <abartlet@samba.org>