### PR TITLE
Pass extra info to hdb_auth_status()

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -753,10 +753,12 @@ pa_enc_chal_validate(astgs_request_t r,
 	goto out;
     }
 
-    ret = KRB5KDC_ERR_PREAUTH_FAILED;
-
-    if (invalidPassword)
+    if (invalidPassword) {
 	auth_status->auth_status = HDB_AUTH_WRONG_PASSWORD;
+	ret = KRB5KDC_ERR_PREAUTH_FAILED;
+    } else {
+	ret = KRB5KDC_ERR_ETYPE_NOSUPP;
+    }
  out:
     free_EncryptedData(&enc_data);
 

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -507,7 +507,7 @@ pa_pkinit_validate(astgs_request_t r,
 	ret = KRB5KRB_AP_ERR_BAD_INTEGRITY;
 	_kdc_r_log(r, 4, "Failed to decode PKINIT PA-DATA -- %s",
 		   r->cname);
-	auth_status->auth_status = HDB_AUTH_PKINIT_FAILURE;
+	auth_status->auth_status = HDB_AUTHSTATUS_PKINIT_FAILURE;
 	goto out;
     }
 
@@ -515,7 +515,7 @@ pa_pkinit_validate(astgs_request_t r,
     if (ret) {
 	_kdc_set_e_text(r, "PKINIT certificate not allowed to "
 			"impersonate principal");
-	auth_status->auth_status = HDB_AUTH_PKINIT_FAILURE;
+	auth_status->auth_status = HDB_AUTHSTATUS_PKINIT_FAILURE;
 	goto out;
     }
     auth_status->auth_details = client_cert;
@@ -536,7 +536,7 @@ pa_pkinit_validate(astgs_request_t r,
     ret = _kdc_add_initial_verified_cas(r->context, r->config,
 					pkp, &r->et);
 
-    auth_status->auth_status = HDB_AUTH_PKINIT_SUCCESS;
+    auth_status->auth_status = HDB_AUTHSTATUS_PKINIT_SUCCESS;
  out:
     if (pkp)
 	_kdc_pk_free_client_param(r->context, pkp);
@@ -565,7 +565,7 @@ pa_gss_validate(astgs_request_t r,
 	if (ret) {
 	    _kdc_set_e_text(r, "GSS-API client not allowed to "
 			    "impersonate principal");
-	    auth_status->auth_status = HDB_AUTH_GSS_FAILURE;
+	    auth_status->auth_status = HDB_AUTHSTATUS_GSS_FAILURE;
 	    goto out;
 	}
 	auth_status->auth_details = client_name;
@@ -590,7 +590,7 @@ pa_gss_validate(astgs_request_t r,
 	goto out;
     }
 
-    auth_status->auth_status = HDB_AUTH_GSS_SUCCESS;
+    auth_status->auth_status = HDB_AUTHSTATUS_GSS_SUCCESS;
  out:
     if (gcp)
 	_kdc_gss_free_client_param(r, gcp);
@@ -624,7 +624,7 @@ pa_enc_chal_validate(astgs_request_t r,
        ret = KRB5KDC_ERR_CLIENT_REVOKED;
        kdc_log(r->context, r->config, 0,
                "Client (%s) is locked out", r->cname);
-       auth_status->auth_status = HDB_AUTH_CLIENT_LOCKED_OUT;
+       auth_status->auth_status = HDB_AUTHSTATUS_CLIENT_LOCKED_OUT;
        return ret;
     }
 
@@ -749,12 +749,12 @@ pa_enc_chal_validate(astgs_request_t r,
 	/*
 	 * Success
 	 */
-	auth_status->auth_status = HDB_AUTH_CORRECT_PASSWORD;
+	auth_status->auth_status = HDB_AUTHSTATUS_CORRECT_PASSWORD;
 	goto out;
     }
 
     if (invalidPassword) {
-	auth_status->auth_status = HDB_AUTH_WRONG_PASSWORD;
+	auth_status->auth_status = HDB_AUTHSTATUS_WRONG_PASSWORD;
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;
     } else {
 	ret = KRB5KDC_ERR_ETYPE_NOSUPP;
@@ -795,7 +795,7 @@ pa_enc_ts_validate(astgs_request_t r,
        ret = KRB5KDC_ERR_CLIENT_REVOKED;
        kdc_log(r->context, r->config, 0,
                "Client (%s) is locked out", r->cname);
-       auth_status->auth_status = HDB_AUTH_CLIENT_LOCKED_OUT;
+       auth_status->auth_status = HDB_AUTHSTATUS_CLIENT_LOCKED_OUT;
        return ret;
     }
 
@@ -866,7 +866,7 @@ pa_enc_ts_validate(astgs_request_t r,
 	krb5_free_error_message(r->context, msg);
 
 	free(auth_status->free_ptr);
-	auth_status->auth_status = HDB_AUTH_WRONG_PASSWORD;
+	auth_status->auth_status = HDB_AUTHSTATUS_WRONG_PASSWORD;
 	auth_status->auth_details = str ? str : "unknown enctype";
 	auth_status->free_ptr = str;
 
@@ -934,7 +934,7 @@ pa_enc_ts_validate(astgs_request_t r,
 	       r->cname, str ? str : "unknown enctype");
     _kdc_audit_addkv((kdc_request_t)r, 0, "pa-etype", "%d",
 		     (int)pa_key->key.keytype);
-    auth_status->auth_status = HDB_AUTH_CORRECT_PASSWORD;
+    auth_status->auth_status = HDB_AUTHSTATUS_CORRECT_PASSWORD;
     auth_status->auth_details = str ? str : "unknown enctype";
     auth_status->free_ptr = str;
 
@@ -2101,7 +2101,7 @@ _kdc_as_rep(astgs_request_t r)
     }
     default:
     {
-	struct kdc_pa_auth_status auth_status = {HDB_AUTH_CLIENT_UNKNOWN, NULL, NULL};
+	struct kdc_pa_auth_status auth_status = {HDB_AUTHSTATUS_CLIENT_UNKNOWN, NULL, NULL};
 	msg = krb5_get_error_message(r->context, ret);
 	kdc_log(r->context, config, 4, "UNKNOWN -- %s: %s", r->cname, msg);
 	krb5_free_error_message(r->context, msg);
@@ -2184,7 +2184,7 @@ _kdc_as_rep(astgs_request_t r)
 		    krb5_boolean default_salt;
 
 		    if (auth_status.auth_status == -1)
-			auth_status.auth_status = HDB_AUTH_GENERIC_FAILURE;
+			auth_status.auth_status = HDB_AUTHSTATUS_GENERIC_FAILURE;
 		    _kdc_audit_auth_status(r,
 					   &auth_status,
 					   pat[n].name);
@@ -2212,7 +2212,7 @@ _kdc_as_rep(astgs_request_t r)
 		r->replaced_reply_key = (pat[n].flags & PA_REPLACE_REPLY_KEY) != 0;
 
 		if (auth_status.auth_status == -1)
-			auth_status.auth_status = HDB_AUTH_GENERIC_SUCCESS;
+			auth_status.auth_status = HDB_AUTHSTATUS_GENERIC_SUCCESS;
 
 		_kdc_audit_auth_status(r,
 				       &auth_status,
@@ -2308,7 +2308,7 @@ _kdc_as_rep(astgs_request_t r)
 
     {
 	struct kdc_pa_auth_status auth_status
-		= {HDB_AUTHZ_SUCCESS,
+		= {HDB_AUTHSTATUS_AUTHORIZATION_SUCCESS,
 		   NULL,
 		   NULL};
 

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -881,7 +881,7 @@ pa_enc_ts_validate(astgs_request_t r,
     }
     free_EncryptedData(&enc_data);
     free(auth_status->free_ptr);
-    auth_status->auth_status = -1;
+    auth_status->auth_status = HDB_AUTHSTATUS_INVALID;
     auth_status->auth_details = NULL;
     auth_status->free_ptr = NULL;
     ret = decode_PA_ENC_TS_ENC(ts_data.data,
@@ -2167,7 +2167,7 @@ _kdc_as_rep(astgs_request_t r)
 	    i = 0;
 	    pa = _kdc_find_padata(req, &i, pat[n].type);
 	    if (pa) {
-		struct kdc_pa_auth_status auth_status = {-1, NULL, NULL};
+		struct kdc_pa_auth_status auth_status = {HDB_AUTHSTATUS_INVALID, NULL, NULL};
 
                 if (r->client->entry.flags.synthetic &&
                     !(pat[n].flags & PA_SYNTHETIC_OK)) {
@@ -2183,7 +2183,7 @@ _kdc_as_rep(astgs_request_t r)
 		    Key *ckey = NULL;
 		    krb5_boolean default_salt;
 
-		    if (auth_status.auth_status == -1)
+		    if (auth_status.auth_status == HDB_AUTHSTATUS_INVALID)
 			auth_status.auth_status = HDB_AUTHSTATUS_GENERIC_FAILURE;
 		    _kdc_audit_auth_status(r,
 					   &auth_status,
@@ -2211,7 +2211,7 @@ _kdc_as_rep(astgs_request_t r)
 
 		r->replaced_reply_key = (pat[n].flags & PA_REPLACE_REPLY_KEY) != 0;
 
-		if (auth_status.auth_status == -1)
+		if (auth_status.auth_status == HDB_AUTHSTATUS_INVALID)
 			auth_status.auth_status = HDB_AUTHSTATUS_GENERIC_SUCCESS;
 
 		_kdc_audit_auth_status(r,

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -82,10 +82,18 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
 /* auth status values */
 
 /*
+ * Un-initialised value, not permitted, used to indicate that a value
+ * wasn't set for the benifit of logic in the caller, must not be
+ * passed to hdb_auth_status()
+ */
+
+#define HDB_AUTHSTATUS_INVALID                  0
+
+/*
  * A ticket was issued after authorization was successfully completed
  * (eg flags on the entry and expiry times were checked)
  */
-#define HDB_AUTHZ_SUCCESS		0
+#define HDB_AUTHSTATUS_AUTHORIZATION_SUCCESS	1
 
 /*
  * The user supplied the wrong password to a password-based
@@ -93,13 +101,7 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
  *
  * The HDB backend might increment a bad password count.
  */
-#define HDB_AUTH_WRONG_PASSWORD		1
-
-/*
- * Unused, was added in 5c104ef172e974a7eec47c65dd76d6b030bed2a1 but
- * never set
- */
-#define HDB_AUTH_INVALID_SIGNATURE	2
+#define HDB_AUTHSTATUS_WRONG_PASSWORD		2
 
 /*
  * The user supplied a correct password to a password-based
@@ -107,48 +109,48 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
  *
  * The HDB backend might reset a bad password count.
  */
-#define HDB_AUTH_CORRECT_PASSWORD	3
+#define HDB_AUTHSTATUS_CORRECT_PASSWORD	        3
 
 /*
  * Attempted authenticaton with an unknown user
  */
-#define HDB_AUTH_CLIENT_UNKNOWN	4
+#define HDB_AUTHSTATUS_CLIENT_UNKNOWN	        4
 
 /*
  * Attempted authenticaton with an known user that is already locked
  * out.
  */
-#define HDB_AUTH_CLIENT_LOCKED_OUT	5
+#define HDB_AUTHSTATUS_CLIENT_LOCKED_OUT	5
 
 /*
  * Successful authentication with a pre-authentication mechanism
  */
-#define HDB_AUTH_GENERIC_SUCCESS	6
+#define HDB_AUTHSTATUS_GENERIC_SUCCESS	        6
 
 /*
  * Failed authentication with a pre-authentication mechanism
  */
-#define HDB_AUTH_GENERIC_FAILURE	7
+#define HDB_AUTHSTATUS_GENERIC_FAILURE	        7
 
 /*
  * Successful pre-authentication with PKINIT (smart card login etc)
  */
-#define HDB_AUTH_PKINIT_SUCCESS	8
+#define HDB_AUTHSTATUS_PKINIT_SUCCESS	        8
 
 /*
  * Failed pre-authentication with PKINIT (smart card login etc)
  */
-#define HDB_AUTH_PKINIT_FAILURE	9
+#define HDB_AUTHSTATUS_PKINIT_FAILURE	        9
 
 /*
  * Successful pre-authentication with GSS pre-authentication
  */
-#define HDB_AUTH_GSS_SUCCESS		10
+#define HDB_AUTHSTATUS_GSS_SUCCESS		10
 
 /*
  * Failed pre-authentication with GSS pre-authentication
  */
-#define HDB_AUTH_GSS_FAILURE		11
+#define HDB_AUTHSTATUS_GSS_FAILURE		11
 
 /* key usage for master key */
 #define HDB_KU_MKEY	0x484442

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -80,17 +80,74 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
 #define HDB_CAP_F_SHARED_DIRECTORY      8
 
 /* auth status values */
+
+/*
+ * A ticket was issued after authorization was successfully completed
+ * (eg flags on the entry and expiry times were checked)
+ */
 #define HDB_AUTHZ_SUCCESS		0
+
+/*
+ * The user supplied the wrong password to a password-based
+ * authentication mechanism (eg ENC-TS, ENC-CHAL)
+ *
+ * The HDB backend might increment a bad password count.
+ */
 #define HDB_AUTH_WRONG_PASSWORD		1
+
+/*
+ * Unused, was added in 5c104ef172e974a7eec47c65dd76d6b030bed2a1 but
+ * never set
+ */
 #define HDB_AUTH_INVALID_SIGNATURE	2
+
+/*
+ * The user supplied a correct password to a password-based
+ * authentication mechanism (eg ENC-TS, ENC-CHAL)
+ *
+ * The HDB backend might reset a bad password count.
+ */
 #define HDB_AUTH_CORRECT_PASSWORD	3
+
+/*
+ * Attempted authenticaton with an unknown user
+ */
 #define HDB_AUTH_CLIENT_UNKNOWN	4
+
+/*
+ * Attempted authenticaton with an known user that is already locked
+ * out.
+ */
 #define HDB_AUTH_CLIENT_LOCKED_OUT	5
+
+/*
+ * Successful authentication with a pre-authentication mechanism
+ */
 #define HDB_AUTH_GENERIC_SUCCESS	6
+
+/*
+ * Failed authentication with a pre-authentication mechanism
+ */
 #define HDB_AUTH_GENERIC_FAILURE	7
+
+/*
+ * Successful pre-authentication with PKINIT (smart card login etc)
+ */
 #define HDB_AUTH_PKINIT_SUCCESS	8
+
+/*
+ * Failed pre-authentication with PKINIT (smart card login etc)
+ */
 #define HDB_AUTH_PKINIT_FAILURE	9
+
+/*
+ * Successful pre-authentication with GSS pre-authentication
+ */
 #define HDB_AUTH_GSS_SUCCESS		10
+
+/*
+ * Failed pre-authentication with GSS pre-authentication
+ */
 #define HDB_AUTH_GSS_FAILURE		11
 
 /* key usage for master key */

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -80,9 +80,18 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
 #define HDB_CAP_F_SHARED_DIRECTORY      8
 
 /* auth status values */
-#define HDB_AUTH_SUCCESS		0
+#define HDB_AUTHZ_SUCCESS		0
 #define HDB_AUTH_WRONG_PASSWORD		1
 #define HDB_AUTH_INVALID_SIGNATURE	2
+#define HDB_AUTH_CORRECT_PASSWORD	3
+#define HDB_AUTH_CLIENT_UNKNOWN	4
+#define HDB_AUTH_CLIENT_LOCKED_OUT	5
+#define HDB_AUTH_GENERIC_SUCCESS	6
+#define HDB_AUTH_GENERIC_FAILURE	7
+#define HDB_AUTH_PKINIT_SUCCESS	8
+#define HDB_AUTH_PKINIT_FAILURE	9
+#define HDB_AUTH_GSS_SUCCESS		10
+#define HDB_AUTH_GSS_FAILURE		11
 
 /* key usage for master key */
 #define HDB_KU_MKEY	0x484442
@@ -280,7 +289,15 @@ typedef struct HDB {
      * In case the entry is locked out, the backend should set the
      * hdb_entry.flags.locked-out flag.
      */
-    krb5_error_code (*hdb_auth_status)(krb5_context, struct HDB *, hdb_entry_ex *, int);
+    krb5_error_code (*hdb_auth_status)(krb5_context,
+				       struct HDB *,
+				       hdb_entry_ex *,
+				       const struct timeval *start_time,
+				       const struct sockaddr *from_addr,
+				       const char *original_client_name,
+				       int auth_type,
+				       const char *auth_details,
+				       const char *pa_type);
     /**
      * Check if delegation is allowed.
      */


### PR DESCRIPTION
From a commit by @metze-samba and myself in Samba's lorikeet-heimdal repo.  

We need more information in our auditing hooks for Samba to fill in it's internal audit logs with.   A common helper function was added to make this maintainable.

@metze-samba I dropped to TODO on this as I think is well baked now. 