### PR TITLE
kdc: add audit plugin API to windc API

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2738,7 +2738,7 @@ _kdc_as_rep(astgs_request_t r)
 
 out:
     r->ret = ret;
-    _kdc_hdb_audit(r);
+    _kdc_audit_request(r);
 
     /*
      * In case of a non proxy error, build an error message.

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -2575,7 +2575,7 @@ _kdc_tgs_rep(astgs_request_t r)
 
 out:
     r->ret = ret;
-    _kdc_hdb_audit(r);
+    _kdc_audit_request(r);
 
     if(ret && ret != HDB_ERR_NOT_FOUND_HERE && data->data == NULL){
 	METHOD_DATA error_method = { 0, NULL };

--- a/kdc/misc.c
+++ b/kdc/misc.c
@@ -343,18 +343,17 @@ _kdc_include_pac_p(astgs_request_t r)
 }
 
 /*
- * Notify the HDB backend of the audited event.
+ * Notify the HDB backend and windc plugin of the audited event.
  */
 
-krb5_error_code
-_kdc_hdb_audit(astgs_request_t r)
+void
+_kdc_audit_request(astgs_request_t r)
 {
     struct HDB *hdb;
 
+    _kdc_windc_audit(r);
+
     hdb = r->clientdb ? r->clientdb : r->config->db[0];
-
     if (hdb && hdb->hdb_audit)
-	return hdb->hdb_audit(r->context, hdb, r->client, (hdb_request_t)r);
-
-    return 0;
+	hdb->hdb_audit(r->context, hdb, r->client, (hdb_request_t)r);
 }

--- a/kdc/windc.c
+++ b/kdc/windc.c
@@ -234,6 +234,24 @@ _kdc_finalize_reply(astgs_request_t r)
     return ret;
 }
 
+static krb5_error_code KRB5_LIB_CALL
+audit(krb5_context context, const void *plug, void *plugctx, void *userctx)
+{
+    krb5plugin_windc_ftable *ft = (krb5plugin_windc_ftable *)plug;
+
+    if (ft->audit)
+	ft->audit((void *)plug, userctx);
+
+    return 0;
+}
+
+void
+_kdc_windc_audit(astgs_request_t r)
+{
+    if (have_plugin)
+        _krb5_plugin_run_f(r->context, &windc_plugin_data, 0, r, audit);
+}
+
 uintptr_t KRB5_CALLCONV
 kdc_get_instance(const char *libname)
 {

--- a/kdc/windc_plugin.h
+++ b/kdc/windc_plugin.h
@@ -84,6 +84,17 @@ typedef krb5_error_code
 typedef krb5_error_code
 (KRB5_CALLCONV *krb5plugin_windc_finalize_reply)(void *, astgs_request_t r);
 
+/*
+ * Audit an AS or TGS request. This function is called after encoding the
+ * reply (on success), or before encoding the error message. If a HDB audit
+ * function is also present, it is called after this one.
+ *
+ * The request should not be modified by the plugin.
+ */
+
+typedef void
+(KRB5_CALLCONV *krb5plugin_windc_audit)(void *, astgs_request_t r);
+
 #define KRB5_WINDC_PLUGIN_MINOR			8
 #define KRB5_WINDC_PLUGING_MINOR KRB5_WINDC_PLUGIN_MINOR
 
@@ -95,6 +106,7 @@ typedef struct krb5plugin_windc_ftable {
     krb5plugin_windc_pac_verify		pac_verify;
     krb5plugin_windc_client_access	client_access;
     krb5plugin_windc_finalize_reply	finalize_reply;
+    krb5plugin_windc_audit		audit;
 } krb5plugin_windc_ftable;
 
 #endif /* HEIMDAL_KDC_WINDC_PLUGIN_H */

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -324,7 +324,7 @@ typedef struct HDB {
      * In case the entry is locked out, the backend should set the
      * hdb_entry.flags.locked-out flag.
      */
-    krb5_error_code (*hdb_audit)(krb5_context, struct HDB *, hdb_entry_ex *, hdb_request_t);
+    void (*hdb_audit)(krb5_context, struct HDB *, hdb_entry_ex *, hdb_request_t);
 
     /**
      * Check if delegation is allowed.

--- a/tests/plugin/windc.c
+++ b/tests/plugin/windc.c
@@ -116,6 +116,12 @@ finalize_reply(void *ctx, astgs_request_t r)
     return 0;
 }
 
+static void KRB5_CALLCONV
+audit(void *ctx, astgs_request_t r)
+{
+    logit("audit", r);
+}
+
 static krb5plugin_windc_ftable windc = {
     KRB5_WINDC_PLUGING_MINOR,
     windc_init,
@@ -123,7 +129,8 @@ static krb5plugin_windc_ftable windc = {
     pac_generate,
     pac_verify,
     client_access,
-    finalize_reply
+    finalize_reply,
+    audit
 };
 
 static const krb5plugin_windc_ftable *const windc_plugins[] = {


### PR DESCRIPTION
Allow the windc plugin to also implement an allback callback. As part of this change, both the HDB and windc audit function signatures are changed to return void.