### PR TITLE
Samba CVE-2020-25719 kdc: Require PAC to be present

### DIFF
--- a/kdc/default_config.c
+++ b/kdc/default_config.c
@@ -100,6 +100,7 @@ krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
     c->historical_anon_realm = FALSE;
     c->strict_nametypes = FALSE;
     c->trpolicy = TRPOLICY_ALWAYS_CHECK;
+    c->require_pac = FALSE;
     c->enable_armored_pa_enc_timestamp = TRUE;
     c->enable_unarmored_pa_enc_timestamp = TRUE;
     c->enable_pkinit = FALSE;
@@ -252,6 +253,14 @@ krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
 	krb5_config_get_time_default (context, NULL,
 				      c->kdc_warn_pwexpire,
 				      "kdc", "kdc_warn_pwexpire", NULL);
+
+    c->require_pac =
+	krb5_config_get_bool_default(context,
+				     NULL,
+				     c->require_pac,
+				     "kdc",
+				     "require_pac",
+				     NULL);
 
     c->enable_armored_pa_enc_timestamp =
 	krb5_config_get_bool_default(context,

--- a/kdc/kdc.h
+++ b/kdc/kdc.h
@@ -84,6 +84,7 @@ typedef struct krb5_kdc_configuration {
     krb5_boolean strict_nametypes;
     enum krb5_kdc_trpolicy trpolicy;
 
+    krb5_boolean require_pac;
     krb5_boolean enable_armored_pa_enc_timestamp;
     krb5_boolean enable_unarmored_pa_enc_timestamp;
 

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -74,8 +74,14 @@ check_PAC(krb5_context context,
     *ppac = NULL;
 
     ret = _krb5_kdc_pac_ticket_parse(context, tkt, &signedticket, &pac);
-    if (ret || pac == NULL)
+    if (ret)
 	return ret;
+
+    if (pac == NULL) {
+	if (config->require_pac)
+	    ret = KRB5KDC_ERR_TGT_REVOKED;
+	return ret;
+    }
 
     /* Verify the server signature. */
     ret = krb5_pac_verify(context, pac, tkt->authtime, client_principal,


### PR DESCRIPTION
This allows Heimdal to match AD behaviour, when configured,
for the behaviour after Microsoft's CVE-2021-42287 when
PacRequestorEnforcement is set to 2.

Samba BUG: https://bugzilla.samba.org/show_bug.cgi?id=14686
REF: https://support.microsoft.com/en-au/topic/kb5008380-authentication-updates-cve-2021-42287-9dafac11-e0d0-4cb8-959a-143bd0201041

Signed-off-by: Joseph Sutton <josephsutton@catalyst.net.nz>
Reviewed-by: Andrew Bartlett <abartlet@samba.org>

[abarlet@samba.org based on Samba commit
 756934f14cc87dc1adfd9315672ae5d49cb24d95
 and f7a2fef8f49a86f63c3dc2f6a2d7d979fb53238a]

This will aid in #891 by introducing the required flag.