### PR TITLE
kdc: Don't conceal error code when using FAST

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -384,7 +384,6 @@ _kdc_fast_mk_error(astgs_request_t r,
 	    return ret;
 	}
 
-	outer_error = KRB5_KDC_ERR_MORE_PREAUTH_DATA_REQUIRED;
 	e_text = NULL;
 	if (r->fast.flags.requested_hidden_names) {
 	    error_client = NULL;

--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -605,9 +605,6 @@ _krb5_fast_unwrap_error(krb5_context context,
 
     memset(&fastrep, 0, sizeof(fastrep));
 
-    if (error->error_code != KRB5_KDC_ERR_MORE_PREAUTH_DATA_REQUIRED)
-	_krb5_debug(context, 10, "using FAST without FAST outer error code");
-
     idx = 0;
     pa = krb5_find_padata(md->val, md->len, KRB5_PADATA_FX_FAST, &idx);
     if (pa == NULL) {


### PR DESCRIPTION
This matches Windows behaviour, which also places the error code in the outer error.