### PR TITLE
kdc: update PAC hooks for Samba

### DIFF
--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -99,6 +99,7 @@ struct astgs_request_desc {
     /* only valid for tgs-req */
     unsigned int rk_is_subkey : 1;
     unsigned int fast_asserted : 1;
+    unsigned int replaced_reply_key : 1;
 
     krb5_crypto armor_crypto;
 

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1969,15 +1969,18 @@ server_lookup:
 		goto out; /* kdc_check_flags() calls _kdc_audit_addreason() */
 
 	    /* If we were about to put a PAC into the ticket, we better fix it to be the right PAC */
-	    if (mspac) {
-		krb5_pac_free(context, mspac);
-		mspac = NULL;
-		ret = _kdc_pac_generate(context, s4u2self_impersonated_client, &mspac);
-		if (ret) {
-		    kdc_log(context, config, 4, "PAC generation failed for -- %s",
-			    tpn);
-		    goto out;
-		}
+	    krb5_pac_free(context, mspac);
+	    mspac = NULL;
+
+	    ret = _kdc_pac_generate(context,
+				    s4u2self_impersonated_client,
+				    server,
+				    NULL,
+				    NULL,
+				    &mspac);
+	    if (ret) {
+		kdc_log(context, config, 4, "PAC generation failed for -- %s", tpn);
+		goto out;
 	    }
 
 	    /*

--- a/kdc/windc_plugin.h
+++ b/kdc/windc_plugin.h
@@ -54,7 +54,11 @@ struct hdb_entry_ex;
 
 typedef krb5_error_code
 (KRB5_CALLCONV *krb5plugin_windc_pac_generate)(void *, krb5_context,
-				 struct hdb_entry_ex *, krb5_pac *);
+					       struct hdb_entry_ex *, /* client */
+					       struct hdb_entry_ex *, /* server */
+					       const krb5_keyblock *, /* pk_replykey */
+					       const krb5_boolean *, /* pac_request */
+					       krb5_pac *);
 
 typedef krb5_error_code
 (KRB5_CALLCONV *krb5plugin_windc_pac_verify)(void *, krb5_context,
@@ -74,7 +78,7 @@ typedef krb5_error_code
 	KDC_REQ *, METHOD_DATA *);
 
 
-#define KRB5_WINDC_PLUGIN_MINOR			6
+#define KRB5_WINDC_PLUGIN_MINOR			7
 #define KRB5_WINDC_PLUGING_MINOR KRB5_WINDC_PLUGIN_MINOR
 
 typedef struct krb5plugin_windc_ftable {

--- a/tests/plugin/windc.c
+++ b/tests/plugin/windc.c
@@ -20,10 +20,19 @@ windc_fini(void *ctx)
 
 static krb5_error_code KRB5_CALLCONV
 pac_generate(void *ctx, krb5_context context,
-	     struct hdb_entry_ex *client, krb5_pac *pac)
+	     struct hdb_entry_ex *client,
+	     struct hdb_entry_ex *server,
+	     const krb5_keyblock *pk_replykey,
+	     const krb5_boolean *pac_request,
+	     krb5_pac *pac)
 {
     krb5_error_code ret;
     krb5_data data;
+
+    if (pac_request != NULL && *pac_request == FALSE) {
+	*pac = NULL;
+	return 0;
+    }
 
     krb5_warnx(context, "pac generate");
 

--- a/tests/plugin/windc.c
+++ b/tests/plugin/windc.c
@@ -5,7 +5,7 @@
 #include <kdc.h>
 #include <windc_plugin.h>
 
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 windc_init(krb5_context context, void **ctx)
 {
     krb5_warnx(context, "windc init");
@@ -13,12 +13,12 @@ windc_init(krb5_context context, void **ctx)
     return 0;
 }
 
-static void
+static void KRB5_CALLCONV
 windc_fini(void *ctx)
 {
 }
 
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 pac_generate(void *ctx, krb5_context context,
 	     struct hdb_entry_ex *client, krb5_pac *pac)
 {
@@ -41,7 +41,7 @@ pac_generate(void *ctx, krb5_context context,
     return 0;
 }
 
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 pac_verify(void *ctx, krb5_context context,
 	   const krb5_principal new_ticket_client,
 	   const krb5_principal delegation_proxy,
@@ -84,7 +84,7 @@ pac_verify(void *ctx, krb5_context context,
     return krb5_pac_verify(context, *pac, 0, NULL, NULL, &key->key);
 }
 
-static krb5_error_code
+static krb5_error_code KRB5_CALLCONV
 client_access(void *ctx,
 	      krb5_context context,
 	      krb5_kdc_configuration *config,
@@ -110,13 +110,13 @@ static const krb5plugin_windc_ftable *const windc_plugins[] = {
     &windc
 };
 
-krb5_error_code
+krb5_error_code KRB5_CALLCONV
 windc_plugin_load(krb5_context context,
 		       krb5_get_instance_func_t *get_instance,
 		       size_t *num_plugins,
 		       const krb5plugin_windc_ftable *const **plugins);
 
-static uintptr_t
+static uintptr_t KRB5_CALLCONV
 windc_get_instance(const char *libname)
 {
     if (strcmp(libname, "hdb") == 0)
@@ -127,7 +127,7 @@ windc_get_instance(const char *libname)
     return 0;
 }
 
-krb5_error_code
+krb5_error_code KRB5_CALLCONV
 windc_plugin_load(krb5_context context,
 		  krb5_get_instance_func_t *get_instance,
 		  size_t *num_plugins,


### PR DESCRIPTION
Samba includes the user's long-term credentials (encrypted in the AS reply key) to allow legacy authentication protocols such as NTLM to work even if the pre-authentication mechanism replaced the reply key (as PKINIT does).

Samba also needs to know whether the client explicitly requested a PAC be included (or excluded), in order to defer PAC exclusion until a service ticket is issued (thereby avoiding a name binding attack if the user is renamed between TGT and service ticket issuance).

References:

https://bugzilla.samba.org/show_bug.cgi?id=11441
https://bugzilla.samba.org/show_bug.cgi?id=14561

Closes: #864

Original authors:
 - Joseph Sutton <josephsutton@catalyst.net.nz>
 - Andrew Bartlett <abartlet@samba.org>
 - Stefan Metzmacher <metze@samba.org>