### PR TITLE
Make part of astgs_request_t public

### DIFF
--- a/kdc/gss_preauth.c
+++ b/kdc/gss_preauth.c
@@ -1017,7 +1017,7 @@ pa_gss_display_name(gss_name_t name,
 
 struct pa_gss_finalize_pac_plugin_ctx {
     astgs_request_t r;
-    krb5_pac mspac;
+    krb5_pac pac;
     krb5_data *pac_data;
 };
 
@@ -1031,7 +1031,7 @@ pa_gss_finalize_pac_cb(krb5_context context,
     struct pa_gss_finalize_pac_plugin_ctx *pa_gss_finalize_pac_ctx = userctx;
 
     return authorizer->finalize_pac(plugctx, context,
-				    pa_gss_finalize_pac_ctx->mspac,
+				    pa_gss_finalize_pac_ctx->pac,
 				    pa_gss_finalize_pac_ctx->pac_data);
 }
 
@@ -1039,12 +1039,12 @@ pa_gss_finalize_pac_cb(krb5_context context,
 krb5_error_code
 _kdc_gss_finalize_pac(astgs_request_t r,
 		      gss_client_params *gcp,
-		      krb5_pac mspac)
+		      krb5_pac pac)
 {
     krb5_error_code ret;
     struct pa_gss_finalize_pac_plugin_ctx ctx;
 
-    ctx.mspac = mspac;
+    ctx.pac = pac;
     ctx.pac_data = &gcp->pac_data;
 
     krb5_clear_error_message(r->context);

--- a/kdc/gss_preauth.c
+++ b/kdc/gss_preauth.c
@@ -816,12 +816,12 @@ _kdc_gss_mk_pa_reply(astgs_request_t r,
 
     /* only return padata in error case if we have an error token */
     if (!GSS_ERROR(gcp->major) || gcp->output_token.length) {
-        ret = krb5_padata_add(r->context, &r->outpadata, KRB5_PADATA_GSS,
+        ret = krb5_padata_add(r->context, r->rep.padata, KRB5_PADATA_GSS,
                               gcp->output_token.value, gcp->output_token.length);
         if (ret)
             return ret;
 
-        /* token is now owned by outpadata */
+        /* token is now owned by r->rep.padata */
         gcp->output_token.length = 0;
         gcp->output_token.value = NULL;
     }

--- a/kdc/gss_preauth.c
+++ b/kdc/gss_preauth.c
@@ -510,10 +510,8 @@ pa_gss_authorize_cb(krb5_context context,
     const krb5plugin_gss_preauth_authorizer_ftable *authorizer = plug;
     struct pa_gss_authorize_plugin_ctx *pa_gss_authorize_plugin_ctx = userctx;
 
-    return authorizer->authorize(plugctx, context,
-                                 &pa_gss_authorize_plugin_ctx->r->req,
-                                 pa_gss_authorize_plugin_ctx->r->client_princ,
-                                 pa_gss_authorize_plugin_ctx->r->client,
+    return authorizer->authorize(plugctx,
+                                 pa_gss_authorize_plugin_ctx->r,
                                  pa_gss_authorize_plugin_ctx->gcp->initiator_name,
                                  pa_gss_authorize_plugin_ctx->gcp->mech_type,
                                  pa_gss_authorize_plugin_ctx->gcp->flags,
@@ -1017,7 +1015,6 @@ pa_gss_display_name(gss_name_t name,
 
 struct pa_gss_finalize_pac_plugin_ctx {
     astgs_request_t r;
-    krb5_pac pac;
     krb5_data *pac_data;
 };
 
@@ -1030,21 +1027,20 @@ pa_gss_finalize_pac_cb(krb5_context context,
     const krb5plugin_gss_preauth_authorizer_ftable *authorizer = plug;
     struct pa_gss_finalize_pac_plugin_ctx *pa_gss_finalize_pac_ctx = userctx;
 
-    return authorizer->finalize_pac(plugctx, context,
-				    pa_gss_finalize_pac_ctx->pac,
+    return authorizer->finalize_pac(plugctx,
+				    pa_gss_finalize_pac_ctx->r,
 				    pa_gss_finalize_pac_ctx->pac_data);
 }
 
 
 krb5_error_code
 _kdc_gss_finalize_pac(astgs_request_t r,
-		      gss_client_params *gcp,
-		      krb5_pac pac)
+		      gss_client_params *gcp)
 {
     krb5_error_code ret;
     struct pa_gss_finalize_pac_plugin_ctx ctx;
 
-    ctx.pac = pac;
+    ctx.r = r;
     ctx.pac_data = &gcp->pac_data;
 
     krb5_clear_error_message(r->context);

--- a/kdc/gss_preauth_authorizer_plugin.h
+++ b/kdc/gss_preauth_authorizer_plugin.h
@@ -64,10 +64,7 @@ typedef struct krb5plugin_gss_preauth_authorizer_ftable_desc {
     krb5_error_code     (KRB5_LIB_CALL *init)(krb5_context, void **);
     void                (KRB5_LIB_CALL *fini)(void *);
     krb5_error_code     (KRB5_LIB_CALL *authorize)(void *,              /*plug_ctx*/
-                                                   krb5_context,        /*context*/
-                                                   KDC_REQ *,           /*req*/
-                                                   krb5_const_principal,/*client_name*/
-                                                   hdb_entry_ex *,      /*client*/
+                                                   astgs_request_t,	/*r*/
                                                    gss_const_name_t,    /*initiator_name*/
                                                    gss_const_OID,       /*mech_type*/
                                                    OM_uint32,           /*ret_flags*/
@@ -75,8 +72,7 @@ typedef struct krb5plugin_gss_preauth_authorizer_ftable_desc {
                                                    krb5_principal *,    /*mapped_name*/
                                                    krb5_data *);        /*pac_data*/
     krb5_error_code     (KRB5_LIB_CALL *finalize_pac)(void *,           /*plug_ctx*/
-                                                      krb5_context,     /*context*/
-                                                      krb5_pac,         /*pac*/
+                                                      astgs_request_t,  /*r*/
                                                       krb5_data *);     /*pac_data*/
 } krb5plugin_gss_preauth_authorizer_ftable;
 

--- a/kdc/kdc.h
+++ b/kdc/kdc.h
@@ -46,6 +46,10 @@
 #include <kx509_asn1.h>
 #include <gssapi/gssapi.h>
 
+#define heim_pcontext krb5_context
+#define heim_pconfig krb5_kdc_configuration *
+#include <heimbase-svc.h>
+
 enum krb5_kdc_trpolicy {
     TRPOLICY_ALWAYS_CHECK,
     TRPOLICY_ALLOW_PER_PRINCIPAL,
@@ -124,6 +128,34 @@ typedef struct krb5_kdc_configuration {
     const char *app;
 } krb5_kdc_configuration;
 
+#define ASTGS_REQUEST_DESC_COMMON_ELEMENTS			\
+    HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;			\
+								\
+    KDC_REQ req;						\
+								\
+    KDC_REP rep;						\
+    EncTicketPart et;						\
+    EncKDCRepPart ek;						\
+								\
+    /* princ requested by client (AS) or canon princ (TGT) */	\
+    krb5_principal client_princ;				\
+    hdb_entry_ex *client;					\
+    HDB *clientdb;						\
+								\
+    krb5_principal server_princ;				\
+    hdb_entry_ex *server;					\
+								\
+    krb5_keyblock reply_key;					\
+								\
+    krb5_pac pac;						\
+    uint64_t pac_attributes;
+
+#ifndef __KDC_LOCL_H__
+struct astgs_request_desc {
+    ASTGS_REQUEST_DESC_COMMON_ELEMENTS
+};
+#endif
+
 typedef struct kdc_request_desc *kdc_request_t;
 typedef struct astgs_request_desc *astgs_request_t;
 typedef struct kx509_req_context_desc *kx509_req_context;
@@ -137,5 +169,8 @@ struct krb5_kdc_service {
 };
 
 #include <kdc-protos.h>
+
+#undef heim_pcontext
+#undef heim_pconfig
 
 #endif

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -70,8 +70,6 @@ struct kdc_patypes;
 struct astgs_request_desc {
     ASTGS_REQUEST_DESC_COMMON_ELEMENTS;
 
-    METHOD_DATA outpadata;
-
     /* Only AS */
     const struct kdc_patypes *pa_used;
     struct as_request_pa_state *pa_state;

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -67,28 +67,6 @@ struct kdc_request_desc {
 struct as_request_pa_state;
 struct kdc_patypes;
 
-#define ASTGS_REQUEST_DESC_COMMON_ELEMENTS			\
-    HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;			\
-								\
-    KDC_REQ req;						\
-								\
-    KDC_REP rep;						\
-    EncTicketPart et;						\
-    EncKDCRepPart ek;						\
-								\
-    /* princ requested by client (AS) or canon princ (TGT) */	\
-    krb5_principal client_princ;				\
-    hdb_entry_ex *client;					\
-    HDB *clientdb;						\
-								\
-    krb5_principal server_princ;				\
-    hdb_entry_ex *server;					\
-								\
-    krb5_keyblock reply_key;					\
-								\
-    krb5_pac pac;						\
-    uint64_t pac_attributes;
-
 struct astgs_request_desc {
     ASTGS_REQUEST_DESC_COMMON_ELEMENTS;
 

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -67,11 +67,30 @@ struct kdc_request_desc {
 struct as_request_pa_state;
 struct kdc_patypes;
 
-struct astgs_request_desc {
-    HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;
+#define ASTGS_REQUEST_DESC_COMMON_ELEMENTS			\
+    HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;			\
+								\
+    KDC_REQ req;						\
+								\
+    KDC_REP rep;						\
+    EncTicketPart et;						\
+    EncKDCRepPart ek;						\
+								\
+    /* princ requested by client (AS) or canon princ (TGT) */	\
+    krb5_principal client_princ;				\
+    hdb_entry_ex *client;					\
+    HDB *clientdb;						\
+								\
+    krb5_principal server_princ;				\
+    hdb_entry_ex *server;					\
+								\
+    krb5_keyblock reply_key;					\
+								\
+    krb5_pac pac;						\
+    uint64_t pac_attributes;
 
-    /* Both AS and TGS */
-    KDC_REQ req;
+struct astgs_request_desc {
+    ASTGS_REQUEST_DESC_COMMON_ELEMENTS;
 
     /* Only AS */
     METHOD_DATA *padata;
@@ -79,24 +98,10 @@ struct astgs_request_desc {
     const struct kdc_patypes *pa_used;
     struct as_request_pa_state *pa_state;
 
-    KDC_REP rep;
-    EncTicketPart et;
-    EncKDCRepPart ek;
-
     /* PA methods can affect both the reply key and the session key (pkinit) */
     krb5_enctype sessionetype;
-    krb5_keyblock reply_key;
     krb5_keyblock session_key;
 
-    /* state */
-    krb5_principal client_princ; /* AS: principal requested by client
-				  * TGS: opt. canon principal from TGT PAC */
-    hdb_entry_ex *client;	 /* AS: client entry
-				  * TGS: opt. client entry, if local to KDC */
-    HDB *clientdb;
-
-    krb5_principal server_princ;
-    hdb_entry_ex *server;
     krb5_timestamp pa_endtime;
     krb5_timestamp pa_max_life;
 
@@ -113,8 +118,6 @@ struct astgs_request_desc {
     Key *armor_key;
 
     KDCFastState fast;
-
-    uint64_t pac_attributes;
 };
 
 typedef struct kx509_req_context_desc {

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -71,7 +71,6 @@ struct astgs_request_desc {
     ASTGS_REQUEST_DESC_COMMON_ELEMENTS;
 
     /* Only AS */
-    METHOD_DATA *padata;
     METHOD_DATA outpadata;
     const struct kdc_patypes *pa_used;
     struct as_request_pa_state *pa_state;

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -70,8 +70,9 @@ struct kdc_patypes;
 struct astgs_request_desc {
     ASTGS_REQUEST_DESC_COMMON_ELEMENTS;
 
-    /* Only AS */
     METHOD_DATA outpadata;
+
+    /* Only AS */
     const struct kdc_patypes *pa_used;
     struct as_request_pa_state *pa_state;
 

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -611,7 +611,7 @@ pa_gss_finalize_pac(astgs_request_t r)
 
     heim_assert(gcp != NULL, "invalid GSS-API client params");
 
-    return _kdc_gss_finalize_pac(r, gcp, r->pac);
+    return _kdc_gss_finalize_pac(r, gcp);
 }
 
 static void

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2746,6 +2746,13 @@ _kdc_as_rep(astgs_request_t r)
     }
 
     /*
+     * Last chance for plugins to update reply
+     */
+    ret = _kdc_finalize_reply(r);
+    if (ret)
+	goto out;
+
+    /*
      * Don't send kvno from client entry if the pre-authentication
      * mechanism replaced the reply key.
      */

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1086,7 +1086,6 @@ _kdc_encode_reply(krb5_context context,
 		  int skvno, const EncryptionKey *skey,
 		  int ckvno,
 		  int rk_is_subkey,
-		  const char **e_text,
 		  krb5_data *reply)
 {
     unsigned char *buf;
@@ -1215,7 +1214,7 @@ _kdc_encode_reply(krb5_context context,
     if(buf_size != len) {
 	free(buf);
 	kdc_log(context, config, 4, "Internal error in ASN.1 encoder");
-	*e_text = "KDC internal error";
+	_kdc_set_e_text(r, "KDC internal error");
 	return KRB5KRB_ERR_GENERIC;
     }
     ret = krb5_crypto_init(context, &r->reply_key, 0, &crypto);
@@ -1257,7 +1256,7 @@ _kdc_encode_reply(krb5_context context,
     if(buf_size != len) {
 	free(buf);
 	kdc_log(context, config, 4, "Internal error in ASN.1 encoder");
-	*e_text = "KDC internal error";
+	_kdc_set_e_text(r, "KDC internal error");
 	return KRB5KRB_ERR_GENERIC;
     }
     reply->data = buf;
@@ -2755,7 +2754,7 @@ _kdc_as_rep(astgs_request_t r)
 			    r, req->req_body.nonce, setype,
 			    r->server->entry.kvno, &skey->key,
 			    pa_used_flag_isset(r, PA_REPLACE_REPLY_KEY) ? 0 : r->client->entry.kvno,
-			    0, &r->e_text, r->reply);
+			    0, r->reply);
     if (ret)
 	goto out;
 

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2381,7 +2381,7 @@ _kdc_as_rep(astgs_request_t r)
      * with in a preauth mech.
      */
 
-    ret = _kdc_check_access(r, req, &r->outpadata);
+    ret = _kdc_check_access(r, &r->outpadata);
     if(ret)
 	goto out;
 

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -603,7 +603,6 @@ tgs_make_reply(astgs_request_t r,
 	       krb5_boolean add_ticket_sig)
 {
     KDC_REQ_BODY *b = &r->req.req_body;
-    const char **e_text = &r->e_text;
     krb5_data *reply = r->reply;
     KDC_REP *rep = &r->rep;
     EncTicketPart *et = &r->et;
@@ -845,8 +844,7 @@ tgs_make_reply(astgs_request_t r,
        DES3? */
     ret = _kdc_encode_reply(r->context, r->config, r, b->nonce,
 			    serverkey->keytype, kvno,
-			    serverkey, 0, r->rk_is_subkey,
-			    e_text, reply);
+			    serverkey, 0, r->rk_is_subkey, reply);
     if (is_weak)
 	krb5_enctype_disable(r->context, serverkey->keytype);
 

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -841,6 +841,10 @@ tgs_make_reply(astgs_request_t r,
 	}
     }
 
+    ret = _kdc_finalize_reply(r);
+    if (ret)
+	goto out;
+
     /* It is somewhat unclear where the etype in the following
        encryption should come from. What we have is a session
        key in the passed tgt, and a list of preferred etypes

--- a/kdc/pkinit.c
+++ b/kdc/pkinit.c
@@ -1137,7 +1137,7 @@ _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
     const krb5_data *req_buffer = &r->request;
     krb5_keyblock *reply_key = &r->reply_key;
     krb5_keyblock *sessionkey = &r->session_key;
-    METHOD_DATA *md = &r->outpadata;
+    METHOD_DATA *md = r->rep.padata;
     krb5_error_code ret;
     void *buf = NULL;
     size_t len = 0, size = 0;

--- a/kdc/windc.c
+++ b/kdc/windc.c
@@ -234,6 +234,30 @@ _kdc_check_access(astgs_request_t r, METHOD_DATA *method_data)
     return ret;
 }
 
+static krb5_error_code KRB5_LIB_CALL
+finalize(krb5_context context, const void *plug, void *plugctx, void *userctx)
+{
+    krb5plugin_windc_ftable *ft = (krb5plugin_windc_ftable *)plug;
+
+    if (ft->finalize_reply == NULL)
+	return KRB5_PLUGIN_NO_HANDLE;
+    return ft->finalize_reply((void *)plug, (astgs_request_t)userctx);
+}
+
+krb5_error_code
+_kdc_finalize_reply(astgs_request_t r)
+{
+    krb5_error_code ret = KRB5_PLUGIN_NO_HANDLE;
+
+    if (have_plugin)
+        ret = _krb5_plugin_run_f(r->context, &windc_plugin_data, 0, r, finalize);
+
+    if (ret == KRB5_PLUGIN_NO_HANDLE)
+        ret = 0;
+
+    return ret;
+}
+
 uintptr_t KRB5_CALLCONV
 kdc_get_instance(const char *libname)
 {

--- a/kdc/windc.c
+++ b/kdc/windc.c
@@ -184,48 +184,24 @@ _kdc_pac_verify(krb5_context context,
 			     0, &uc, verify);
 }
 
-struct check_uc {
-    krb5_kdc_configuration *config;
-    hdb_entry_ex *client_ex;
-    const char *client_name;
-    hdb_entry_ex *server_ex;
-    const char *server_name;
-    KDC_REQ *req;
-    METHOD_DATA *method_data;
-};
-
 static krb5_error_code KRB5_LIB_CALL
 check(krb5_context context, const void *plug, void *plugctx, void *userctx)
 {
     krb5plugin_windc_ftable *ft = (krb5plugin_windc_ftable *)plug;
-    struct check_uc *uc = (struct check_uc *)userctx;    
 
     if (ft->client_access == NULL)
 	return KRB5_PLUGIN_NO_HANDLE;
-    return ft->client_access((void *)plug, context, uc->config, 
-			     uc->client_ex, uc->client_name, 
-			     uc->server_ex, uc->server_name, 
-			     uc->req, uc->method_data);
+    return ft->client_access((void *)plug, userctx);
 }
 
-
 krb5_error_code
-_kdc_check_access(astgs_request_t r, METHOD_DATA *method_data)
+_kdc_check_access(astgs_request_t r)
 {
     krb5_error_code ret = KRB5_PLUGIN_NO_HANDLE;
-    struct check_uc uc;
 
     if (have_plugin) {
-        uc.config = r->config;
-        uc.client_ex = r->client;
-        uc.client_name = r->cname;
-        uc.server_ex = r->server;
-        uc.server_name = r->sname;
-        uc.req = &r->req;
-        uc.method_data = method_data;
-
         ret = _krb5_plugin_run_f(r->context, &windc_plugin_data,
-                                 0, &uc, check);
+                                 0, r, check);
     }
 
     if (ret == KRB5_PLUGIN_NO_HANDLE)

--- a/kdc/windc.c
+++ b/kdc/windc.c
@@ -210,7 +210,7 @@ check(krb5_context context, const void *plug, void *plugctx, void *userctx)
 
 
 krb5_error_code
-_kdc_check_access(astgs_request_t r, KDC_REQ *req, METHOD_DATA *method_data)
+_kdc_check_access(astgs_request_t r, METHOD_DATA *method_data)
 {
     krb5_error_code ret = KRB5_PLUGIN_NO_HANDLE;
     struct check_uc uc;
@@ -221,7 +221,7 @@ _kdc_check_access(astgs_request_t r, KDC_REQ *req, METHOD_DATA *method_data)
         uc.client_name = r->cname;
         uc.server_ex = r->server;
         uc.server_name = r->sname;
-        uc.req = req;
+        uc.req = &r->req;
         uc.method_data = method_data;
 
         ret = _krb5_plugin_run_f(r->context, &windc_plugin_data,
@@ -229,7 +229,7 @@ _kdc_check_access(astgs_request_t r, KDC_REQ *req, METHOD_DATA *method_data)
     }
 
     if (ret == KRB5_PLUGIN_NO_HANDLE)
-        return kdc_check_flags(r, req->msg_type == krb_as_req,
+        return kdc_check_flags(r, r->req.msg_type == krb_as_req,
                                r->client, r->server);
     return ret;
 }

--- a/kdc/windc_plugin.h
+++ b/kdc/windc_plugin.h
@@ -71,12 +71,7 @@ typedef krb5_error_code
 			       krb5_pac *);
 
 typedef krb5_error_code
-(KRB5_CALLCONV *krb5plugin_windc_client_access)(
-	void *, krb5_context,
-	krb5_kdc_configuration *config,
-	hdb_entry_ex *, const char *, 
-	hdb_entry_ex *, const char *, 
-	KDC_REQ *, METHOD_DATA *);
+(KRB5_CALLCONV *krb5plugin_windc_client_access)(void *, astgs_request_t);
 
 typedef krb5_error_code
 (KRB5_CALLCONV *krb5plugin_windc_finalize_reply)(void *, astgs_request_t r);

--- a/kdc/windc_plugin.h
+++ b/kdc/windc_plugin.h
@@ -37,6 +37,7 @@
 #define HEIMDAL_KDC_WINDC_PLUGIN_H 1
 
 #include <krb5.h>
+#include <kdc.h>
 
 /*
  * The PAC generate function should allocate a krb5_pac using
@@ -77,8 +78,10 @@ typedef krb5_error_code
 	hdb_entry_ex *, const char *, 
 	KDC_REQ *, METHOD_DATA *);
 
+typedef krb5_error_code
+(KRB5_CALLCONV *krb5plugin_windc_finalize_reply)(void *, astgs_request_t r);
 
-#define KRB5_WINDC_PLUGIN_MINOR			7
+#define KRB5_WINDC_PLUGIN_MINOR			8
 #define KRB5_WINDC_PLUGING_MINOR KRB5_WINDC_PLUGIN_MINOR
 
 typedef struct krb5plugin_windc_ftable {
@@ -88,6 +91,7 @@ typedef struct krb5plugin_windc_ftable {
     krb5plugin_windc_pac_generate	pac_generate;
     krb5plugin_windc_pac_verify		pac_verify;
     krb5plugin_windc_client_access	client_access;
+    krb5plugin_windc_finalize_reply	finalize_reply;
 } krb5plugin_windc_ftable;
 
 #endif /* HEIMDAL_KDC_WINDC_PLUGIN_H */

--- a/tests/plugin/windc.c
+++ b/tests/plugin/windc.c
@@ -95,15 +95,9 @@ pac_verify(void *ctx, krb5_context context,
 }
 
 static krb5_error_code KRB5_CALLCONV
-client_access(void *ctx,
-	      krb5_context context,
-	      krb5_kdc_configuration *config,
-	      hdb_entry_ex *client, const char *client_name,
-	      hdb_entry_ex *server, const char *server_name,
-	      KDC_REQ *req,
-	      METHOD_DATA *data)
+client_access(void *ctx, astgs_request_t r)
 {
-    krb5_warnx(context, "client_access");
+    krb5_warnx(r->context, "client_access");
     return 0;
 }
 

--- a/tests/plugin/windc.c
+++ b/tests/plugin/windc.c
@@ -94,17 +94,36 @@ pac_verify(void *ctx, krb5_context context,
     return krb5_pac_verify(context, *pac, 0, NULL, NULL, &key->key);
 }
 
+static void logit(const char *what, astgs_request_t r)
+{
+    char *client_princ_name = NULL;
+    char *server_princ_name = NULL;
+
+    if (r->client_princ)
+	krb5_unparse_name(r->context, r->client_princ, &client_princ_name);
+    if (r->server_princ)
+	krb5_unparse_name(r->context, r->server_princ, &server_princ_name);
+
+    krb5_warnx(r->context, "%s: client %s server %s",
+	       what,
+	       client_princ_name ? client_princ_name : "<unknown>",
+	       server_princ_name ? server_princ_name : "<unknown>");
+
+    krb5_xfree(server_princ_name);
+    krb5_xfree(client_princ_name);
+}
+
 static krb5_error_code KRB5_CALLCONV
 client_access(void *ctx, astgs_request_t r)
 {
-    krb5_warnx(r->context, "client_access");
+    logit("client_access", r);
     return 0;
 }
 
 static krb5_error_code KRB5_CALLCONV
 finalize_reply(void *ctx, astgs_request_t r)
 {
-    krb5_warnx(r->context, "finalize_reply");
+    logit("finalize_reply", r);
     return 0;
 }
 

--- a/tests/plugin/windc.c
+++ b/tests/plugin/windc.c
@@ -107,13 +107,21 @@ client_access(void *ctx,
     return 0;
 }
 
+static krb5_error_code KRB5_CALLCONV
+finalize_reply(void *ctx, astgs_request_t r)
+{
+    krb5_warnx(r->context, "finalize_reply");
+    return 0;
+}
+
 static krb5plugin_windc_ftable windc = {
     KRB5_WINDC_PLUGING_MINOR,
     windc_init,
     windc_fini,
     pac_generate,
     pac_verify,
-    client_access
+    client_access,
+    finalize_reply
 };
 
 static const krb5plugin_windc_ftable *const windc_plugins[] = {


### PR DESCRIPTION
Encapsulate as much state as possible in `astgs_request_t`, with a view to eventually migrating the KDC to a table-driven architecture. In the interim, use a single `astgs_request_t` argument for pre- and post-hook plugins, e.g.:

```c
static krb5_error_code KRB5_CALLCONV
client_access(void *ctx, astgs_request_t r)
{
    krb5_warnx(r->context, "client_access");
    return 0;
}

static krb5_error_code KRB5_CALLCONV
finalize_reply(void *ctx, astgs_request_t r)
{
    krb5_warnx(r->context, "finalize_reply");
    return 0;
}
```

The `astgs_request_t` structure is separated into a public and private component, depending on whether we are building the KDC or not.