### PR TITLE
Revert "KCM wrong size memcmp"

### DIFF
--- a/kcm/cache.c
+++ b/kcm/cache.c
@@ -105,7 +105,7 @@ kcm_ccache_resolve_by_uuid(krb5_context context,
     for (p = ccache_head; p != NULL; p = p->next) {
 	if ((p->flags & KCM_FLAGS_VALID) == 0)
 	    continue;
-	if (memcmp(p->uuid, uuid, sizeof(*uuid)) == 0) {
+	if (memcmp(p->uuid, uuid, sizeof(kcmuuid_t)) == 0) {
 	    ret = 0;
 	    break;
 	}


### PR DESCRIPTION
'uuid' is seen as an 'unsigned char*', thus '*uuid' is an 'unsigned char' where size is 1.

This solves a problem where two KCM ccaches's uuid have the same first byte hides each other.

What we observe:
  * A user cannot discover tickets with (klist -l) but can access it with it's name
  * The 'rpc.gssd' daemon is doing the same kind of pattern but using GSS calls (gss_acquire_cred)

What GDB told us:
  * The 'kcm_ccache_get_uuids' is okay, all ccache are really present
  * The 'kcm_ccache_resolve_by_uuid' is buggy, it only compare the first byte of each uuid.
    Which may be the same as the one we're seeking. Selected ccache that will be, most probably, filtered-out afterward with a call to 'kcm_access'.
    This leads to 'KRB5_FCC_NOFILE' errors while the uuid is correct.

Similar calls may be present.

This reverts commit 936017e4d62628851463cdd953b934875b995625,