### PR TITLE
gss: expose PAC info buffers under urn:mspac:

### DIFF
--- a/lib/gssapi/Makefile.am
+++ b/lib/gssapi/Makefile.am
@@ -383,6 +383,7 @@ LDADD = libgssapi.la \
 	$(LIB_roken)
 
 test_names_LDADD = $(LDADD) $(top_builddir)/lib/asn1/libasn1.la
+test_context_LDADD = $(LDADD) $(top_builddir)/lib/wind/libwind.la
 
 # gss
 

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -500,6 +500,7 @@ EXPORTS
 	krb5_pac_add_buffer
 	krb5_pac_free
 	krb5_pac_get_buffer
+	_krb5_pac_get_buffer_by_name
 	krb5_pac_get_kdc_checksum_info
 	krb5_pac_get_types
 	krb5_pac_init

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -493,6 +493,7 @@ HEIMDAL_KRB5_2.0 {
 		krb5_pac_add_buffer;
 		krb5_pac_free;
 		krb5_pac_get_buffer;
+		_krb5_pac_get_buffer_by_name;
 		krb5_pac_get_kdc_checksum_info;
 		krb5_pac_get_types;
 		krb5_pac_init;


### PR DESCRIPTION
Expose PAC info buffers using naming attributes prefixed with `urn:mspac:`, aligned with MIT.