### PR TITLE
win10sdk and asn1 build improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ install:
 
 build_script:
   - set PSDKDir=C:\Program Files\Microsoft SDKs\Windows\v7.1
-  - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.Cmd" /xp /x64 /Release
+  - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.Cmd" /win7 /x64 /Release
   - set WIXDIR="c:\Program Files (x86)\Windows Installer XML v3.5"
   # We're not doing any codesigning in the Appveyor build yet.
   - SET CODESIGN_PKT=0000000000000000

--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -905,6 +905,17 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 /* Define if you have the function `strtok_r'. */
 /* #define HAVE_STRTOK_R 1 */
 
+#if defined(__has_include)
+# if __has_include(<corecrt.h>)
+#  define HAVE_UCRT 1
+# endif
+#endif
+
+#ifdef HAVE_UCRT
+#define HAVE_STRTOLL 1
+#define HAVE_STRTOULL 1
+#endif
+
 /* Define to 1 if the system has the type `struct addrinfo'. */
 #define HAVE_STRUCT_ADDRINFO 1
 

--- a/lib/asn1/NTMakefile
+++ b/lib/asn1/NTMakefile
@@ -112,6 +112,21 @@ $(BINDIR)\asn1_gen.exe: $(OBJ)\asn1_gen.obj $(LIBHEIMDAL)
 	$(EXECONLINK) $(LIBVERS) $(LIBROKEN)
 	$(EXEPREP)
 
+LIBASN1_X= \
+	$(gen_files_rfc2459)		\
+	$(gen_files_rfc4108)		\
+	$(gen_files_cms)		\
+	$(gen_files_krb5)		\
+	$(gen_files_ocsp)		\
+	$(gen_files_pkinit)		\
+	$(gen_files_pkcs8)		\
+	$(gen_files_pkcs9)		\
+	$(gen_files_pkcs10)		\
+	$(gen_files_pkcs12)		\
+	$(gen_files_digest)		\
+	$(gen_files_kx509)		\
+	$(gen_files_x690sample)
+
 LIBASN1_OBJS=	\
 	$(OBJ)\der.obj				\
 	$(OBJ)\der_get.obj			\
@@ -124,6 +139,7 @@ LIBASN1_OBJS=	\
 	$(OBJ)\der_format.obj			\
 	$(OBJ)\template.obj			\
 	$(OBJ)\extra.obj			\
+	$(OBJ)\oid_resolution.obj		\
 	$(OBJ)\timegm.obj			\
 	$(gen_files_rfc2459:.x=.obj)		\
 	$(gen_files_rfc4108:.x=.obj)		\
@@ -140,11 +156,9 @@ LIBASN1_OBJS=	\
 	$(gen_files_x690sample:.x=.obj)		\
 	$(OBJ)\asn1_err.obj
 
-$(OBJ)\oid_resolution.obj: $(LIBASN1_OBJS)
+$(OBJ)\oid_resolution.obj: $(LIBASN1_X)
 
-LIBASN1_OBJS2=	$(LIBASN1_OBJS) $(OBJ)\oid_resolution.obj
-
-$(LIBASN1): $(LIBASN1_OBJS2)
+$(LIBASN1): $(LIBASN1_OBJS)
 	$(LIBCON_C) -out:$@ @<<
 $(**: =
 )

--- a/lib/asn1/NTMakefile
+++ b/lib/asn1/NTMakefile
@@ -31,7 +31,7 @@
 
 RELDIR=lib\asn1
 
-intcflags=-I$(SRCDIR) -I$(OBJ) -DROKEN_RENAME -DASN1_IOS_SUPPORTED
+intcflags=-I$(SRCDIR) -I$(OBJ) -DROKEN_RENAME -DASN1_IOS_SUPPORTED -DASN1_LIB
 
 !include ../../windows/NTMakefile.w32
 

--- a/lib/asn1/NTMakefile
+++ b/lib/asn1/NTMakefile
@@ -1,6 +1,6 @@
 ########################################################################
 #
