### PR TITLE
Fix up lib/roken parse/unparse functions

### DIFF
--- a/kdc/config.c
+++ b/kdc/config.c
@@ -221,8 +221,13 @@ configure(krb5_context context, int argc, char **argv, int *optidx)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_kdc_set_dbinfo");
 
-    if(max_request_str)
-	max_request_tcp = max_request_udp = parse_bytes(max_request_str, NULL);
+    if (max_request_str) {
+        ssize_t bytes;
+
+        if ((bytes = parse_bytes(max_request_str, NULL)) < 0)
+            krb5_errx(context, 1, "--max-request must be non-negative");
+	max_request_tcp = max_request_udp = bytes;
+    }
 
     if(max_request_tcp == 0){
 	p = krb5_config_get_string (context,
@@ -230,8 +235,13 @@ configure(krb5_context context, int argc, char **argv, int *optidx)
 				    "kdc",
 				    "max-request",
 				    NULL);
-	if(p)
-	    max_request_tcp = max_request_udp = parse_bytes(p, NULL);
+        if (p) {
+            ssize_t bytes;
+
+            if ((bytes = parse_bytes(max_request_str, NULL)) < 0)
+                krb5_errx(context, 1, "[kdc] max-request must be non-negative");
+            max_request_tcp = max_request_udp = bytes;
+        }
     }
 
     if(require_preauth != -1)

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1581,10 +1581,11 @@ _log_astgs_req(astgs_request_t r, krb5_enctype setype)
 
     {
 	char fixedstr[128];
+	int result;
 
-	unparse_flags(KDCOptions2int(b->kdc_options), asn1_KDCOptions_units(),
-		      fixedstr, sizeof(fixedstr));
-	if (*fixedstr) {
+	result = unparse_flags(KDCOptions2int(b->kdc_options), asn1_KDCOptions_units(),
+			       fixedstr, sizeof(fixedstr));
+	if (result > 0) {
 	    _kdc_r_log(r, 4, "Requested flags: %s", fixedstr);
 	    _kdc_audit_addkv((kdc_request_t)r, KDC_AUDIT_EATWHITE,
 			     "flags", "%s", fixedstr);

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1432,6 +1432,8 @@ tgs_build_reply(astgs_request_t priv,
     Key *tkey_sign;
     int flags = HDB_F_FOR_TGS_REQ;
 
+    int result;
+
     memset(&sessionkey, 0, sizeof(sessionkey));
     memset(&adtkt, 0, sizeof(adtkt));
     memset(&enc_pa_data, 0, sizeof(enc_pa_data));
@@ -1464,10 +1466,10 @@ tgs_build_reply(astgs_request_t priv,
     if (ret)
 	goto out;
     cpn = priv->cname;
-    unparse_flags (KDCOptions2int(b->kdc_options),
-		   asn1_KDCOptions_units(),
-		   opt_str, sizeof(opt_str));
-    if(*opt_str)
+    result = unparse_flags(KDCOptions2int(b->kdc_options),
+			   asn1_KDCOptions_units(),
+			   opt_str, sizeof(opt_str));
+    if (result > 0)
 	kdc_log(context, config, 4,
 		"TGS-REQ %s from %s for %s [%s]",
 		cpn, from, spn, opt_str);

--- a/kuser/klist.c
+++ b/kuser/klist.c
@@ -227,10 +227,12 @@ print_cred_verbose(krb5_context context, krb5_creds *cred, int do_json)
                    printable_time_long(cred->times.renew_till));
         {
             char flags[1024];
-            unparse_flags(TicketFlags2int(cred->flags.b),
-                          asn1_TicketFlags_units(),
-                          flags, sizeof(flags));
-            printf(N_("Ticket flags: %s\n", ""), flags);
+            int result = unparse_flags(TicketFlags2int(cred->flags.b),
+                                       asn1_TicketFlags_units(),
+                                       flags, sizeof(flags));
+            if (result > 0) {
+                printf(N_("Ticket flags: %s\n", ""), flags);
+            }
         }
         printf(N_("Addresses: ", ""));
         if (cred->addresses.len != 0) {

--- a/lib/hx509/cert.c
+++ b/lib/hx509/cert.c
@@ -971,7 +971,7 @@ check_key_usage(hx509_context context, const Certificate *cert,
     size_t size;
     int ret;
     size_t i = 0;
-    unsigned ku_flags;
+    uint64_t ku_flags;
 
     if (_hx509_cert_get_version(cert) < 3)
 	return 0;
@@ -992,14 +992,16 @@ check_key_usage(hx509_context context, const Certificate *cert,
 	return ret;
     ku_flags = KeyUsage2int(ku);
     if ((ku_flags & flags) != flags) {
-	unsigned missing = (~ku_flags) & flags;
+	uint64_t missing = (~ku_flags) & flags;
 	char buf[256], *name;
 
-	unparse_flags(missing, asn1_KeyUsage_units(), buf, sizeof(buf));
+	int result = unparse_flags(missing, asn1_KeyUsage_units(),
+				   buf, sizeof(buf));
 	_hx509_unparse_Name(&cert->tbsCertificate.subject, &name);
 	hx509_set_error_string(context, 0, HX509_KU_CERT_MISSING,
 			       "Key usage %s required but missing "
-			       "from certificate %s", buf,
+			       "from certificate %s",
+			       (result > 0) ? buf : "<unknown>",
                                name ? name : "<unknown>");
 	free(name);
 	return HX509_KU_CERT_MISSING;

--- a/lib/hx509/hxtool.c
+++ b/lib/hx509/hxtool.c
@@ -1607,7 +1607,8 @@ int
 random_data(void *opt, int argc, char **argv)
 {
     void *ptr;
-    int len, ret;
+    ssize_t len;
+    int ret;
 
     len = parse_bytes(argv[0], "byte");
     if (len <= 0) {

--- a/lib/hx509/ks_p11.c
+++ b/lib/hx509/ks_p11.c
@@ -38,7 +38,7 @@
 #include "ref/pkcs11.h"
 
 struct p11_slot {
-    int flags;
+    uint64_t flags;
 #define P11_SESSION		1
 #define P11_SESSION_IN_USE	2
 #define P11_LOGIN_REQ		4

--- a/lib/roken/parse_bytes-test.c
+++ b/lib/roken/parse_bytes-test.c
@@ -38,7 +38,7 @@
 
 static struct testcase {
     int canonicalp;
-    int val;
+    ssize_t val;
     const char *def_unit;
     const char *str;
 } tests[] = {
@@ -52,6 +52,7 @@ static struct testcase {
     {1, 1024 * 1024, NULL, "1 megabyte"},
     {0, 1025, NULL, "1 kilobyte 1"},
     {1, 1025, NULL, "1 kilobyte 1 byte"},
+    {1, 1024UL * 1024 * 1024 * 1024, NULL, "1 terabyte"},
 };
 
 int
@@ -62,20 +63,20 @@ main(int argc, char **argv)
 
     for (i = 0; i < sizeof(tests)/sizeof(tests[0]); ++i) {
 	char buf[256];
-	int val = parse_bytes (tests[i].str, tests[i].def_unit);
+	ssize_t val = parse_bytes (tests[i].str, tests[i].def_unit);
 
 	if (val != tests[i].val) {
-	    printf ("parse_bytes (%s, %s) = %d != %d\n",
+	    printf ("parse_bytes (%s, %s) = %lld != %lld\n",
 		    tests[i].str,
 		    tests[i].def_unit ? tests[i].def_unit : "none",
-		    val, tests[i].val);
+		    (long long)val, (long long)tests[i].val);
 	    ++ret;
 	}
 	if (tests[i].canonicalp) {
 	    (void) unparse_bytes (tests[i].val, buf, sizeof(buf));
 	    if (strcmp (tests[i].str, buf) != 0) {
-		printf ("unparse_bytes (%d) = \"%s\" != \"%s\"\n",
-			tests[i].val, buf, tests[i].str);
+		printf ("unparse_bytes (%lld) = \"%s\" != \"%s\"\n",
+			(long long)tests[i].val, buf, tests[i].str);
 		++ret;
 	    }
 	}

--- a/lib/roken/parse_bytes.c
+++ b/lib/roken/parse_bytes.c
@@ -37,6 +37,10 @@
 #include "parse_bytes.h"
 
 static struct units bytes_units[] = {
+    { "petabyte", 1024UL * 1024 * 1024 * 1024 * 1024 },
+    { "PB", 1024UL * 1024 * 1024 * 1024 * 1024 },
+    { "terabyte", 1024UL * 1024 * 1024 * 1024 },
+    { "TB", 1024UL * 1024 * 1024 * 1024 },
     { "gigabyte", 1024 * 1024 * 1024 },
     { "gbyte", 1024 * 1024 * 1024 },
     { "GB", 1024 * 1024 * 1024 },
@@ -50,26 +54,28 @@ static struct units bytes_units[] = {
 };
 
 static struct units bytes_short_units[] = {
+    { "PB", 1024UL * 1024 * 1024 * 1024 * 1024 },
+    { "TB", 1024UL * 1024 * 1024 * 1024 },
     { "GB", 1024 * 1024 * 1024 },
     { "MB", 1024 * 1024 },
     { "KB", 1024 },
     { NULL, 0 }
 };
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-parse_bytes (const char *s, const char *def_unit)
+ROKEN_LIB_FUNCTION ssize_t ROKEN_LIB_CALL
+parse_bytes(const char *s, const char *def_unit)
 {
     return parse_units (s, bytes_units, def_unit);
 }
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_bytes (int t, char *s, size_t len)
+unparse_bytes(ssize_t t, char *s, size_t len)
 {
     return unparse_units (t, bytes_units, s, len);
 }
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_bytes_short (int t, char *s, size_t len)
+unparse_bytes_short (ssize_t t, char *s, size_t len)
 {
     return unparse_units_approx (t, bytes_short_units, s, len);
 }

--- a/lib/roken/parse_bytes.h
+++ b/lib/roken/parse_bytes.h
@@ -46,13 +46,13 @@
 #endif
 #endif
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-parse_bytes (const char *s, const char *def_unit);
+ROKEN_LIB_FUNCTION ssize_t ROKEN_LIB_CALL
+parse_bytes(const char *s, const char *def_unit);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_bytes (int t, char *s, size_t len);
+unparse_bytes(ssize_t t, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_bytes_short (int t, char *s, size_t len);
+unparse_bytes_short(ssize_t t, char *s, size_t len);
 
 #endif /* __PARSE_BYTES_H__ */

--- a/lib/roken/parse_time.c
+++ b/lib/roken/parse_time.c
@@ -50,20 +50,20 @@ static struct units time_units[] = {
     {NULL, 0},
 };
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION int64_t ROKEN_LIB_CALL
 parse_time (const char *s, const char *def_unit)
 {
     return parse_units (s, time_units, def_unit);
 }
 
 ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
-unparse_time (int t, char *s, size_t len)
+unparse_time(int64_t t, char *s, size_t len)
 {
     return unparse_units (t, time_units, s, len);
 }
 
 ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
-unparse_time_approx (int t, char *s, size_t len)
+unparse_time_approx(int64_t t, char *s, size_t len)
 {
     return unparse_units_approx (t, time_units, s, len);
 }
@@ -79,20 +79,20 @@ print_time_table (FILE *f)
 #undef unparse_time_approx
 #undef print_time_table
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION int64_t ROKEN_LIB_CALL
 parse_time(const char *s, const char *def_unit)
 {
     return rk_parse_units(s, time_units, def_unit);
 }
 
 ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
-unparse_time(int t, char *s, size_t len)
+unparse_time(int64_t t, char *s, size_t len)
 {
     return rk_unparse_units(t, time_units, s, len);
 }
 
 ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
-unparse_time_approx(int t, char *s, size_t len)
+unparse_time_approx(int64_t t, char *s, size_t len)
 {
     return rk_unparse_units_approx(t, time_units, s, len);
 }

--- a/lib/roken/parse_time.h
+++ b/lib/roken/parse_time.h
@@ -46,14 +46,14 @@
 #endif
 #endif
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION int64_t ROKEN_LIB_CALL
 parse_time (const char *s, const char *def_unit);
 
 ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
-unparse_time (int t, char *s, size_t len);
+unparse_time(int64_t t, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
-unparse_time_approx (int t, char *s, size_t len);
+unparse_time_approx(int64_t t, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
 print_time_table (FILE *f);
@@ -65,14 +65,14 @@ print_time_table (FILE *f);
 #define unparse_time_approx rk_unparse_time_approx
 #define print_time_table rk_print_time_table
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION int64_t ROKEN_LIB_CALL
 parse_time (const char *s, const char *def_unit);
 
 ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
-unparse_time (int t, char *s, size_t len);
+unparse_time(int64_t t, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION size_t ROKEN_LIB_CALL
-unparse_time_approx (int t, char *s, size_t len);
+unparse_time_approx(int64_t t, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
 print_time_table (FILE *f);

--- a/lib/roken/parse_units.h
+++ b/lib/roken/parse_units.h
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifndef ROKEN_LIB_FUNCTION
 #ifdef _WIN32
@@ -51,29 +52,29 @@
 
 struct units {
     const char *name;
-    unsigned long long mult;
+    uint64_t mult;
 };
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION int64_t ROKEN_LIB_CALL
 parse_units (const char *s, const struct units *units,
 	     const char *def_unit);
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
 print_units_table (const struct units *units, FILE *f);
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION uint64_t ROKEN_LIB_CALL
 parse_flags (const char *s, const struct units *units,
 	     int orig);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_units (int num, const struct units *units, char *s, size_t len);
+unparse_units(int64_t num, const struct units *units, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_units_approx (int num, const struct units *units, char *s,
-		      size_t len);
+unparse_units_approx(int64_t num, const struct units *units, char *s,
+		     size_t len);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_flags (int num, const struct units *units, char *s, size_t len);
+unparse_flags(uint64_t num, const struct units *units, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
 print_flags_table (const struct units *units, FILE *f);
@@ -88,26 +89,26 @@ print_flags_table (const struct units *units, FILE *f);
 #define unparse_flags rk_unparse_flags
 #define print_flags_table rk_print_flags_table
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION int64_t ROKEN_LIB_CALL
 parse_units (const char *s, const struct units *units,
 	     const char *def_unit);
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
 print_units_table (const struct units *units, FILE *f);
 
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION uint64_t ROKEN_LIB_CALL
 parse_flags (const char *s, const struct units *units,
 	     int orig);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_units (int num, const struct units *units, char *s, size_t len);
+unparse_units(int64_t num, const struct units *units, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_units_approx (int num, const struct units *units, char *s,
-		      size_t len);
+unparse_units_approx(int64_t num, const struct units *units, char *s,
+		     size_t len);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_flags (int num, const struct units *units, char *s, size_t len);
+unparse_flags(uint64_t num, const struct units *units, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
 print_flags_table (const struct units *units, FILE *f);


### PR DESCRIPTION
Another patch by @josephsutton1:

If a function calls unparse_flags() to convert a KDCOptions value into a
string when the 'validate' flag is set, KDCOptions2int() will return 1
<< 31, which becomes −2147483648 when converted to a 32-bit signed
integer. Since the loop in unparse_something() only runs as long as its
input is greater than zero, this will result in nothing being printed to
the buffer. Changing unparse_flags() to take an int64_t avoids this
behaviour, at least until a 64th flag bit is added. We also return an
error value of -1 from unparse_something() if it receives a negative
value.

However, the callers are not checking the result from unparse_flags()
and would still have attempted to log these uninitialised bytes. Modify
some of these callers so that they perform this checking.