### PR TITLE
heimdal:kdc: Only check for default salt for des-cbc-crc enctype

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -119,6 +119,23 @@ is_default_salt_p(const krb5_salt *default_salt, const Key *key)
     return TRUE;
 }
 
+/*
+ * Detect if `key' is the using the the precomputed `default_salt'
+ * (for des-cbc-crc) or any salt otherwise.
+ *
+ * This is for avoiding Kerberos v4 (yes really) keys in AS-REQ as
+ * that salt is strange, and a buggy client will try to use the
+ * principal as the salt and not the returned value.
+ */
+
+static krb5_boolean
+is_good_salt_p(const krb5_salt *default_salt, const Key *key)
+{
+    if (key->key.keytype != (krb5_enctype)ETYPE_DES_CBC_CRC)
+	return TRUE;
+    return is_default_salt_p(default_salt, key);
+}
+
 
 krb5_boolean
 _kdc_is_anon_request(const KDC_REQ *req)
@@ -277,7 +294,7 @@ _kdc_find_etype(astgs_request_t r, uint32_t flags,
                         enctype = p[i];
                         ret = 0;
                         if (is_preauth && ret_key != NULL &&
-                            !is_default_salt_p(&def_salt, key))
+                            !is_good_salt_p(&def_salt, key))
                             continue;
                     }
                 }
@@ -310,7 +327,7 @@ _kdc_find_etype(astgs_request_t r, uint32_t flags,
                 enctype = etypes[i];
 		ret = 0;
 		if (is_preauth && ret_key != NULL &&
-		    !is_default_salt_p(&def_salt, key))
+		    !is_good_salt_p(&def_salt, key))
 		    continue;
 	    }
 	}


### PR DESCRIPTION
This function is used to prefer keys that have a default salt over keys that do not, to preserve compatibility with older clients that do not check the returned salt. With Active Directory salt generation, this can lead to RC4 keys (which do not use a salt) being preferred over AES keys (which use a non-default salt for machine accounts). To avoid this behaviour, we can apply this check only for the des-cbc-crc enctype.