-# Copyright (c) 2009, Secure Endpoints Inc.
+# Copyright (c) 2009-2022, Secure Endpoints Inc.
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without
@@ -166,6 +166,131 @@ $(**: =
 
 clean::
 	-$(RM) $(LIBASN1)
+
+#
+# The static runtime version LIBASN1_S is for use by thirdparty
+# components.  It is not used in the construction of the Heimdal
+# DLLs.
+
+LIBASN1_S_OBJS=	\
+	$(OBJ)\der.s.obj			\
+	$(OBJ)\der_get.s.obj			\
+	$(OBJ)\der_put.s.obj			\
+	$(OBJ)\der_free.s.obj			\
+	$(OBJ)\der_print.s.obj			\
+	$(OBJ)\der_length.s.obj			\
+	$(OBJ)\der_copy.s.obj			\
+	$(OBJ)\der_cmp.s.obj			\
+	$(OBJ)\der_format.s.obj			\
+	$(OBJ)\template.s.obj			\
+	$(OBJ)\extra.s.obj			\
+	$(OBJ)\oid_resolution.s.obj		\
+	$(OBJ)\timegm.s.obj			\
+	$(gen_files_rfc2459:.x=.s.obj)		\
+	$(gen_files_rfc4108:.x=.s.obj)		\
+	$(gen_files_cms:.x=.s.obj)		\
+	$(gen_files_krb5:.x=.s.obj)		\
+	$(gen_files_ocsp:.x=.s.obj)		\
+	$(gen_files_pkinit:.x=.s.obj)		\
+	$(gen_files_pkcs8:.x=.s.obj)		\
+	$(gen_files_pkcs9:.x=.s.obj)		\
+	$(gen_files_pkcs10:.x=.s.obj)		\
+	$(gen_files_pkcs12:.x=.s.obj)		\
+	$(gen_files_digest:.x=.s.obj)		\
+	$(gen_files_kx509:.x=.s.obj)		\
+	$(gen_files_x690sample:.x=.s.obj)	\
+	$(OBJ)\asn1_err.s.obj
+
+$(OBJ)\oid_resolution.s.obj: oid_resolution.c $(LIBASN1_X)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ oid_resolution.c
+
+$(OBJ)\der.s.obj: der.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\der_get.s.obj: der_get.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\der_put.s.obj: der_put.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\der_free.s.obj: der_free.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\der_print.s.obj: der_print.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\der_length.s.obj: der_length.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\der_copy.s.obj: der_copy.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\der_cmp.s.obj: der_cmp.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\der_format.s.obj: der_format.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\template.s.obj: template.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\extra.s.obj: extra.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\timegm.s.obj: timegm.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_rfc2459:.x=.s.obj): $(gen_files_rfc2459:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_rfc4108:.x=.s.obj): $(gen_files_rfc4108:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_cms:.x=.s.obj): $(gen_files_cms:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_krb5:.x=.s.obj): $(gen_files_krb5:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_ocsp:.x=.s.obj): $(gen_files_ocsp:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_pkinit:.x=.s.obj): $(gen_files_pkinit:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_pkcs8:.x=.s.obj): $(gen_files_pkcs8:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_pkcs9:.x=.s.obj): $(gen_files_pkcs9:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_pkcs10:.x=.s.obj): $(gen_files_pkcs10:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_pkcs12:.x=.s.obj): $(gen_files_pkcs12:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_digest:.x=.s.obj): $(gen_files_digest:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_kx509:.x=.s.obj): $(gen_files_kx509:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(gen_files_x690sample:.x=.s.obj): $(gen_files_x690sample:.x=.c)
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(OBJ)\asn1_err.s.obj: $(OBJ)\asn1_err.c
+	$(C2OBJ_C_MT) -Fo$@ -Fd$(@D)\ $**
+
+$(LIBASN1_S): $(LIBASN1_S_OBJS)
+	$(LIBCON_C) -out:$@ @<<
+$(**: =
+)
+<<
+
+clean::
+	-$(RM) $(LIBASN1_S)
+
 
 #
 # Generate list of exports
@@ -421,7 +546,7 @@ $(OBJ)\der-private.h: $(libasn1_SOURCES)
 clean::
 	-$(RM) $(INCDIR)\der-protos.h
 
-all:: $(INCFILES) $(GENINCFILES) $(ASN1_BINARIES) $(LIBASN1)
+all:: $(INCFILES) $(GENINCFILES) $(ASN1_BINARIES) $(LIBASN1) $(LIBASN1_S)
 
 all-tools:: $(LIBEXECDIR)\asn1_print.exe $(BINDIR)\asn1_gen.exe
 

--- a/lib/asn1/gen.c
+++ b/lib/asn1/gen.c
@@ -427,7 +427,9 @@ generate_header_of_codefile(const char *name)
     fprintf (codefile,
 	     "/* Generated from %s */\n"
 	     "/* Do not edit */\n\n"
-	     "#define  ASN1_LIB\n\n"
+	     "#if defined(_WIN32) && !defined(ASN1_LIB)\n"
+	     "# error \"ASN1_LIB must be defined\"\n"
+	     "#endif\n"
 	     "#include <stdio.h>\n"
 	     "#include <stdlib.h>\n"
 	     "#include <time.h>\n"

--- a/lib/asn1/gen_template.c
+++ b/lib/asn1/gen_template.c
@@ -549,11 +549,11 @@ defval(struct templatehead *temp, Member *m)
 {
     switch (m->defval->type) {
     case booleanvalue:
-        add_line(temp, "{ A1_OP_DEFVAL|A1_DV_BOOLEAN, ~0, (void *)%u }",
+	add_line(temp, "{ A1_OP_DEFVAL|A1_DV_BOOLEAN, ~0, (void *)(uintptr_t)%u }",
                  m->defval->u.booleanvalue);
         break;
     case nullvalue:
-        add_line(temp, "{ A1_OP_DEFVAL|A1_DV_NULL, ~0, (void *)0 }");
+	add_line(temp, "{ A1_OP_DEFVAL|A1_DV_NULL, ~0, (void *)(uintptr_t)0 }");
         break;
     case integervalue: {
         const char *dv = "A1_DV_INTEGER";
@@ -585,7 +585,7 @@ defval(struct templatehead *temp, Member *m)
             dv = "A1_DV_INTEGER64";
         else
             dv = "A1_DV_INTEGER32";
-        add_line(temp, "{ A1_OP_DEFVAL|%s, ~0, (void *)%llu }",
+	add_line(temp, "{ A1_OP_DEFVAL|%s, ~0, (void *)(uintptr_t)%llu }",
                  dv, (long long)m->defval->u.integervalue);
         break;
     }
@@ -595,7 +595,7 @@ defval(struct templatehead *temp, Member *m)
         if (rk_strasvis(&quoted, m->defval->u.stringvalue,
                         VIS_CSTYLE | VIS_NL, "\"") < 0)
             err(1, "Could not quote a string");
-        add_line(temp, "{ A1_OP_DEFVAL|A1_DV_UTF8STRING, ~0, (void *)\"%s\" }",
+	add_line(temp, "{ A1_OP_DEFVAL|A1_DV_UTF8STRING, ~0, (void *)(uintptr_t)\"%s\" }",
                  quoted);
         free(quoted);
         break;
@@ -628,7 +628,7 @@ defval(struct templatehead *temp, Member *m)
         sz -= len;
         p += len;
 
-        add_line(temp, "{ A1_OP_DEFVAL|A1_DV_INTEGER, ~0, (void *)\"%s\" }", s);
+	add_line(temp, "{ A1_OP_DEFVAL|A1_DV_INTEGER, ~0, (void *)(uintptr_t)\"%s\" }", s);
         free(s);
         break;
     }
@@ -794,7 +794,7 @@ template_object_set(IOSObjectSet *os, Field *typeidfield, Field *opentypefield)
         switch (typeidobjf->value->type) {
         case integervalue:
             add_line(&tl->template,
-                     "{ A1_OP_OPENTYPE_ID | A1_OTI_IS_INTEGER, 0, (void *)%lld }",
+		     "{ A1_OP_OPENTYPE_ID | A1_OTI_IS_INTEGER, 0, (void *)(uintptr_t)%lld }",
                      (long long)typeidobjf->value->u.integervalue);
             break;
         case objectidentifiervalue:
@@ -820,7 +820,7 @@ template_object_set(IOSObjectSet *os, Field *typeidfield, Field *opentypefield)
     }
     free(objects);
 
-    tlist_header(tl, "{ 0, 0, ((void *)%lu) }", nobjs);
+    tlist_header(tl, "{ 0, 0, ((void *)(uintptr_t)%lu) }", nobjs);
     tlist_print(tl);
     tlist_add(tl);
     os->symbol->emitted_template = 1;
@@ -957,7 +957,7 @@ template_members(struct templatehead *temp,
                          "{ A1_OP_NAME, %d, \"%s\" }", m->val, m->name);
                 nmemb++;
             }
-            tlist_header(tl, "{ 0, 0, ((void *)%lu) }", nmemb);
+	    tlist_header(tl, "{ 0, 0, ((void *)(uintptr_t)%lu) }", nmemb);
             /* XXX Accidentally O(N^2)? */
             if (!tlist_find_dup(tl)) {
                 tlist_print(tl);
@@ -1039,7 +1039,7 @@ template_members(struct templatehead *temp,
 	}
 
 	fprintf(f, "static const struct asn1_template asn1_%s_%s[] = {\n", basetype, bname);
-	fprintf(f, "/* 0 */ { 0%s, sizeof(%s), ((void *)%lu) },\n",
+	fprintf(f, "/* 0 */ { 0%s, sizeof(%s), ((void *)(uintptr_t)%lu) },\n",
 		rfc1510_bitstring ? "|A1_HBF_RFC1510" : "",
 		basetype, (unsigned long)count);
 	i = 1;
@@ -1343,7 +1343,7 @@ template_members(struct templatehead *temp,
 	}
 
 	fprintf(f, "static const struct asn1_template %s[] = {\n", tname);
-	fprintf(f, "/* 0 */ { %s, offsetof(%s%s, element), ((void *)%lu) },\n",
+	fprintf(f, "/* 0 */ { %s, offsetof(%s%s, element), ((void *)(uintptr_t)%lu) },\n",
 		e ? e : "0", isstruct ? "struct " : "", basetype, (unsigned long)count);
 	i = 1;
 	HEIM_TAILQ_FOREACH(q, &template, members) {
@@ -1464,7 +1464,7 @@ generate_template_type(const char *varname,
 
     fprintf(get_code_file(), "/* generate_template_type: %s */\n", tl->name);
 
-    tlist_header(tl, "{ 0%s%s, sizeof(%s), ((void *)%lu) }",
+    tlist_header(tl, "{ 0%s%s, sizeof(%s), ((void *)(uintptr_t)%lu) }",
 		 (symname && preserve_type(symname)) ? "|A1_HF_PRESERVE" : "",
 		 have_ellipsis ? "|A1_HF_ELLIPSIS" : "", szt, tlist_count(tl));
 

--- a/lib/gssapi/NTMakefile
+++ b/lib/gssapi/NTMakefile
@@ -33,6 +33,8 @@
 
 RELDIR=lib\gssapi 
 
+intcflags=-DASN1_LIB
+
 !include ../../windows/NTMakefile.w32 
 
 krb5src = \

--- a/lib/hdb/NTMakefile
+++ b/lib/hdb/NTMakefile
@@ -31,6 +31,8 @@
 
 RELDIR=lib\hdb
 
+intcflags=-DASN1_LIB
+
 !include ../../windows/NTMakefile.w32 
 
 gen_files_hdb = $(OBJ)\asn1_hdb_asn1.x

--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -356,18 +356,22 @@ ROKEN_CPP_START
 
 #define fsync   _commit
 
-/* The MSVC implementation of snprintf is not C99 compliant.  */
+#define timezone    _timezone
+
+#define tzname  _tzname
+
+#define _PIPE_BUFFER_SZ 8192
+#define pipe(fds) _pipe((fds), _PIPE_BUFFER_SZ, O_BINARY);
+
+#define ftruncate(fd, sz) _chsize((fd), (sz))
+
+#if !defined(HAVE_UCRT)
 #define snprintf    rk_snprintf
 #define vsnprintf   rk_vsnprintf
 #define vasnprintf  rk_vasnprintf
 #define vasprintf   rk_vasprintf
 #define asnprintf   rk_asnprintf
 #define asprintf    rk_asprintf
-
-#define _PIPE_BUFFER_SZ 8192
-#define pipe(fds) _pipe((fds), _PIPE_BUFFER_SZ, O_BINARY);
-
-#define ftruncate(fd, sz) _chsize((fd), (sz))
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
 rk_snprintf (char *str, size_t sz, const char *format, ...);
@@ -386,6 +390,7 @@ rk_vasnprintf (char **ret, size_t max_sz, const char *format, va_list args);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
 rk_vsnprintf (char *str, size_t sz, const char *format, va_list args);
+#endif /* !defined(HAVE_UCRT) */
 
 /* missing stat.h predicates */
 

--- a/lib/roken/strtoll.c
+++ b/lib/roken/strtoll.c
@@ -38,6 +38,8 @@
 
 #include "roken.h"
 
+#ifndef HAVE_STRTOLL
+
 /* #include <sys/cdefs.h> */
 
 #include <limits.h>
@@ -150,3 +152,4 @@ noconv:
 	*endptr = (char *)(any ? s - 1 : nptr);
     return ret;
 }
+#endif /* !HAVE_STRTOLL */

--- a/lib/roken/strtoull.c
+++ b/lib/roken/strtoull.c
@@ -38,6 +38,8 @@
 
 #include "roken.h"
 
+#ifndef HAVE_STRTOULL
+
 /* #include <sys/cdefs.h> */
 
 #include <limits.h>
@@ -124,3 +126,4 @@ noconv:
 	*endptr = (char *)(any ? s - 1 : nptr);
     return (acc);
 }
+#endif /* !HAVE_STRTOULL */

--- a/packages/windows/installer/NTMakefile
+++ b/packages/windows/installer/NTMakefile
@@ -133,7 +133,13 @@ clean::
 ######################################################################
 # Runtime modules
 
-!if [ $(PERL) $(SRC)\cf\w32-detect-vc-version.pl $(CC) ]==16
+!if [ $(PERL) $(SRC)\cf\w32-detect-vc-version.pl $(CC) ]==19
+VCVER=VC2019
+!elseif [ $(PERL) $(SRC)\cf\w32-detect-vc-version.pl $(CC) ]==18
+VCVER=VC2018
+!elseif [ $(PERL) $(SRC)\cf\w32-detect-vc-version.pl $(CC) ]==17
+VCVER=VC2017
+!elseif [ $(PERL) $(SRC)\cf\w32-detect-vc-version.pl $(CC) ]==16
 VCVER=VC100
 !elseif [ $(PERL) $(SRC)\cf\w32-detect-vc-version.pl $(CC) ]==15
 VCVER=VC90
@@ -164,21 +170,26 @@ MMDIR=$(SystemDrive)\Program Files (x86)\Common Files\Merge Modules
 !endif
 !endif
 
-!if exist("$(MMDIR)")
-
+#
+# Don't specify a runtime module when the Universal C Runtime
+# is available.
+#
+!if "$(APPVER)"=="10.0"
+RUNTIMEMODULE32=""
+RUNTIMEMODULE64=""
+!else
+! if exist("$(MMDIR)")
 RUNTIMEMODULE32="$(MMDIR)\Microsoft_$(VCVER)_$(CRTNAME)_x86.msm"
-!if "$(VCVER)"=="VC100"
-RUNTIMEMODULE64="$(MMDIR)\Microsoft_$(VCVER)_$(CRTNAME)_x64.msm"
-!else
+!  if "$(VCVER)"=="VC90" || "$(VCVER)"=="VC80"
 RUNTIMEMODULE64="$(MMDIR)\Microsoft_$(VCVER)_$(CRTNAME)_x86_x64.msm"
-!endif
-
-!else
+!  else
+RUNTIMEMODULE64="$(MMDIR)\Microsoft_$(VCVER)_$(CRTNAME)_x64.msm"
+!  endif
+! else
 RUNTIMEMODULE32="$(MSSDK)\Redist\VC\microsoft.vcxx.crt.x86_msm.msm"
 RUNTIMEMODULE64="$(MSSDK)\Redist\VC\microsoft.vcxx.crt.x64_msm.msm"
-
+! endif
 !endif
-
 
 ######################################################################
 # Heimdal installer

--- a/packages/windows/installer/heimdal-installer.wxs
+++ b/packages/windows/installer/heimdal-installer.wxs
@@ -99,9 +99,10 @@
       <Merge Id='Heimdal.Policy.32' Language='0'
              SourceFile='$(var.InstDir32)\Heimdal.Policy.msm' />
 
-      <Merge Id='Runtime.32' Language='0'
-             SourceFile='$(var.RuntimeModule32)' />
-
+      <?if "$(var.RuntimeModule32)" != "" ?>
+	<Merge Id='Runtime.32' Language='0'
+	       SourceFile='$(var.RuntimeModule32)' />
+      <?endif?>
     </DirectoryRef>
     <?endif?>
 
@@ -127,9 +128,10 @@
       <Merge Id='Heimdal.Policy.64' Language='0'
              SourceFile='$(var.InstDir64)\Heimdal.Policy.msm' />
 
-      <Merge Id='Runtime.64' Language='0'
-             SourceFile='$(var.RuntimeModule64)' />
-
+      <?if "$(var.RuntimeModule64)" != "" ?>
+	<Merge Id='Runtime.64' Language='0'
+	       SourceFile='$(var.RuntimeModule64)' />
+      <?endif?>
     </DirectoryRef>
     <?endif?>
 
@@ -370,12 +372,12 @@
       <MergeRef Id='Heimdal.Assemblies.64' />
       <MergeRef Id='Heimdal.GSS.64' />
       <MergeRef Id='Heimdal.Policy.64' />
-      <MergeRef Id='Runtime.64' />
+      <?if "$(var.RuntimeModule64)" != "" ?><MergeRef Id='Runtime.64' /><?endif?>
       <?else?>
       <MergeRef Id='Heimdal.Assemblies.32' />
       <MergeRef Id='Heimdal.GSS.32' />
       <MergeRef Id='Heimdal.Policy.32' />
-      <MergeRef Id='Runtime.32' />
+      <?if "$(var.RuntimeModule32)" != "" ?><MergeRef Id='Runtime.32' /><?endif?>
       <?endif?>
 
       <?ifdef Target32?>
@@ -393,7 +395,7 @@
         <MergeRef Id='Heimdal.Assemblies.32' />
 	<MergeRef Id='Heimdal.GSS.32' />
         <MergeRef Id='Heimdal.Policy.32' />
-        <MergeRef Id='Runtime.32' />
+	<?if "$(var.RuntimeModule32)" != "" ?><MergeRef Id='Runtime.32' /><?endif?>
       </Feature>
       <?endif?>
       <?endif?>

--- a/windows/NTMakefile.sdk
+++ b/windows/NTMakefile.sdk
@@ -1,0 +1,128 @@
+########################################################################
+#
+# Copyright (c) 2021, PADL Software Pty Ltd.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN if ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+!if !defined(CPU) || "$(CPU)" == ""
+CPU         =AMD64
+!endif
+
+!if "$(CPU)" == "X86" || "$(CPU)" == "x86"
+CPU         =i386
+!endif
+
+!if !defined(APPVER)
+APPVER      =6.1
+!endif
+
+!if "$(APPVER)" == "5.0"
+NMAKE_WINVER=0x0500
+!elseif "$(APPVER)" == "5.01"
+NMAKE_WINVER=0x0501
+!elseif "$(APPVER)" == "5.02"
+NMAKE_WINVER=0x0502
+!elseif "$(APPVER)" == "6.0"
+NMAKE_WINVER=0x0600
+!elseif "$(APPVER)" == "6.1"
+NMAKE_WINVER=0x0601
+!elseif "$(APPVER)" == "10.0"
+NMAKE_WINVER=0x0A00
+!endif
+
+cc          = cl
+link        = link
+implib      = lib
+
+cflags      = -c -DCRTAPI1=_cdecl -DCRTAPI2=_cdecl -nologo -GS -W4
+
+!if "$(CPU)" == "i386"
+cflags      = $(cflags) -D_X86_=1
+!endif
+!if "$(CPU)" == "AMD64"
+cflags      = $(cflags) -D_AMD64_=1
+!endif
+!if "$(CPU)" == "ARM"
+cflags      = $(cflags) -D_ARM_=1
+!endif
+!if "$(CPU)" == "ARM64"
+cflags      = $(cflags) -D_ARM64_=1
+!endif
+
+cflags      = $(cflags) -DWIN32 -D_WIN32
+!if "$(CPU)" == "AMD64" || "$(CPU)" == "ARM64"
+cflags      = $(cflags) -DWIN64 -D_WIN64
+!endif
+
+cflags      = $(cflags) -D_WINNT -D_WIN32_WINNT=$(NMAKE_WINVER)
+cflags      = $(cflags) -DNTDDI_VERSION=$(NMAKE_WINVER)0000
+cflags      = $(cflags) -D_WIN32_IE=$(NMAKE_WINVER) -DWINVER=$(NMAKE_WINVER)
+
+!ifdef NODEBUG
+cdebug      = -Ox -DNDEBUG
+!else
+cdebug      = -Zi -Od -DDEBUG
+!endif
+
+cvarsmt     = -D_MT
+cvarsdll    = -D_MT -D_DLL
+!ifdef NODEBUG
+cvarsmt     = $(cvarsmt) -MTd
+cvarsdll    = $(cvarsdll) -MDd
+!else
+cvarsmt     = $(cvarsmt) -MT
+cvarsdll    = $(cvarsdll) -MD
+!endif
+cvars       = $(cvarsmt)
+
+lflags      = $(lflags) /INCREMENTAL:NO /NOLOGO
+!ifdef NODEBUG
+ldebug      = /RELEASE
+!else
+ldebug      = /DEBUG /DEBUGTYPE:cv
+!endif
+
+!if "$(CPU)" == "i386"
+dllentry    = _DllMainCRTStartup@12
+!else
+dllentry    = _DllMainCRTStartup
+!endif
+
+conlflags   = $(lflags) -subsystem:console,$(APPVER)
+guilflags   = $(lflags) -subsystem:windows,$(APPVER)
+dlllflags   = $(lflags) -entry:$(dllentry) -dll
+
+baselibs    = kernel32.lib ws2_32.lib mswsock.lib advapi32.lib
+conlibs     = $(baselibs)
+conlibsmt   = $(baselibs)
+conlibsdll  = $(baselibs)
+
+winlibs     = $(baselibs) user32.lib gdi32.lib comdlg32.lib winspool.lib
+guilibs     = $(winlibs)
+guilibsmt   = $(winlibs)
+guilibsdll  = $(winlibs)

--- a/windows/NTMakefile.w32
+++ b/windows/NTMakefile.w32
@@ -39,7 +39,7 @@ prep::
 
 all:: prep
 
-!include <Win32.Mak>
+!include "NTMakefile.sdk"
 
 !ifdef NODEBUG
 BUILD=rel

--- a/windows/NTMakefile.w32
+++ b/windows/NTMakefile.w32
@@ -207,6 +207,8 @@ EXEGUILINK_C = $(LINK) $(ldebug) $(guilflags) $(guilibsdll) $(libmach)
 DLLCONLINK_C = $(LINK) $(ldebug) $(dlllflags) $(conlibsdll) $(libmach)
 DLLGUILINK_C = $(LINK) $(ldebug) $(dlllflags) $(guilibsdll) $(libmach)
 
+C2OBJ_C_MT = $(CC) $(cdebug) $(cflags) $(cvarsmt) $(AUXCFLAGS) $(intcflags) $(cdefines) $(cincdirs) $(cwarn)
+
 !else # STATICRUNTIME
 
 C2OBJ_C = $(CC) $(cdebug) $(cflags) $(cvarsmt) $(AUXCFLAGS) $(intcflags) $(cdefines) $(cincdirs) $(cwarn)
@@ -574,6 +576,7 @@ DLLPREP_MERGE=\
 #
 
 LIBASN1	    =$(LIBDIR)\libasn1.lib
+LIBASN1_S   =$(LIBDIR)\libasn1_s.lib
 LIBCOMERR   =$(LIBDIR)\libcom_err.lib
 LIBEDITLINE =$(LIBDIR)\libeditline.lib
 LIBGSSAPI   =$(LIBDIR)\libgssapi.lib


### PR DESCRIPTION
Permit building with Windows 10 SDK and Visual Studio 2015 through 2019

Ensure that LIB_ASN1 is defined by all compiled source files that might be linked to generated ASN1 sources.  Doing this correctly prevents many linker warnings complaining about a library object referencing an internal DATA object via an import.

Build a static runtime version of libasn1.lib named libasn1_s.lib.   This is needed by thirdparty components that require the ASN1 library but cannot link to a dynamic runtime.

When casting an integer constant to `(void *)` use an intermediate cast to `(uintptr_t)` to prevent warnings about a smaller signed integer being extended to a larger unsigned pointer type.