### PR TITLE
kdc: Don't advertise padata types that will not be accepted

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2179,6 +2179,16 @@ _kdc_as_rep(astgs_request_t r)
 	for (n = 0; n < sizeof(pat) / sizeof(pat[0]); n++) {
 	    if ((pat[n].flags & PA_ANNOUNCE) == 0)
 		continue;
+
+	    if (!r->armor_crypto && (pat[n].flags & PA_REQ_FAST))
+		continue;
+	    if (pat[n].type == KRB5_PADATA_ENC_TIMESTAMP) {
+		if (r->armor_crypto && !r->config->enable_armored_pa_enc_timestamp)
+		    continue;
+		if (!r->armor_crypto && !r->config->enable_unarmored_pa_enc_timestamp)
+		    continue;
+	    }
+
 	    ret = krb5_padata_add(r->context, &r->outpadata,
 				  pat[n].type, NULL, 0);
 	    if (ret)


### PR DESCRIPTION
Instead of always advertising PADATA-ENCRYPTED-CHALLENGE, we only advertise it if FAST is in use.

We also check configuration options to only advertise PADATA-ENC-TIMESTAMP if it will be accepted based on whether FAST is currently in use. This permits the non-RFC behaviour required to avoid breaking earlier Heimdal clients.

This incorporates changes from Apple Heimdal-597.140.2.