### PR TITLE
tgs-rep: always return canonical realm even if canonicalize falg is not set, same as Windows.

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -611,7 +611,11 @@ tgs_make_reply(astgs_request_t r,
     if(ret)
 	goto out;
 
-    ret = copy_Realm(&server_principal->realm, &rep.ticket.realm);
+    if (server->entry.flags.force_canonicalize)
+	ret = copy_Realm(&server->entry.principal->realm, &rep.ticket.realm);
+    else
+	ret = copy_Realm(&server_principal->realm, &rep.ticket.realm);
+
     if (ret)
 	goto out;
     _krb5_principal2principalname(&rep.ticket.sname, server_principal);


### PR DESCRIPTION
This is an import of an older Samba commit, updated over time in our lorikeet-heimdal tree we would like to get upstream if possible.

The AD-behaviour regression was introduced by upstream commit:
378f34b4be9865ed3949918fba8d2dd877b395c0

Signed-off-by: Isaac Boukris <iboukris@gmail.com>

[abartlet@samba.org Similar to Samba commit a9e6119ca0c2a78ef314c3162122539ee834aa04
 but made conditional on server->entry.flags.force_canonicalize to
 allow upstream submission]