### PR TITLE
kdc: Check FAST authdata in ticket rather than in request body

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1199,11 +1199,11 @@ next_kvno:
 	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
 	    goto out;
 	}
-
-	ret = validate_fast_ad(r, *auth_data);
-	if (ret)
-	    goto out;
     }
+
+    ret = validate_fast_ad(r, (*ticket)->ticket.authorization_data);
+    if (ret)
+	goto out;
 
     
     /*


### PR DESCRIPTION
This matches Windows behaviour and the RFC6113 specification.