### PR TITLE
heimdal: Make _krb5_pac_get_kdc_checksum_info() into a global function

### DIFF
--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -499,6 +499,7 @@ EXPORTS
 	krb5_pac_add_buffer
 	krb5_pac_free
 	krb5_pac_get_buffer
+	krb5_pac_get_kdc_checksum_info
 	krb5_pac_get_types
 	krb5_pac_init
 	krb5_pac_parse
@@ -822,7 +823,6 @@ EXPORTS
 	_krb5_pac_sign
 	_krb5_kdc_pac_sign_ticket
 	_krb5_kdc_pac_ticket_parse
-	_krb5_pac_get_kdc_checksum_info
 	_kdc_tkt_insert_pac
 	_kdc_tkt_add_if_relevant_ad
 	_krb5_parse_moduli

--- a/lib/krb5/pac.c
+++ b/lib/krb5/pac.c
@@ -1294,10 +1294,10 @@ out:
 }
 
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
-_krb5_pac_get_kdc_checksum_info(krb5_context context,
-				krb5_pac pac,
-				krb5_cksumtype *cstype,
-				uint16_t *rodc_id)
+krb5_pac_get_kdc_checksum_info(krb5_context context,
+			       krb5_pac pac,
+			       krb5_cksumtype *cstype,
+			       uint16_t *rodc_id)
 {
     krb5_error_code ret;
     krb5_storage *sp = NULL;

--- a/lib/krb5/test_pac.c
+++ b/lib/krb5/test_pac.c
@@ -823,9 +823,9 @@ check_ticket_signature(krb5_context context,
     if (ret)
 	t_err(context, tkt->name, "krb5_pac_verify ticket-sig", ret);
 
-    ret = _krb5_pac_get_kdc_checksum_info(context, pac, &cstype, &rodc_id);
+    ret = krb5_pac_get_kdc_checksum_info(context, pac, &cstype, &rodc_id);
     if (ret)
-	t_err(context, tkt->name, "_krb5_pac_get_kdc_checksum_info", ret);
+	t_err(context, tkt->name, "krb5_pac_get_kdc_checksum_info", ret);
 
     heim_assert(cstype == CKSUMTYPE_HMAC_MD5, "Wrong checksum type");
     heim_assert(rodc_id == tkt->rodc_id, "Wrong RODCIdentifier");
@@ -874,9 +874,9 @@ check_ticket_signature(krb5_context context,
     if (ret)
 	t_err(context, tkt->name, "krb5_pac_verify ticket-sig 2", ret);
 
-    ret = _krb5_pac_get_kdc_checksum_info(context, pac, &cstype, &rodc_id);
+    ret = krb5_pac_get_kdc_checksum_info(context, pac, &cstype, &rodc_id);
     if (ret)
-	t_err(context, tkt->name, "_krb5_pac_get_kdc_checksum_info 2", ret);
+	t_err(context, tkt->name, "krb5_pac_get_kdc_checksum_info 2", ret);
 
     heim_assert(cstype == CKSUMTYPE_HMAC_MD5, "Wrong checksum type 2");
     heim_assert(rodc_id == tkt->rodc_id, "Wrong RODCIdentifier 2");

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -492,6 +492,7 @@ HEIMDAL_KRB5_2.0 {
 		krb5_pac_add_buffer;
 		krb5_pac_free;
 		krb5_pac_get_buffer;
+		krb5_pac_get_kdc_checksum_info;
 		krb5_pac_get_types;
 		krb5_pac_init;
 		krb5_pac_parse;
@@ -814,7 +815,6 @@ HEIMDAL_KRB5_2.0 {
 		_krb5_pac_sign;
 		_krb5_kdc_pac_sign_ticket;
 		_krb5_kdc_pac_ticket_parse;
-		_krb5_pac_get_kdc_checksum_info;
 		_kdc_tkt_insert_pac;
 		_kdc_tkt_add_if_relevant_ad;
 		_krb5_parse_moduli;

--- a/tests/plugin/windc.c
+++ b/tests/plugin/windc.c
@@ -64,7 +64,7 @@ pac_verify(void *ctx, krb5_context context,
 	return ret;
     krb5_data_free(&data);
 
-    ret = _krb5_pac_get_kdc_checksum_info(context, *pac, &cstype, &rodc_id);
+    ret = krb5_pac_get_kdc_checksum_info(context, *pac, &cstype, &rodc_id);
     if (ret)
 	return ret;
 


### PR DESCRIPTION
This lets us call it from Samba.