### PR TITLE
add attribute dictionary to kdc_request_t

### DIFF
--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -122,6 +122,24 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 #endif
 #endif
 
+
+#ifdef BUILD_KDC_LIB
+#ifndef KDC_LIB
+#ifdef _WIN32
+#define KDC_LIB_FUNCTION
+#define KDC_LIB_NORETURN_FUNCTION __declspec(noreturn)
+#define KDC_LIB_CALL     __stdcall
+#define KDC_LIB_VARIABLE
+#else
+#define KDC_LIB_FUNCTION
+#define KDC_LIB_NORETURN_FUNCTION
+#define KDC_LIB_CALL
+#define KDC_LIB_VARIABLE
+#endif
+#endif
+#endif
+
+
 /* Feature macros */
 
 @FEATURE_DEFS@

--- a/kdc/Makefile.am
+++ b/kdc/Makefile.am
@@ -112,6 +112,8 @@ altsecid_gss_preauth_authorizer_la_LDFLAGS = -module \
 					     $(LIB_openldap)
 endif
 
+libkdc_la_CPPFLAGS = -DBUILD_KDC_LIB $(AM_CPPFLAGS)
+
 libkdc_la_SOURCES = 		\
 	default_config.c 	\
 	ca.c			\

--- a/kdc/NTMakefile
+++ b/kdc/NTMakefile
@@ -33,7 +33,7 @@ RELDIR=kdc
 
 !include ../windows/NTMakefile.w32 
 
-intcflags=-I$(OBJ) -I$(SRC)\lib\gssapi -I$(OBJDIR)\lib\gssapi -I$(OBJDIR)\lib\gss_preauth
+intcflags=-I$(OBJ) -I$(SRC)\lib\gssapi -I$(OBJDIR)\lib\gssapi -I$(OBJDIR)\lib\gss_preauth -DBUILD_KDC_LIB
 
 BINPROGRAMS=$(BINDIR)\string2key.exe
 

