### PR TITLE
asn1: Fix binary search off-by-one read

### DIFF
--- a/lib/asn1/template.c
+++ b/lib/asn1/template.c
@@ -566,7 +566,7 @@ _asn1_decode_open_type(const struct asn1_template *t,
         const void *vp = DPO(data, ttypeid->offset);
         int c = -1;
 
-        while (left <= right) {
+        while (left < right) {
             size_t mid = (left + right) >> 1;
 
             if ((tos[3 + mid * 3].tt & A1_OP_MASK) != A1_OP_OPENTYPE_ID)
@@ -577,10 +577,7 @@ _asn1_decode_open_type(const struct asn1_template *t,
             else if (typeid_is_oid)
                 c = der_heim_oid_cmp(vp, tos[3 + mid * 3].ptr);
             if (c < 0) {
-                if (mid)
-                    right = mid - 1;
-                else
-                    break;
+                right = mid;
             } else if (c > 0) {
                 left = mid + 1;
             } else {


### PR DESCRIPTION
Previously, if left==right==A1_HEADER_LEN(tos), this would read past the end of the template array. Now we treat [left, right) as a half-open interval and no longer try to read from 'right'.