### PR TITLE
Upstream Heimdal-side helpers for Samba's Nov 2021 security release

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1455,7 +1455,10 @@ tgs_build_reply(astgs_request_t priv,
 	    ret = KRB5KDC_ERR_POLICY;
 	    goto out;
 	}
-	_krb5_principalname2krb5_principal(context, &p, t->sname, t->realm);
+	ret = _krb5_principalname2krb5_principal(context, &p, t->sname, t->realm);
+	if (ret)
+	    goto out;
+
 	ret = krb5_unparse_name(context, p, &tpn);
 	if (ret)
 		goto out;

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -350,7 +350,7 @@ check_constrained_delegation(krb5_context context,
  * Determine if s4u2self is allowed from this client to this server
  *
  * For example, regardless of the principal being impersonated, if the
- * 'client' and 'server' are the same, then it's safe.
+ * 'client' and 'server' (target) are the same, then it's safe.
  */
 
 static krb5_error_code
@@ -358,18 +358,28 @@ check_s4u2self(krb5_context context,
 	       krb5_kdc_configuration *config,
 	       HDB *clientdb,
 	       hdb_entry_ex *client,
-	       krb5_const_principal server)
+	       hdb_entry_ex *target_server,
+	       krb5_const_principal target_server_principal)
 {
     krb5_error_code ret;
 
-    /* if client does a s4u2self to itself, that ok */
-    if (krb5_principal_compare(context, client->entry.principal, server) == TRUE)
-	return 0;
-
+    /*
+     * Always allow the plugin to check, this might be faster, allow a
+     * policy or audit check and can look into the DB records
+     * directly
+     */
     if (clientdb->hdb_check_s4u2self) {
-	ret = clientdb->hdb_check_s4u2self(context, clientdb, client, server);
+	ret = clientdb->hdb_check_s4u2self(context,
+					   clientdb,
+					   client,
+					   target_server);
 	if (ret == 0)
 	    return 0;
+    } else if (krb5_principal_compare(context,
+				      client->entry.principal,
+				      target_server_principal) == TRUE) {
+	/* if client does a s4u2self to itself, and there is no plugin, that is ok */
+	return 0;
     } else {
 	ret = KRB5KDC_ERR_BADOPTION;
     }
@@ -1993,7 +2003,7 @@ server_lookup:
 	     * Check that service doing the impersonating is
 	     * requesting a ticket to it-self.
 	     */
-	    ret = check_s4u2self(context, config, clientdb, client, sp);
+	    ret = check_s4u2self(context, config, clientdb, client, server, sp);
 	    if (ret) {
 		kdc_log(context, config, 4, "S4U2Self: %s is not allowed "
 			"to impersonate to service "

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -292,9 +292,9 @@ typedef struct HDB {
     krb5_error_code (*hdb_check_pkinit_ms_upn_match)(krb5_context, struct HDB *, hdb_entry_ex *, krb5_const_principal);
 
     /**
-     * Check if s4u2self is allowed from this client to this server
+     * Check if s4u2self is allowed from this client to this server or the SPN is a valid SPN of this client (for user2user)
      */
-    krb5_error_code (*hdb_check_s4u2self)(krb5_context, struct HDB *, hdb_entry_ex *, hdb_entry_ex *);
+    krb5_error_code (*hdb_check_client_matches_target_service)(krb5_context, struct HDB *, hdb_entry_ex *, hdb_entry_ex *);
 
     /**
      * Enable/disable synchronous updates

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -294,7 +294,7 @@ typedef struct HDB {
     /**
      * Check if s4u2self is allowed from this client to this server
      */
-    krb5_error_code (*hdb_check_s4u2self)(krb5_context, struct HDB *, hdb_entry_ex *, krb5_const_principal);
+    krb5_error_code (*hdb_check_s4u2self)(krb5_context, struct HDB *, hdb_entry_ex *, hdb_entry_ex *);
 
     /**
      * Enable/disable synchronous updates


### PR DESCRIPTION
This proposes the patches that were made to Samba to address the November 2021 Security issues 

See https://www.samba.org/samba/security/CVE-2020-25719.html

We made changes to our (older) copy of Heimdal to address these issues and @josephsutton1 has now forward-ported those to modern Heimdal. 

(I've written the new longer commit messages)