--- a/kdc/bx509d.c
+++ b/kdc/bx509d.c
@@ -882,6 +882,7 @@ set_req_desc(struct MHD_Connection *connection,
     r->req_life = 0;
     r->ret = 0;
     r->kv = heim_dict_create(10);
+    r->attributes = heim_dict_create(1);
     ci = MHD_get_connection_info(connection,
                                  MHD_CONNECTION_INFO_CLIENT_ADDRESS);
     if (ci) {

--- a/kdc/ca.c
+++ b/kdc/ca.c
@@ -97,7 +97,7 @@ get_cf(krb5_context context,
 /*
  * Build a certifate for `principal' and its CSR.
  */
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 kdc_issue_certificate(krb5_context context,
                       const char *app_name,
                       krb5_log_facility *logf,

--- a/kdc/csr_authorizer.c
+++ b/kdc/csr_authorizer.c
@@ -65,7 +65,7 @@ static struct heim_plugin_data csr_authorizer_data = {
  * Invoke a plugin to validate a JWT/SAML/OIDC token and partially-evaluate
  * access control.
  */
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 kdc_authorize_csr(krb5_context context,
                   const char *app,
                   hx509_request csr,

--- a/kdc/default_config.c
+++ b/kdc/default_config.c
@@ -69,7 +69,7 @@ load_kdc_plugins_once(void *ctx)
 #endif
 }
 
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
 {
     static heim_base_once_t load_kdc_plugins = HEIM_BASE_ONCE_INIT;
@@ -391,7 +391,7 @@ krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
     return 0;
 }
 
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 krb5_kdc_pkinit_config(krb5_context context, krb5_kdc_configuration *config)
 {
 #ifdef PKINIT

--- a/kdc/gss_preauth_authorizer_plugin.h
+++ b/kdc/gss_preauth_authorizer_plugin.h
@@ -69,11 +69,9 @@ typedef struct krb5plugin_gss_preauth_authorizer_ftable_desc {
                                                    gss_const_OID,       /*mech_type*/
                                                    OM_uint32,           /*ret_flags*/
                                                    krb5_boolean *,      /*authorized*/
-                                                   krb5_principal *,    /*mapped_name*/
-                                                   krb5_data *);        /*pac_data*/
+                                                   krb5_principal *);	/*mapped_name*/
     krb5_error_code     (KRB5_LIB_CALL *finalize_pac)(void *,           /*plug_ctx*/
-                                                      astgs_request_t,  /*r*/
-                                                      krb5_data *);     /*pac_data*/
+                                                      astgs_request_t); /*r*/
 } krb5plugin_gss_preauth_authorizer_ftable;
 
 #endif /* HEIMDAL_KDC_GSS_PREAUTH_AUTHORIZER_PLUGIN_H */

--- a/kdc/httpkadmind.c
+++ b/kdc/httpkadmind.c
@@ -1529,6 +1529,7 @@ set_req_desc(struct MHD_Connection *connection,
     r->cname = NULL;
     r->addr = NULL;
     r->kv = heim_dict_create(10);
+    r->attributes = heim_dict_create(1);
     /* Our fields */
     r->connection = connection;
     r->kadm_handle = NULL;

--- a/kdc/kdc-plugin.c
+++ b/kdc/kdc-plugin.c
@@ -61,7 +61,7 @@ load(krb5_context context, const void *plug, void *plugctx, void *userctx)
     return KRB5_PLUGIN_NO_HANDLE;
 }
 
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 krb5_kdc_plugin_init(krb5_context context)
 {
     (void)_krb5_plugin_run_f(context, &kdc_plugin_data, 0, NULL, load);
@@ -279,7 +279,7 @@ _kdc_plugin_audit(astgs_request_t r)
     return ret;
 }
 
-uintptr_t KRB5_CALLCONV
+KDC_LIB_FUNCTION uintptr_t KDC_LIB_CALL
 kdc_get_instance(const char *libname)
 {
     static const char *instance = "libkdc";

--- a/kdc/kdc.h
+++ b/kdc/kdc.h
@@ -46,6 +46,16 @@
 #include <kx509_asn1.h>
 #include <gssapi/gssapi.h>
 
+#if !defined(BUILD_KDC_LIB) && defined(_WIN32)
+# define KDC_LIB_FUNCTION __declspec(dllimport)
+# define KDC_LIB_CALL     __stdcall
+# define KDC_LIB_VARIABLE __declspec(dllimport)
+#else
+# define KDC_LIB_FUNCTION
+# define KDC_LIB_CALL
+# define KDC_LIB_VARIABLE
+#endif
+
 #define heim_pcontext krb5_context
 #define heim_pconfig krb5_kdc_configuration *
 #include <heimbase-svc.h>

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -64,7 +64,6 @@ struct kdc_request_desc {
     HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;
 };
 
-struct as_request_pa_state;
 struct kdc_patypes;
 
 struct astgs_request_desc {
@@ -72,7 +71,6 @@ struct astgs_request_desc {
 
     /* Only AS */
     const struct kdc_patypes *pa_used;
-    struct as_request_pa_state *pa_state;
 
     /* PA methods can affect both the reply key and the session key (pkinit) */
     krb5_enctype sessionetype;

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1612,7 +1612,7 @@ _log_astgs_req(astgs_request_t r, krb5_enctype setype)
  * and error code otherwise.
  */
 
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 kdc_check_flags(astgs_request_t r,
                 krb5_boolean is_as_req,
                 hdb_entry_ex *client_ex,

--- a/kdc/libkdc-exports.def
+++ b/kdc/libkdc-exports.def
@@ -6,6 +6,7 @@ EXPORTS
 	kdc_log_msg
 	kdc_log_msg_va
 	kdc_openlog
+	kdc_check_flags
 	kdc_validate_token
 	krb5_kdc_plugin_init
 	krb5_kdc_get_config
@@ -22,11 +23,16 @@ EXPORTS
 	krb5_kdc_request_delete_attribute
 	_kdc_audit_addkv
 	_kdc_audit_addkv_timediff
+	_kdc_audit_addaddrs
+	_kdc_audit_addreason
 	_kdc_audit_getkv
 	_kdc_audit_setkv_bool
 	_kdc_audit_setkv_number
 	_kdc_audit_setkv_object
-	_kdc_audit_addreason
+	_kdc_audit_trail
 	_kdc_audit_vaddkv
 	_kdc_audit_vaddreason
-	_kdc_audit_trail
+
+	; needed for digest-service
+	_kdc_db_fetch
+	_kdc_free_ent

--- a/kdc/libkdc-exports.def
+++ b/kdc/libkdc-exports.def
@@ -16,6 +16,10 @@ EXPORTS
 	krb5_kdc_save_request
 	krb5_kdc_update_time
 	krb5_kdc_pk_initialize
+	krb5_kdc_request_set_attribute
+	krb5_kdc_request_get_attribute
+	krb5_kdc_request_copy_attribute
+	krb5_kdc_request_delete_attribute
 	_kdc_audit_addkv
 	_kdc_audit_addkv_timediff
 	_kdc_audit_getkv

--- a/kdc/log.c
+++ b/kdc/log.c
@@ -35,7 +35,7 @@
 
 #include "kdc_locl.h"
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 kdc_openlog(krb5_context context,
 	    const char *service,
 	    krb5_kdc_configuration *config)
@@ -63,7 +63,7 @@ kdc_openlog(krb5_context context,
 #undef __attribute__
 #define __attribute__(X)
 
-char*
+KDC_LIB_FUNCTION char * KDC_LIB_CALL
 kdc_log_msg_va(krb5_context context,
 	       krb5_kdc_configuration *config,
 	       int level, const char *fmt, va_list ap)
@@ -74,7 +74,7 @@ kdc_log_msg_va(krb5_context context,
     return msg;
 }
 
-char*
+KDC_LIB_FUNCTION char * KDC_LIB_CALL
 kdc_log_msg(krb5_context context,
 	    krb5_kdc_configuration *config,
 	    int level, const char *fmt, ...)
@@ -88,7 +88,7 @@ kdc_log_msg(krb5_context context,
     return s;
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 kdc_vlog(krb5_context context,
          krb5_kdc_configuration *config,
          int level, const char *fmt, va_list ap)
@@ -97,7 +97,7 @@ kdc_vlog(krb5_context context,
     free(kdc_log_msg_va(context, config, level, fmt, ap));
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 kdc_log(krb5_context context,
 	krb5_kdc_configuration *config,
 	int level, const char *fmt, ...)

--- a/kdc/misc.c
+++ b/kdc/misc.c
@@ -122,7 +122,7 @@ synthesize_client(krb5_context context,
     return ret;
 }
 
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 _kdc_db_fetch(krb5_context context,
 	      krb5_kdc_configuration *config,
 	      krb5_const_principal principal,
@@ -245,7 +245,7 @@ out:
     return ret;
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_free_ent(krb5_context context, hdb_entry_ex *ent)
 {
     hdb_free_entry (context, ent);

--- a/kdc/pkinit.c
+++ b/kdc/pkinit.c
@@ -1926,7 +1926,7 @@ load_mappings(krb5_context context, const char *fn)
  *
  */
 
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 krb5_kdc_pk_initialize(krb5_context context,
 		       krb5_kdc_configuration *config,
 		       const char *user_id,

--- a/kdc/process.c
+++ b/kdc/process.c
@@ -359,7 +359,10 @@ process_request(krb5_context context,
     r->datagram_reply = datagram_reply;
     r->reply = reply;
     r->kv = heim_dict_create(10);
-    if (!r->kv) {
+    r->attributes = heim_dict_create(1);
+    if (r->kv == NULL || r->attributes == NULL) {
+	heim_release(r->kv);
+	heim_release(r->attributes);
 	free(r);
 	return krb5_enomem(context);
     }
@@ -385,6 +388,7 @@ process_request(krb5_context context,
 
             heim_release(r->reason);
             heim_release(r->kv);
+	    heim_release(r->attributes);
             free(r);
 	    return ret;
 	}
@@ -392,6 +396,7 @@ process_request(krb5_context context,
 
     heim_release(r->reason);
     heim_release(r->kv);
+    heim_release(r->attributes);
     free(r);
     return -1;
 }
@@ -504,4 +509,28 @@ out:
     krb5_storage_free(sp);
 
     return 0;
+}
+
+krb5_error_code
+krb5_kdc_request_set_attribute(kdc_request_t r, heim_object_t key, heim_object_t value)
+{
+    return heim_dict_set_value(r->attributes, key, value);
+}
+
+heim_object_t
+krb5_kdc_request_get_attribute(kdc_request_t r, heim_object_t key)
+{
+    return heim_dict_get_value(r->attributes, key);
+}
+
+heim_object_t
+krb5_kdc_request_copy_attribute(kdc_request_t r, heim_object_t key)
+{
+    return heim_dict_copy_value(r->attributes, key);
+}
+
+void
+krb5_kdc_request_delete_attribute(kdc_request_t r, heim_object_t key)
+{
+    heim_dict_delete_key(r->attributes, key);
 }

--- a/kdc/process.c
+++ b/kdc/process.c
@@ -42,14 +42,14 @@
 #undef  __attribute__
 #define __attribute__(x)
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_vaddreason(kdc_request_t r, const char *fmt, va_list ap)
 	__attribute__ ((__format__ (__printf__, 2, 0)))
 {
     heim_audit_vaddreason((heim_svc_req_desc)r, fmt, ap);
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_addreason(kdc_request_t r, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)))
 {
@@ -66,7 +66,7 @@ _kdc_audit_addreason(kdc_request_t r, const char *fmt, ...)
  * not a kv-pair.
  */
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_vaddkv(kdc_request_t r, int flags, const char *k,
 		  const char *fmt, va_list ap)
 	__attribute__ ((__format__ (__printf__, 4, 0)))
@@ -74,7 +74,7 @@ _kdc_audit_vaddkv(kdc_request_t r, int flags, const char *k,
     heim_audit_vaddkv((heim_svc_req_desc)r, flags, k, fmt, ap);
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_addkv(kdc_request_t r, int flags, const char *k,
 		 const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 4, 5)))
@@ -86,7 +86,7 @@ _kdc_audit_addkv(kdc_request_t r, int flags, const char *k,
     va_end(ap);
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_addkv_timediff(kdc_request_t r, const char *k,
 			  const struct timeval *start,
 			  const struct timeval *end)
@@ -94,25 +94,25 @@ _kdc_audit_addkv_timediff(kdc_request_t r, const char *k,
     heim_audit_addkv_timediff((heim_svc_req_desc)r,k, start, end);
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_setkv_bool(kdc_request_t r, const char *k, krb5_boolean v)
 {
     heim_audit_setkv_bool((heim_svc_req_desc)r, k, (int)v);
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_setkv_number(kdc_request_t r, const char *k, int64_t v)
 {
     heim_audit_setkv_number((heim_svc_req_desc)r, k, v);
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_setkv_object(kdc_request_t r, const char *k, heim_object_t obj)
 {
     heim_audit_setkv_object((heim_svc_req_desc)r, k, obj);
 }
 
-heim_object_t
+KDC_LIB_FUNCTION heim_object_t KDC_LIB_CALL
 _kdc_audit_getkv(kdc_request_t r, const char *k)
 {
     return heim_audit_getkv((heim_svc_req_desc)r, k);
@@ -122,7 +122,7 @@ _kdc_audit_getkv(kdc_request_t r, const char *k)
  * Add up to 3 key value pairs to record HostAddresses from request body or
  * PA-TGS ticket or whatever.
  */
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_addaddrs(kdc_request_t r, HostAddresses *a, const char *key)
 {
     size_t i;
@@ -142,7 +142,7 @@ _kdc_audit_addaddrs(kdc_request_t r, HostAddresses *a, const char *key)
     }
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 _kdc_audit_trail(kdc_request_t r, krb5_error_code ret)
 {
     const char *retname = NULL;
@@ -195,7 +195,7 @@ _kdc_audit_trail(kdc_request_t r, krb5_error_code ret)
     heim_audit_trail((heim_svc_req_desc)r, ret, retname);
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 krb5_kdc_update_time(struct timeval *tv)
 {
     if (tv == NULL)
@@ -406,7 +406,7 @@ process_request(krb5_context context,
  * sending a reply in `reply'.
  */
 
-int
+KDC_LIB_FUNCTION int KDC_LIB_CALL
 krb5_kdc_process_request(krb5_context context,
 			 krb5_kdc_configuration *config,
 			 unsigned char *buf,
@@ -428,7 +428,7 @@ krb5_kdc_process_request(krb5_context context,
  * This only processes krb5 requests
  */
 
-int
+KDC_LIB_FUNCTION int KDC_LIB_CALL
 krb5_kdc_process_krb5_request(krb5_context context,
 			      krb5_kdc_configuration *config,
 			      unsigned char *buf,
@@ -447,7 +447,7 @@ krb5_kdc_process_krb5_request(krb5_context context,
  *
  */
 
-int
+KDC_LIB_FUNCTION int KDC_LIB_CALL
 krb5_kdc_save_request(krb5_context context,
 		      const char *fn,
 		      const unsigned char *buf,
@@ -511,25 +511,25 @@ out:
     return 0;
 }
 
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 krb5_kdc_request_set_attribute(kdc_request_t r, heim_object_t key, heim_object_t value)
 {
     return heim_dict_set_value(r->attributes, key, value);
 }
 
-heim_object_t
+KDC_LIB_FUNCTION heim_object_t KDC_LIB_CALL
 krb5_kdc_request_get_attribute(kdc_request_t r, heim_object_t key)
 {
     return heim_dict_get_value(r->attributes, key);
 }
 
-heim_object_t
+KDC_LIB_FUNCTION heim_object_t KDC_LIB_CALL
 krb5_kdc_request_copy_attribute(kdc_request_t r, heim_object_t key)
 {
     return heim_dict_copy_value(r->attributes, key);
 }
 
-void
+KDC_LIB_FUNCTION void KDC_LIB_CALL
 krb5_kdc_request_delete_attribute(kdc_request_t r, heim_object_t key)
 {
     heim_dict_delete_key(r->attributes, key);

--- a/kdc/set_dbinfo.c
+++ b/kdc/set_dbinfo.c
@@ -64,7 +64,7 @@ add_db(krb5_context context, struct krb5_kdc_configuration *c,
     return 0;
 }
 
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 krb5_kdc_set_dbinfo(krb5_context context, struct krb5_kdc_configuration *c)
 {
     struct hdb_dbinfo *info, *d;

--- a/kdc/token_validator.c
+++ b/kdc/token_validator.c
@@ -78,7 +78,7 @@ static struct heim_plugin_data token_validator_data = {
  * Invoke a plugin to validate a JWT/SAML/OIDC token and partially-evaluate
  * access control.
  */
-krb5_error_code
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 kdc_validate_token(krb5_context context,
                    const char *realm,
                    const char *token_kind,

--- a/kdc/version-script.map
+++ b/kdc/version-script.map
@@ -20,6 +20,10 @@ HEIMDAL_KDC_1.0 {
 		krb5_kdc_save_request;
 		krb5_kdc_update_time;
 		krb5_kdc_pk_initialize;
+		krb5_kdc_request_set_attribute;
+		krb5_kdc_request_get_attribute;
+		krb5_kdc_request_copy_attribute;
+		krb5_kdc_request_delete_attribute;
 		_kdc_audit_addkv;
 		_kdc_audit_setkv_bool;
 		_kdc_audit_setkv_number;

--- a/kdc/version-script.map
+++ b/kdc/version-script.map
@@ -25,14 +25,16 @@ HEIMDAL_KDC_1.0 {
 		krb5_kdc_request_copy_attribute;
 		krb5_kdc_request_delete_attribute;
 		_kdc_audit_addkv;
+		_kdc_audit_addkv_timediff;
+		_kdc_audit_addaddrs;
+		_kdc_audit_addreason;
+		_kdc_audit_getkv;
 		_kdc_audit_setkv_bool;
 		_kdc_audit_setkv_number;
 		_kdc_audit_setkv_object;
-		_kdc_audit_getkv;
-		_kdc_audit_addreason;
+		_kdc_audit_trail;
 		_kdc_audit_vaddkv;
 		_kdc_audit_vaddreason;
-		_kdc_audit_trail;
 
 		# needed for digest-service
 		_kdc_db_fetch;

--- a/lib/base/heimbase-svc.h
+++ b/lib/base/heimbase-svc.h
@@ -72,6 +72,7 @@
     heim_string_t reason;                                       \
     /* auditing key/value store */                              \
     heim_dict_t kv;                                             \
+    heim_dict_t attributes;                                     \
     int32_t ret
 
 #endif /* HEIMBASE_SVC_H */


### PR DESCRIPTION
Add a heim_dict_t to the KDC request structure for use by pre-authentication mechanisms and plugins.
