### PR TITLE
complete support for DB6

### DIFF
--- a/cf/db.m4
+++ b/cf/db.m4
@@ -59,7 +59,7 @@ AS_IF([test "x$with_berkeley_db" != xno],
 
 dnl db_create is used by db3 and db4 and db5
 
-  AC_FIND_FUNC_NO_LIBS(db_create, [$dbheader] db-5 db5 db4 db3 db, [
+  AC_FIND_FUNC_NO_LIBS(db_create, [$dbheader] db-5 db4 db3 db, [
   #include <stdio.h>
   #ifdef HAVE_DBHEADER
   #include <$dbheader/db.h>

--- a/cf/db.m4
+++ b/cf/db.m4
@@ -57,9 +57,9 @@ AS_IF([test "x$with_berkeley_db" != xno],
 	           db.h					\
     ])])
 
-dnl db_create is used by db3 and db4 and db5
+dnl db_create is used by db3 and db4 and db5 and db6
 
-  AC_FIND_FUNC_NO_LIBS(db_create, [$dbheader] db-5 db4 db3 db, [
+  AC_FIND_FUNC_NO_LIBS(db_create, [$dbheader] db-6 db-5 db4 db3 db, [
   #include <stdio.h>
   #ifdef HAVE_DBHEADER
   #include <$dbheader/db.h>
@@ -83,7 +83,7 @@ dnl db_create is used by db3 and db4 and db5
     else
       DB3LIB=""
     fi
-    AC_DEFINE(HAVE_DB3, 1, [define if you have a berkeley db3/4/5 library])
+    AC_DEFINE(HAVE_DB3, 1, [define if you have a berkeley db3/4/5/6 library])
   fi
 
 dnl dbopen is used by db1/db2

--- a/lib/roken/ndbm_wrap.c
+++ b/lib/roken/ndbm_wrap.c
@@ -36,6 +36,8 @@
 #include "ndbm_wrap.h"
 #if defined(HAVE_DBHEADER)
 #include <db.h>
+#elif defined(HAVE_DB6_DB_H)
+#include <db6/db.h>
 #elif defined(HAVE_DB5_DB_H)
 #include <db5/db.h>
 #elif defined(HAVE_DB4_DB_H)


### PR DESCRIPTION
The prior inclusion of DB6 checks within the tree was incomplete.   The db6/db.h header was tested for and used in some places but the test for db_create() within libdb-6 if present did not exist.   

The roken ndbm-wrap functionality was also unaware of DB6.
