### PR TITLE
Initialise KDC reply

### DIFF
--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -423,7 +423,7 @@ get_cred_kdc(krb5_context context,
     TGS_REQ req;
     krb5_data enc;
     krb5_data resp;
-    krb5_kdc_rep rep;
+    krb5_kdc_rep rep = {0};
     KRB_ERROR error;
     krb5_error_code ret;
     unsigned nonce;
@@ -543,7 +543,6 @@ get_cred_kdc(krb5_context context,
     if(ret)
 	goto out;
 
-    memset(&rep, 0, sizeof(rep));
     if(decode_TGS_REP(resp.data, resp.length, &rep.kdc_rep, &len) == 0) {
 	unsigned eflags = 0;
 


### PR DESCRIPTION
The reply structure was not being zero-initialised in all cases, leading to crashes or possible heap corruption on error paths when we later freed it.