### PR TITLE
kdc: Add support for explicit armoring from MS-KILE

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -442,6 +442,8 @@ fast_unwrap_request(astgs_request_t r,
     krb5_flags ap_req_options;
     Key *armor_key = NULL;
     krb5_keyblock armorkey;
+    krb5_keyblock explicit_armorkey;
+    krb5_boolean explicit_armor;
     krb5_error_code ret;
     krb5_ap_req ap_req;
     KrbFastReq fastreq;
@@ -492,10 +494,12 @@ fast_unwrap_request(astgs_request_t r,
 	goto out;
     }
 
+    explicit_armor = fxreq.u.armored_data.armor != NULL && tgs_ac != NULL;
+
     /*
      *
      */
-    if (tgs_ac == NULL) {
+    if (fxreq.u.armored_data.armor != NULL) {
 	if (fxreq.u.armored_data.armor->armor_type != 1) {
 	    kdc_log(r->context, r->config, 4,
 		    "Incorrect AS-REQ armor type");
@@ -575,9 +579,21 @@ fast_unwrap_request(astgs_request_t r,
 			       ac->remote_subkey,
 			       &ticket->ticket.key,
 			       &armorkey,
-			       &r->armor_crypto);
+			       explicit_armor ? NULL : &r->armor_crypto);
     if (ret)
 	goto out;
+
+    if (explicit_armor) {
+	ret = _krb5_fast_explicit_armor_key(r->context,
+					    &armorkey,
+					    tgs_ac->remote_subkey,
+					    &explicit_armorkey,
+					    &r->armor_crypto);
+	if (ret)
+	    goto out;
+
+	krb5_free_keyblock_contents(r->context, &explicit_armorkey);
+    }
 
     krb5_free_keyblock_contents(r->context, &armorkey);
 

--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -96,6 +96,22 @@ _krb5_fast_armor_key(krb5_context context,
 			  armor_crypto);
 }
 
+KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
+_krb5_fast_explicit_armor_key(krb5_context context,
+			      krb5_keyblock *armorkey,
+			      krb5_keyblock *subkey,
+			      krb5_keyblock *explicit_armorkey,
+			      krb5_crypto *explicit_armor_crypto)
+{
+    return _krb5_fast_cf2(context,
+			  armorkey,
+			  "explicitarmor",
+			  subkey,
+			  "tgsarmor",
+			  explicit_armorkey,
+			  explicit_armor_crypto);
+}
+
 static krb5_error_code
 check_fast(krb5_context context, struct krb5_fast_state *state)
 {

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -875,6 +875,7 @@ EXPORTS
 	; FAST
 	_krb5_fast_cf2
 	_krb5_fast_armor_key
+	_krb5_fast_explicit_armor_key
 
 	; Recent additions
 	krb5_cc_type_dcc;

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -865,6 +865,7 @@ HEIMDAL_KRB5_2.0 {
 		# FAST
 		_krb5_fast_cf2;
 		_krb5_fast_armor_key;
+		_krb5_fast_explicit_armor_key;
 
                 # TGS
                 _krb5_find_capath;


### PR DESCRIPTION
This is required for compound identity.