### PR TITLE
kdc: add finalize_reply API to windc plugin

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2746,6 +2746,13 @@ _kdc_as_rep(astgs_request_t r)
     }
 
     /*
+     * Last chance for plugins to update reply
+     */
+    ret = _kdc_finalize_reply(r, &r->rep, &r->et, &r->ek);
+    if (ret)
+	goto out;
+
+    /*
      * Don't send kvno from client entry if the pre-authentication
      * mechanism replaced the reply key.
      */

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -846,6 +846,10 @@ tgs_make_reply(astgs_request_t r,
 	}
     }
 
+    ret = _kdc_finalize_reply(r, &rep, &et, &ek);
+    if (ret)
+	goto out;
+
     /* It is somewhat unclear where the etype in the following
        encryption should come from. What we have is a session
        key in the passed tgt, and a list of preferred etypes

--- a/kdc/windc_plugin.h
+++ b/kdc/windc_plugin.h
@@ -77,8 +77,17 @@ typedef krb5_error_code
 	hdb_entry_ex *, const char *, 
 	KDC_REQ *, METHOD_DATA *);
 
+typedef krb5_error_code
+(KRB5_CALLCONV *krb5plugin_windc_finalize_reply)(void *,
+						krb5_context context,
+						krb5_kdc_configuration *config,
+						hdb_entry_ex *client,
+						hdb_entry_ex *server,
+						KDC_REP *rep,
+						EncTicketPart *et,
+						EncKDCRepPart *ek);
 
-#define KRB5_WINDC_PLUGIN_MINOR			7
+#define KRB5_WINDC_PLUGIN_MINOR			8
 #define KRB5_WINDC_PLUGING_MINOR KRB5_WINDC_PLUGIN_MINOR
 
 typedef struct krb5plugin_windc_ftable {
@@ -88,6 +97,7 @@ typedef struct krb5plugin_windc_ftable {
     krb5plugin_windc_pac_generate	pac_generate;
     krb5plugin_windc_pac_verify		pac_verify;
     krb5plugin_windc_client_access	client_access;
+    krb5plugin_windc_finalize_reply	finalize_reply;
 } krb5plugin_windc_ftable;
 
 #endif /* HEIMDAL_KDC_WINDC_PLUGIN_H */

--- a/tests/plugin/windc.c
+++ b/tests/plugin/windc.c
@@ -107,13 +107,25 @@ client_access(void *ctx,
     return 0;
 }
 
+static krb5_error_code KRB5_CALLCONV
+finalize_reply(void *ctx,
+	      krb5_context context,
+	      krb5_kdc_configuration *config,
+	      hdb_entry_ex *client, hdb_entry_ex *server,
+	      KDC_REP *rep, EncTicketPart *et, EncKDCRepPart *ek)
+{
+    krb5_warnx(context, "finalize_reply");
+    return 0;
+}
+
 static krb5plugin_windc_ftable windc = {
     KRB5_WINDC_PLUGING_MINOR,
     windc_init,
     windc_fini,
     pac_generate,
     pac_verify,
-    client_access
+    client_access,
+    finalize_reply
 };
 
 static const krb5plugin_windc_ftable *const windc_plugins[] = {


### PR DESCRIPTION
Allow a windc plugin to finalize the KDC reply (including the encrypted ticket and reply parts) before encoding for transmission.