### PR TITLE
kdc: allow cross-realm FAST armor TGT

### DIFF
--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -102,6 +102,9 @@ struct astgs_request_desc {
     unsigned int replaced_reply_key : 1;
 
     krb5_crypto armor_crypto;
+    hdb_entry_ex *armor_server;
+    krb5_ticket *armor_ticket;
+    Key *armor_key;
 
     KDCFastState fast;
 };

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2739,6 +2739,10 @@ out:
 	krb5_crypto_destroy(r->context, r->armor_crypto);
 	r->armor_crypto = NULL;
     }
+    if (r->armor_ticket)
+	krb5_free_ticket(r->context, r->armor_ticket);
+    if (r->armor_server)
+	_kdc_free_ent(r->context, r->armor_server);
     krb5_free_keyblock_contents(r->context, &r->reply_key);
     krb5_free_keyblock_contents(r->context, &r->session_key);
     krb5_free_keyblock_contents(r->context, &r->strengthen_key);

--- a/lib/asn1/krb5.asn1
+++ b/lib/asn1/krb5.asn1
@@ -215,6 +215,7 @@ AUTHDATA-TYPE ::= INTEGER {
 	KRB5-AUTHDATA-SIGNTICKET-OLDER(-17),
 	KRB5-AUTHDATA-SIGNTICKET-OLD(142),
 	KRB5-AUTHDATA-SIGNTICKET(512),
+	KRB5-AUTHDATA-SYNTHETIC-PRINC-USED(513), -- principal was synthetised
 	KRB5-AUTHDATA-AP-OPTIONS(143),
         -- N.B. these assignments have not been confirmed yet.
         --

--- a/tests/kdc/check-fast.in
+++ b/tests/kdc/check-fast.in
@@ -148,10 +148,18 @@ for mech in sanon-x25519 spnego ; do
 	--anonymous --gss-mech=${mech} @$R 2>/dev/null || \
 	{ ec=1 ; eval "${testfailed}"; }
 
+    echo "Getting service ticket"
+    ${kgetcred} ${server}@${R} || { exit 1; }
+    ${kdestroy}
+
     echo "Trying ${mech} pre-authentication with anonymous FAST armor"; > messages.log
     ${kinit} --pk-anon-fast-armor \
 	--anonymous --gss-mech=${mech} @$R 2>/dev/null || \
 	{ ec=1 ; eval "${testfailed}"; }
+
+    echo "Getting service ticket"
+    ${kgetcred} ${server}@${R} || { exit 1; }
+    ${kdestroy}
 
     echo "Trying ${mech} pre-authentication with no FAST armor"; > messages.log
     ${kinit} \


### PR DESCRIPTION
08e0305b introduced a patch to validate armor ticket PACs, but required that the armor client principal was in the local realm (as it did not allow _kdc_db_fetch() to fail).

Allwo cross-realm FAST armor clients by using the same logic to look up the client principal as the TGS itself does, i.e. use db_fetch_client() which ignores HDB_ERR_NOT_FOUND_HERE.