### PR TITLE
Use ASN.1 type decoration for profit in HDB and for PACs

### DIFF
--- a/kadmin/load.c
+++ b/kadmin/load.c
@@ -519,7 +519,7 @@ doit(const char *filename, int mergep)
 	if (parse_keys(&ent.entry, e.key)) {
 	    fprintf (stderr, "%s:%d:error parsing keys (%s)\n",
 		     filename, lineno, e.key);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
@@ -527,35 +527,35 @@ doit(const char *filename, int mergep)
 	if (parse_event(&ent.entry.created_by, e.created) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing created event (%s)\n",
 		     filename, lineno, e.created);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
 	if (parse_event_alloc (&ent.entry.modified_by, e.modified) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing event (%s)\n",
 		     filename, lineno, e.modified);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
 	if (parse_time_string_alloc (&ent.entry.valid_start, e.valid_start) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing time (%s)\n",
 		     filename, lineno, e.valid_start);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
 	if (parse_time_string_alloc (&ent.entry.valid_end,   e.valid_end) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing time (%s)\n",
 		     filename, lineno, e.valid_end);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
 	if (parse_time_string_alloc (&ent.entry.pw_end,      e.pw_end) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing time (%s)\n",
 		     filename, lineno, e.pw_end);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
@@ -563,7 +563,7 @@ doit(const char *filename, int mergep)
 	if (parse_integer_alloc (&ent.entry.max_life,  e.max_life) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing lifetime (%s)\n",
 		     filename, lineno, e.max_life);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 
@@ -571,7 +571,7 @@ doit(const char *filename, int mergep)
 	if (parse_integer_alloc (&ent.entry.max_renew, e.max_renew) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing lifetime (%s)\n",
 		     filename, lineno, e.max_renew);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
@@ -579,7 +579,7 @@ doit(const char *filename, int mergep)
 	if (parse_hdbflags2int (&ent.entry.flags, e.flags) != 1) {
 	    fprintf (stderr, "%s:%d:error parsing flags (%s)\n",
 		     filename, lineno, e.flags);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
@@ -587,7 +587,7 @@ doit(const char *filename, int mergep)
 	if(parse_generation(e.generation, &ent.entry.generation) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing generation (%s)\n",
 		     filename, lineno, e.generation);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
@@ -595,13 +595,13 @@ doit(const char *filename, int mergep)
 	if (parse_extensions(&e.extensions, &ent.entry.extensions) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing extension (%s)\n",
 		     filename, lineno, e.extensions);
-	    hdb_free_entry (context, &ent);
+	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
 
 	ret2 = db->hdb_store(context, db, HDB_F_REPLACE, &ent);
-	hdb_free_entry (context, &ent);
+	hdb_free_entry (context, db, &ent);
 	if (ret2) {
 	    krb5_warn(context, ret2, "db_store");
 	    break;

--- a/kadmin/load.c
+++ b/kadmin/load.c
@@ -418,7 +418,7 @@ doit(const char *filename, int mergep)
     int lineno;
     int flags = O_RDWR;
     struct entry e;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     HDB *db = _kadm5_s_get_db(kadm_handle);
 
     f = fopen(filename, "r");
@@ -506,7 +506,7 @@ doit(const char *filename, int mergep)
 	skip_next(p);
 
 	memset(&ent, 0, sizeof(ent));
-	ret2 = krb5_parse_name(context, e.principal, &ent.entry.principal);
+	ret2 = krb5_parse_name(context, e.principal, &ent.principal);
 	if (ret2) {
 	    const char *msg = krb5_get_error_message(context, ret);
 	    fprintf(stderr, "%s:%d:%s (%s)\n",
@@ -516,7 +516,7 @@ doit(const char *filename, int mergep)
 	    continue;
 	}
 
-	if (parse_keys(&ent.entry, e.key)) {
+	if (parse_keys(&ent, e.key)) {
 	    fprintf (stderr, "%s:%d:error parsing keys (%s)\n",
 		     filename, lineno, e.key);
 	    hdb_free_entry (context, db, &ent);
@@ -524,35 +524,35 @@ doit(const char *filename, int mergep)
 	    continue;
 	}
 
-	if (parse_event(&ent.entry.created_by, e.created) == -1) {
+	if (parse_event(&ent.created_by, e.created) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing created event (%s)\n",
 		     filename, lineno, e.created);
 	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
-	if (parse_event_alloc (&ent.entry.modified_by, e.modified) == -1) {
+	if (parse_event_alloc (&ent.modified_by, e.modified) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing event (%s)\n",
 		     filename, lineno, e.modified);
 	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
-	if (parse_time_string_alloc (&ent.entry.valid_start, e.valid_start) == -1) {
+	if (parse_time_string_alloc (&ent.valid_start, e.valid_start) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing time (%s)\n",
 		     filename, lineno, e.valid_start);
 	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
-	if (parse_time_string_alloc (&ent.entry.valid_end,   e.valid_end) == -1) {
+	if (parse_time_string_alloc (&ent.valid_end,   e.valid_end) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing time (%s)\n",
 		     filename, lineno, e.valid_end);
 	    hdb_free_entry (context, db, &ent);
             ret = 1;
 	    continue;
 	}
-	if (parse_time_string_alloc (&ent.entry.pw_end,      e.pw_end) == -1) {
+	if (parse_time_string_alloc (&ent.pw_end,      e.pw_end) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing time (%s)\n",
 		     filename, lineno, e.pw_end);
 	    hdb_free_entry (context, db, &ent);
@@ -560,7 +560,7 @@ doit(const char *filename, int mergep)
 	    continue;
 	}
 
-	if (parse_integer_alloc (&ent.entry.max_life,  e.max_life) == -1) {
+	if (parse_integer_alloc (&ent.max_life,  e.max_life) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing lifetime (%s)\n",
 		     filename, lineno, e.max_life);
 	    hdb_free_entry (context, db, &ent);
@@ -568,7 +568,7 @@ doit(const char *filename, int mergep)
 	    continue;
 
 	}
-	if (parse_integer_alloc (&ent.entry.max_renew, e.max_renew) == -1) {
+	if (parse_integer_alloc (&ent.max_renew, e.max_renew) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing lifetime (%s)\n",
 		     filename, lineno, e.max_renew);
 	    hdb_free_entry (context, db, &ent);
@@ -576,7 +576,7 @@ doit(const char *filename, int mergep)
 	    continue;
 	}
 
-	if (parse_hdbflags2int (&ent.entry.flags, e.flags) != 1) {
+	if (parse_hdbflags2int (&ent.flags, e.flags) != 1) {
 	    fprintf (stderr, "%s:%d:error parsing flags (%s)\n",
 		     filename, lineno, e.flags);
 	    hdb_free_entry (context, db, &ent);
@@ -584,7 +584,7 @@ doit(const char *filename, int mergep)
 	    continue;
 	}
 
-	if(parse_generation(e.generation, &ent.entry.generation) == -1) {
+	if(parse_generation(e.generation, &ent.generation) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing generation (%s)\n",
 		     filename, lineno, e.generation);
 	    hdb_free_entry (context, db, &ent);
@@ -592,7 +592,7 @@ doit(const char *filename, int mergep)
 	    continue;
 	}
 
-	if (parse_extensions(&e.extensions, &ent.entry.extensions) == -1) {
+	if (parse_extensions(&e.extensions, &ent.extensions) == -1) {
 	    fprintf (stderr, "%s:%d:error parsing extension (%s)\n",
 		     filename, lineno, e.extensions);
 	    hdb_free_entry (context, db, &ent);

--- a/kdc/altsecid_gss_preauth_authorizer.c
+++ b/kdc/altsecid_gss_preauth_authorizer.c
@@ -397,7 +397,7 @@ authorize(void *ctx,
     struct altsecid_gss_preauth_authorizer_context *c = ctx;
     struct ad_server_tuple *server = NULL;
     krb5_error_code ret;
-    krb5_const_realm realm = krb5_principal_get_realm(r->context, r->client->entry.principal);
+    krb5_const_realm realm = krb5_principal_get_realm(r->context, r->client->principal);
     krb5_boolean reconnect_p = FALSE;
     krb5_boolean is_tgs;
     heim_data_t requestor_sid = NULL;
@@ -405,7 +405,7 @@ authorize(void *ctx,
     *authorized = FALSE;
     *mapped_name = NULL;
 
-    if (!krb5_principal_is_federated(r->context, r->client->entry.principal) ||
+    if (!krb5_principal_is_federated(r->context, r->client->principal) ||
         (ret_flags & GSS_C_ANON_FLAG))
         return KRB5_PLUGIN_NO_HANDLE;
 

--- a/kdc/digest-service.c
+++ b/kdc/digest-service.c
@@ -60,7 +60,7 @@ ntlm_service(void *ctx, const heim_idata *req,
     unsigned char sessionkey[16];
     heim_idata rep = { 0, NULL };
     krb5_context context = ctx;
-    hdb_entry_ex *user = NULL;
+    hdb_entry *user = NULL;
     HDB *db = NULL;
     Key *key = NULL;
     NTLMReply ntp;
@@ -119,7 +119,7 @@ ntlm_service(void *ctx, const heim_idata *req,
 	if (ret)
 	    goto failed;
 
-	ret = hdb_enctype2key(context, &user->entry, NULL,
+	ret = hdb_enctype2key(context, user, NULL,
 			      ETYPE_ARCFOUR_HMAC_MD5, &key);
 	if (ret) {
 	    krb5_set_error_message(context, ret, "NTLM missing arcfour key");

--- a/kdc/digest-service.c
+++ b/kdc/digest-service.c
@@ -61,6 +61,7 @@ ntlm_service(void *ctx, const heim_idata *req,
     heim_idata rep = { 0, NULL };
     krb5_context context = ctx;
     hdb_entry_ex *user = NULL;
+    HDB *db = NULL;
     Key *key = NULL;
     NTLMReply ntp;
     size_t size;
@@ -113,7 +114,7 @@ ntlm_service(void *ctx, const heim_idata *req,
 	krb5_principal_set_type(context, client, KRB5_NT_NTLM);
 
 	ret = _kdc_db_fetch(context, config, client,
-			    HDB_F_GET_CLIENT, NULL, NULL, &user);
+			    HDB_F_GET_CLIENT, NULL, &db, &user);
 	krb5_free_principal(context, client);
 	if (ret)
 	    goto failed;
@@ -213,7 +214,7 @@ ntlm_service(void *ctx, const heim_idata *req,
 
     free_NTLMRequest2(&ntq);
     if (user)
-	_kdc_free_ent (context, user);
+	_kdc_free_ent (context, db, user);
 }
 
 static int help_flag;

--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -109,7 +109,7 @@ get_fastuser_crypto(astgs_request_t r,
 {
     krb5_principal fast_princ;
     HDB *fast_db;
-    hdb_entry_ex *fast_user = NULL;
+    hdb_entry *fast_user = NULL;
     Key *cookie_key = NULL;
     krb5_crypto fast_crypto = NULL;
     krb5_error_code ret;
@@ -131,7 +131,7 @@ get_fastuser_crypto(astgs_request_t r,
 	ret = _kdc_get_preferred_key(r->context, r->config, fast_user,
 				     "fast-cookie", &enctype, &cookie_key);
     else
-	ret = hdb_enctype2key(r->context, &fast_user->entry, NULL,
+	ret = hdb_enctype2key(r->context, fast_user, NULL,
 			      enctype, &cookie_key);
     if (ret)
 	goto out;
@@ -563,7 +563,7 @@ fast_unwrap_request(astgs_request_t r,
 	    goto out;
 	}
 
-	ret = hdb_enctype2key(r->context, &r->armor_server->entry, NULL,
+	ret = hdb_enctype2key(r->context, r->armor_server, NULL,
 			      ap_req.ticket.enc_part.etype,
 			      &r->armor_key);
 	if (ret) {
@@ -836,7 +836,7 @@ _kdc_fast_check_armor_pac(astgs_request_t r)
     krb5_pac mspac = NULL;
     krb5_principal armor_client_principal = NULL;
     HDB *armor_db;
-    hdb_entry_ex *armor_client = NULL;
+    hdb_entry *armor_client = NULL;
     char *armor_client_principal_name = NULL;
 
     flags = HDB_F_FOR_TGS_REQ;

--- a/kdc/gss_preauth.c
+++ b/kdc/gss_preauth.c
@@ -682,6 +682,7 @@ _kdc_gss_check_client(astgs_request_t r,
     krb5_principal initiator_princ = NULL;
     hdb_entry_ex *initiator = NULL;
     krb5_boolean authorized = FALSE;
+    HDB *clientdb = r->clientdb;
 
     OM_uint32 minor;
     gss_buffer_desc display_name = GSS_C_EMPTY_BUFFER;
@@ -742,7 +743,7 @@ _kdc_gss_check_client(astgs_request_t r,
     if (krb5_principal_is_federated(r->context, r->client->entry.principal)) {
         initiator->entry.flags.force_canonicalize = 1;
 
-        _kdc_free_ent(r->context, r->client);
+        _kdc_free_ent(r->context, clientdb, r->client);
         r->client = initiator;
         initiator = NULL;
     } else if (!krb5_principal_compare(r->context,
@@ -760,7 +761,7 @@ _kdc_gss_check_client(astgs_request_t r,
 out:
     krb5_free_principal(r->context, initiator_princ);
     if (initiator)
-        _kdc_free_ent(r->context, initiator);
+        _kdc_free_ent(r->context, r->clientdb, initiator);
     gss_release_buffer(&minor, &display_name);
 
     return ret;

--- a/kdc/gss_preauth.c
+++ b/kdc/gss_preauth.c
@@ -584,7 +584,7 @@ pa_gss_authorize_default(astgs_request_t r,
 {
     krb5_error_code ret;
     krb5_principal principal;
-    krb5_const_realm realm = r->server->entry.principal->realm;
+    krb5_const_realm realm = r->server->principal->realm;
     int flags = 0, cross_realm_allowed = 0, unauth_anon;
 
     /*
@@ -680,7 +680,7 @@ _kdc_gss_check_client(astgs_request_t r,
 {
     krb5_error_code ret;
     krb5_principal initiator_princ = NULL;
-    hdb_entry_ex *initiator = NULL;
+    hdb_entry *initiator = NULL;
     krb5_boolean authorized = FALSE;
     HDB *clientdb = r->clientdb;
 
@@ -740,15 +740,15 @@ _kdc_gss_check_client(astgs_request_t r,
      * two principals must match, noting that GSS pre-authentication is
      * for authentication, not general purpose impersonation.
      */
-    if (krb5_principal_is_federated(r->context, r->client->entry.principal)) {
-        initiator->entry.flags.force_canonicalize = 1;
+    if (krb5_principal_is_federated(r->context, r->client->principal)) {
+        initiator->flags.force_canonicalize = 1;
 
         _kdc_free_ent(r->context, clientdb, r->client);
         r->client = initiator;
         initiator = NULL;
     } else if (!krb5_principal_compare(r->context,
-                                       r->client->entry.principal,
-                                       initiator->entry.principal)) {
+                                       r->client->principal,
+                                       initiator->principal)) {
         kdc_log(r->context, r->config, 2,
                 "GSS %s initiator %.*s does not match principal %s",
                 gss_oid_to_name(gcp->mech_type),

--- a/kdc/hprop.c
+++ b/kdc/hprop.c
@@ -87,28 +87,28 @@ open_socket(krb5_context context, const char *hostname, const char *port)
 }
 
 krb5_error_code
-v5_prop(krb5_context context, HDB *db, hdb_entry_ex *entry, void *appdata)
+v5_prop(krb5_context context, HDB *db, hdb_entry *entry, void *appdata)
 {
     krb5_error_code ret;
     struct prop_data *pd = appdata;
     krb5_data data;
 
     if(encrypt_flag) {
-	ret = hdb_seal_keys_mkey(context, &entry->entry, mkey5);
+	ret = hdb_seal_keys_mkey(context, entry, mkey5);
 	if (ret) {
 	    krb5_warn(context, ret, "hdb_seal_keys_mkey");
 	    return ret;
 	}
     }
     if(decrypt_flag) {
-	ret = hdb_unseal_keys_mkey(context, &entry->entry, mkey5);
+	ret = hdb_unseal_keys_mkey(context, entry, mkey5);
 	if (ret) {
 	    krb5_warn(context, ret, "hdb_unseal_keys_mkey");
 	    return ret;
 	}
     }
 
-    ret = hdb_entry2value(context, &entry->entry, &data);
+    ret = hdb_entry2value(context, entry, &data);
     if(ret) {
 	krb5_warn(context, ret, "hdb_entry2value");
 	return ret;

--- a/kdc/hprop.h
+++ b/kdc/hprop.h
@@ -53,7 +53,7 @@ struct prop_data{
 #define NEVERDATE ((1U << 31) - 1)
 #endif
 
-krb5_error_code v5_prop(krb5_context, HDB*, hdb_entry_ex*, void*);
+krb5_error_code v5_prop(krb5_context, HDB*, hdb_entry*, void*);
 int mit_prop_dump(void*, const char*);
 
 #endif /* __HPROP_H__ */

--- a/kdc/hpropd.c
+++ b/kdc/hpropd.c
@@ -279,7 +279,7 @@ main(int argc, char **argv)
 	    else
 		nprincs++;
 	}
-	hdb_free_entry(context, &entry);
+	hdb_free_entry(context, db, &entry);
     }
     if (!print_dump)
 	krb5_log(context, fac, 0, "Received %d principals", nprincs);

--- a/kdc/hpropd.c
+++ b/kdc/hpropd.c
@@ -226,7 +226,7 @@ main(int argc, char **argv)
     nprincs = 0;
     while (1){
 	krb5_data data;
-	hdb_entry_ex entry;
+	hdb_entry entry;
 
 	if (from_stdin) {
 	    ret = krb5_read_message(context, &sock, &data);
@@ -255,7 +255,7 @@ main(int argc, char **argv)
 	    break;
 	}
 	memset(&entry, 0, sizeof(entry));
-	ret = hdb_value2entry(context, &data, &entry.entry);
+	ret = hdb_value2entry(context, &data, &entry);
 	krb5_data_free(&data);
 	if (ret)
 	    krb5_err(context, 1, ret, "hdb_value2entry");
@@ -269,7 +269,7 @@ main(int argc, char **argv)
 	    ret = db->hdb_store(context, db, 0, &entry);
 	    if (ret == HDB_ERR_EXISTS) {
 		char *s;
-		ret = krb5_unparse_name(context, entry.entry.principal, &s);
+		ret = krb5_unparse_name(context, entry.principal, &s);
 		if (ret)
 		    s = strdup(unparseable_name);
 		krb5_warnx(context, "Entry exists: %s", s);

--- a/kdc/kdc-plugin.h
+++ b/kdc/kdc-plugin.h
@@ -38,8 +38,7 @@
 
 #include <krb5.h>
 #include <kdc.h>
-
-struct hdb_entry_ex;
+#include <hdb.h>
 
 /*
  * Allocate a PAC for the given client with krb5_pac_init(),
@@ -47,9 +46,11 @@ struct hdb_entry_ex;
  */
 
 typedef krb5_error_code
-(KRB5_CALLCONV *krb5plugin_kdc_pac_generate)(void *, krb5_context,
-					     struct hdb_entry_ex *, /* client */
-					     struct hdb_entry_ex *, /* server */
+(KRB5_CALLCONV *krb5plugin_kdc_pac_generate)(void *,
+					     krb5_context, /* context */
+					     krb5_kdc_configuration *, /* configuration */
+					     hdb_entry *, /* client */
+					     hdb_entry *, /* server */
 					     const krb5_keyblock *, /* pk_replykey */
 					     uint64_t,	      /* pac_attributes */
 					     krb5_pac *);
@@ -61,12 +62,14 @@ typedef krb5_error_code
  */
 
 typedef krb5_error_code
-(KRB5_CALLCONV *krb5plugin_kdc_pac_verify)(void *, krb5_context,
+(KRB5_CALLCONV *krb5plugin_kdc_pac_verify)(void *,
+					   krb5_context, /* context */
+					   krb5_kdc_configuration *, /* configuration */
 					   const krb5_principal, /* new ticket client */
 					   const krb5_principal, /* delegation proxy */
-					   struct hdb_entry_ex *,/* client */
-					   struct hdb_entry_ex *,/* server */
-					   struct hdb_entry_ex *,/* krbtgt */
+					   hdb_entry *,/* client */
+					   hdb_entry *,/* server */
+					   hdb_entry *,/* krbtgt */
 					   krb5_pac *);
 
 /*
@@ -115,7 +118,7 @@ typedef krb5_error_code
  * Plugins should carefully check API contract notes for changes
  * between plugin API versions.
  */
-#define KRB5_PLUGIN_KDC_VERSION_9	9
+#define KRB5_PLUGIN_KDC_VERSION_10	10
 
 typedef struct krb5plugin_kdc_ftable {
     int			minor_version;

--- a/kdc/kdc.h
+++ b/kdc/kdc.h
@@ -148,10 +148,12 @@ typedef struct krb5_kdc_configuration {
     /* server principal */					\
     krb5_principal server_princ;				\
     hdb_entry_ex *server;					\
+    HDB *serverdb;						\
 								\
     /* presented ticket in TGS-REQ (unused by AS) */		\
     krb5_principal *krbtgt_princ;				\
     hdb_entry_ex *krbtgt;					\
+    HDB *krbtgtdb;						\
     krb5_ticket *ticket;					\
 								\
     krb5_keyblock reply_key;					\

--- a/kdc/kdc.h
+++ b/kdc/kdc.h
@@ -141,18 +141,18 @@ typedef struct krb5_kdc_configuration {
 								\
     /* client principal (AS) or TGT/S4U principal (TGS) */	\
     krb5_principal client_princ;				\
-    hdb_entry_ex *client;					\
+    hdb_entry *client;						\
     HDB *clientdb;						\
     krb5_principal canon_client_princ;				\
 								\
     /* server principal */					\
     krb5_principal server_princ;				\
-    hdb_entry_ex *server;					\
+    hdb_entry *server;						\
     HDB *serverdb;						\
 								\
     /* presented ticket in TGS-REQ (unused by AS) */		\
     krb5_principal *krbtgt_princ;				\
-    hdb_entry_ex *krbtgt;					\
+    hdb_entry *krbtgt;						\
     HDB *krbtgtdb;						\
     krb5_ticket *ticket;					\
 								\

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -88,6 +88,7 @@ struct astgs_request_desc {
 
     krb5_crypto armor_crypto;
     hdb_entry_ex *armor_server;
+    HDB *armor_serverdb;
     krb5_ticket *armor_ticket;
     Key *armor_key;
 

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -87,7 +87,7 @@ struct astgs_request_desc {
     unsigned int fast_asserted : 1;
 
     krb5_crypto armor_crypto;
-    hdb_entry_ex *armor_server;
+    hdb_entry *armor_server;
     HDB *armor_serverdb;
     krb5_ticket *armor_ticket;
     Key *armor_key;

--- a/kdc/kx509.c
+++ b/kdc/kx509.c
@@ -254,7 +254,7 @@ is_local_realm(krb5_context context,
     krb5_error_code ret;
     krb5_principal tgs;
     HDB *db;
-    hdb_entry_ex *ent = NULL;
+    hdb_entry *ent = NULL;
 
     ret = krb5_make_principal(context, &tgs, realm, KRB5_TGS_NAME, realm,
                               NULL);

--- a/kdc/kx509.c
+++ b/kdc/kx509.c
@@ -253,6 +253,7 @@ is_local_realm(krb5_context context,
 {
     krb5_error_code ret;
     krb5_principal tgs;
+    HDB *db;
     hdb_entry_ex *ent = NULL;
 
     ret = krb5_make_principal(context, &tgs, realm, KRB5_TGS_NAME, realm,
@@ -261,9 +262,9 @@ is_local_realm(krb5_context context,
         return ret;
     if (ret == 0)
         ret = _kdc_db_fetch(context, reqctx->config, tgs, HDB_F_GET_KRBTGT,
-                            NULL, NULL, &ent);
+                            NULL, &db, &ent);
     if (ent)
-        _kdc_free_ent(context, ent);
+        _kdc_free_ent(context, db, ent);
     krb5_free_principal(context, tgs);
     if (ret == HDB_ERR_NOENTRY || ret == HDB_ERR_NOT_FOUND_HERE)
         return KRB5KRB_AP_ERR_NOT_US;

--- a/kdc/misc.c
+++ b/kdc/misc.c
@@ -117,7 +117,7 @@ synthesize_client(krb5_context context,
         *(e->entry.max_life) = config->synthetic_clients_max_life;
         *h = e;
     } else {
-        hdb_free_entry(context, e);
+        hdb_free_entry(context, &null_db, e);
     }
     return ret;
 }
@@ -246,9 +246,9 @@ out:
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_free_ent(krb5_context context, hdb_entry_ex *ent)
+_kdc_free_ent(krb5_context context, HDB *db, hdb_entry_ex *ent)
 {
-    hdb_free_entry (context, ent);
+    hdb_free_entry (context, db, ent);
     free (ent);
 }
 

--- a/kdc/mit_dump.c
+++ b/kdc/mit_dump.c
@@ -146,7 +146,7 @@ mit_prop_dump(void *arg, const char *file)
     char *line = NULL;
     int lineno = 0;
     FILE *f;
-    struct hdb_entry_ex ent;
+    hdb_entry ent;
     struct prop_data *pd = arg;
     krb5_storage *sp = NULL;
     krb5_data kdb_ent;
@@ -202,7 +202,7 @@ mit_prop_dump(void *arg, const char *file)
         }
         ret = krb5_storage_to_data(sp, &kdb_ent);
         if (ret) break;
-        ret = _hdb_mdb_value2entry(pd->context, &kdb_ent, 0, &ent.entry);
+        ret = _hdb_mdb_value2entry(pd->context, &kdb_ent, 0, &ent);
         krb5_data_free(&kdb_ent);
         if (ret) {
             warnx("line: %d: failed to store; ignoring", lineno);

--- a/kdc/mit_dump.c
+++ b/kdc/mit_dump.c
@@ -209,7 +209,7 @@ mit_prop_dump(void *arg, const char *file)
             continue;
         }
 	ret = v5_prop(pd->context, NULL, &ent, arg);
-        hdb_free_entry(pd->context, &ent);
+        hdb_free_entry(pd->context, NULL, &ent); /* XXX */
         if (ret) break;
     }
 

--- a/lib/asn1/krb5.opt
+++ b/lib/asn1/krb5.opt
@@ -5,4 +5,5 @@
 --sequence=ETYPE-INFO
 --sequence=ETYPE-INFO2
 --preserve-binary=KDC-REQ-BODY
+--decorate=PrincipalNameAttrs:void:pac?:::
 --decorate=Principal:PrincipalNameAttrs:nameattrs?

--- a/lib/asn1/krb5.opt
+++ b/lib/asn1/krb5.opt
@@ -5,5 +5,5 @@
 --sequence=ETYPE-INFO
 --sequence=ETYPE-INFO2
 --preserve-binary=KDC-REQ-BODY
---decorate=PrincipalNameAttrs:void:pac?:::
+--decorate=PrincipalNameAttrs:heim_object_t:pac
 --decorate=Principal:PrincipalNameAttrs:nameattrs?

--- a/lib/base/heimbasepriv.h
+++ b/lib/base/heimbasepriv.h
@@ -65,6 +65,7 @@ enum {
     HEIM_TID_DATA = 134,
     HEIM_TID_DB = 135,
     HEIM_TID_PA_AUTH_MECH = 136,
+    HEIM_TID_PAC = 137,
     HEIM_TID_USER = 255
 
 };

--- a/lib/hdb/Makefile.am
+++ b/lib/hdb/Makefile.am
@@ -146,10 +146,7 @@ $(srcdir)/hdb-private.h: $(dist_libhdb_la_SOURCES)
 $(gen_files_hdb) hdb_asn1.h hdb_asn1-priv.h: hdb_asn1_files
 
 hdb_asn1_files: $(ASN1_COMPILE_DEP) $(srcdir)/hdb.asn1
-	$(ASN1_COMPILE) --sequence=HDB-extensions	\
-			--sequence=HDB-Ext-KeyRotation	\
-			--sequence=HDB-Ext-KeySet	\
-			--sequence=Keys $(srcdir)/hdb.asn1 hdb_asn1
+	$(ASN1_COMPILE) --option-file=$(srcdir)/hdb.opt $(srcdir)/hdb.asn1 hdb_asn1
 
 # to help stupid solaris make
 

--- a/lib/hdb/NTMakefile
+++ b/lib/hdb/NTMakefile
@@ -37,7 +37,7 @@ intcflags=-DASN1_LIB
 
 $(OBJ)\asn1_hdb_asn1.c $(OBJ)\hdb_asn1.h $(OBJ)\hdb_asn1-priv.h: $(BINDIR)\asn1_compile.exe hdb.asn1
 	cd $(OBJ)
-	$(BINDIR)\asn1_compile.exe --sequence=HDB-extensions --sequence=HDB-Ext-KeyRotation --sequence=HDB-Ext-KeySet --sequence=Keys --one-code-file $(SRCDIR)\hdb.asn1 hdb_asn1
+	$(BINDIR)\asn1_compile.exe --one-code-file --option-file=$(SRCDIR)\hdb.opt $(SRCDIR)\hdb.asn1 hdb_asn1
 	cd $(SRCDIR)
 
 !ifdef OPENLDAP_MODULE

--- a/lib/hdb/common.c
+++ b/lib/hdb/common.c
@@ -233,13 +233,13 @@ _hdb_fetch_kvno(krb5_context context, HDB *db, krb5_const_principal principal,
 	/* Decrypt the current keys */
 	ret = hdb_unseal_keys(context, db, &entry->entry);
 	if (ret) {
-	    hdb_free_entry(context, entry);
+	    hdb_free_entry(context, db, entry);
 	    return ret;
 	}
 	/* Decrypt the key history too */
 	ret = hdb_unseal_keys_kvno(context, db, 0, flags, &entry->entry);
 	if (ret) {
-	    hdb_free_entry(context, entry);
+	    hdb_free_entry(context, db, entry);
 	    return ret;
 	}
     } else if ((flags & HDB_F_DECRYPT)) {
@@ -247,7 +247,7 @@ _hdb_fetch_kvno(krb5_context context, HDB *db, krb5_const_principal principal,
 	    /* Decrypt the current keys */
 	    ret = hdb_unseal_keys(context, db, &entry->entry);
 	    if (ret) {
-		hdb_free_entry(context, entry);
+		hdb_free_entry(context, db, entry);
 		return ret;
 	    }
 	} else {
@@ -259,7 +259,7 @@ _hdb_fetch_kvno(krb5_context context, HDB *db, krb5_const_principal principal,
 	     */
 	    ret = hdb_unseal_keys_kvno(context, db, kvno, flags, &entry->entry);
 	    if (ret) {
-		hdb_free_entry(context, entry);
+		hdb_free_entry(context, db, entry);
 		return ret;
 	    }
 	}
@@ -273,7 +273,7 @@ _hdb_fetch_kvno(krb5_context context, HDB *db, krb5_const_principal principal,
 	 */
 	ret = add_default_salts(context, db, &entry->entry);
 	if (ret) {
-	    hdb_free_entry(context, entry);
+	    hdb_free_entry(context, db, entry);
 	    return ret;
 	}
     }
@@ -1567,7 +1567,7 @@ fetch_it(krb5_context context,
             ret = pick_kvno(context, db, flags, t, kvno, ent);
     }
     if (ret)
-        hdb_free_entry(context, ent);
+        hdb_free_entry(context, db, ent);
     krb5_free_principal(context, nsprinc);
     free(host);
     return ret;

--- a/lib/hdb/db.c
+++ b/lib/hdb/db.c
@@ -143,14 +143,14 @@ DB_seq(krb5_context context, HDB *db,
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
 	code = hdb_unseal_keys (context, db, &entry->entry);
 	if (code)
-	    hdb_free_entry (context, entry);
+	    hdb_free_entry (context, db, entry);
     }
     if (code == 0 && entry->entry.principal == NULL) {
 	entry->entry.principal = malloc(sizeof(*entry->entry.principal));
 	if (entry->entry.principal == NULL) {
 	    code = ENOMEM;
 	    krb5_set_error_message(context, code, "malloc: out of memory");
-	    hdb_free_entry (context, entry);
+	    hdb_free_entry (context, db, entry);
 	} else {
 	    hdb_key2principal(context, &key_data, entry->entry.principal);
 	}

--- a/lib/hdb/db.c
+++ b/lib/hdb/db.c
@@ -114,7 +114,7 @@ DB_unlock(krb5_context context, HDB *db)
 
 static krb5_error_code
 DB_seq(krb5_context context, HDB *db,
-       unsigned flags, hdb_entry_ex *entry, int flag)
+       unsigned flags, hdb_entry *entry, int flag)
 {
     DB *d = (DB*)db->hdb_db;
     DBT key, value;
@@ -138,21 +138,21 @@ DB_seq(krb5_context context, HDB *db,
     data.data = value.data;
     data.length = value.size;
     memset(entry, 0, sizeof(*entry));
-    if (hdb_value2entry(context, &data, &entry->entry))
+    if (hdb_value2entry(context, &data, entry))
 	return DB_seq(context, db, flags, entry, R_NEXT);
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
-	code = hdb_unseal_keys (context, db, &entry->entry);
+	code = hdb_unseal_keys (context, db, entry);
 	if (code)
 	    hdb_free_entry (context, db, entry);
     }
-    if (code == 0 && entry->entry.principal == NULL) {
-	entry->entry.principal = malloc(sizeof(*entry->entry.principal));
-	if (entry->entry.principal == NULL) {
+    if (code == 0 && entry->principal == NULL) {
+	entry->principal = malloc(sizeof(*entry->principal));
+	if (entry->principal == NULL) {
 	    code = ENOMEM;
 	    krb5_set_error_message(context, code, "malloc: out of memory");
 	    hdb_free_entry (context, db, entry);
 	} else {
-	    hdb_key2principal(context, &key_data, entry->entry.principal);
+	    hdb_key2principal(context, &key_data, entry->principal);
 	}
     }
     return code;
@@ -160,14 +160,14 @@ DB_seq(krb5_context context, HDB *db,
 
 
 static krb5_error_code
-DB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
+DB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry *entry)
 {
     return DB_seq(context, db, flags, entry, R_FIRST);
 }
 
 
 static krb5_error_code
-DB_nextkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
+DB_nextkey(krb5_context context, HDB *db, unsigned flags, hdb_entry *entry)
 {
     return DB_seq(context, db, flags, entry, R_NEXT);
 }

--- a/lib/hdb/db3.c
+++ b/lib/hdb/db3.c
@@ -161,12 +161,12 @@ DB_seq(krb5_context context, HDB *db,
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
 	code = hdb_unseal_keys (context, db, &entry->entry);
 	if (code)
-	    hdb_free_entry (context, entry);
+	    hdb_free_entry (context, db, entry);
     }
     if (entry->entry.principal == NULL) {
 	entry->entry.principal = malloc(sizeof(*entry->entry.principal));
 	if (entry->entry.principal == NULL) {
-	    hdb_free_entry (context, entry);
+	    hdb_free_entry (context, db, entry);
 	    krb5_set_error_message(context, ENOMEM, "malloc: out of memory");
 	    return ENOMEM;
 	} else {

--- a/lib/hdb/db3.c
+++ b/lib/hdb/db3.c
@@ -136,7 +136,7 @@ DB_unlock(krb5_context context, HDB *db)
 
 static krb5_error_code
 DB_seq(krb5_context context, HDB *db,
-       unsigned flags, hdb_entry_ex *entry, int flag)
+       unsigned flags, hdb_entry *entry, int flag)
 {
     DBT key, value;
     DBC *dbcp = db->hdb_dbc;
@@ -156,21 +156,21 @@ DB_seq(krb5_context context, HDB *db,
     data.data = value.data;
     data.length = value.size;
     memset(entry, 0, sizeof(*entry));
-    if (hdb_value2entry(context, &data, &entry->entry))
+    if (hdb_value2entry(context, &data, entry))
 	return DB_seq(context, db, flags, entry, DB_NEXT);
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
-	code = hdb_unseal_keys (context, db, &entry->entry);
+	code = hdb_unseal_keys (context, db, entry);
 	if (code)
 	    hdb_free_entry (context, db, entry);
     }
-    if (entry->entry.principal == NULL) {
-	entry->entry.principal = malloc(sizeof(*entry->entry.principal));
-	if (entry->entry.principal == NULL) {
+    if (entry->principal == NULL) {
+	entry->principal = malloc(sizeof(*entry->principal));
+	if (entry->principal == NULL) {
 	    hdb_free_entry (context, db, entry);
 	    krb5_set_error_message(context, ENOMEM, "malloc: out of memory");
 	    return ENOMEM;
 	} else {
-	    hdb_key2principal(context, &key_data, entry->entry.principal);
+	    hdb_key2principal(context, &key_data, entry->principal);
 	}
     }
     return 0;
@@ -178,14 +178,14 @@ DB_seq(krb5_context context, HDB *db,
 
 
 static krb5_error_code
-DB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
+DB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry *entry)
 {
     return DB_seq(context, db, flags, entry, DB_FIRST);
 }
 
 
 static krb5_error_code
-DB_nextkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
+DB_nextkey(krb5_context context, HDB *db, unsigned flags, hdb_entry *entry)
 {
     return DB_seq(context, db, flags, entry, DB_NEXT);
 }

--- a/lib/hdb/hdb-keytab.c
+++ b/lib/hdb/hdb-keytab.c
@@ -90,14 +90,14 @@ hkt_unlock(krb5_context context, HDB *db)
 
 static krb5_error_code
 hkt_firstkey(krb5_context context, HDB *db,
-	     unsigned flags, hdb_entry_ex *entry)
+	     unsigned flags, hdb_entry *entry)
 {
     return HDB_ERR_DB_INUSE;
 }
 
 static krb5_error_code
 hkt_nextkey(krb5_context context, HDB * db, unsigned flags,
-	     hdb_entry_ex * entry)
+	     hdb_entry * entry)
 {
     return HDB_ERR_DB_INUSE;
 }
@@ -119,7 +119,7 @@ hkt_open(krb5_context context, HDB * db, int flags, mode_t mode)
 
 static krb5_error_code
 hkt_fetch_kvno(krb5_context context, HDB * db, krb5_const_principal principal,
-	       unsigned flags, krb5_kvno kvno, hdb_entry_ex * entry)
+	       unsigned flags, krb5_kvno kvno, hdb_entry * entry)
 {
     hdb_keytab k = (hdb_keytab)db->hdb_db;
     krb5_error_code ret;
@@ -132,13 +132,13 @@ hkt_fetch_kvno(krb5_context context, HDB * db, krb5_const_principal principal,
 
     memset(&ktentry, 0, sizeof(ktentry));
 
-    entry->entry.flags.server = 1;
-    entry->entry.flags.forwardable = 1;
-    entry->entry.flags.renewable = 1;
+    entry->flags.server = 1;
+    entry->flags.forwardable = 1;
+    entry->flags.renewable = 1;
 
     /* Not recorded in the OD backend, make something up */
     ret = krb5_parse_name(context, "hdb/keytab@WELL-KNOWN:KEYTAB-BACKEND",
-			  &entry->entry.created_by.principal);
+			  &entry->created_by.principal);
     if (ret)
 	goto out;
 
@@ -155,7 +155,7 @@ hkt_fetch_kvno(krb5_context context, HDB * db, krb5_const_principal principal,
 	goto out;
     }
 
-    ret = krb5_copy_principal(context, principal, &entry->entry.principal);
+    ret = krb5_copy_principal(context, principal, &entry->principal);
     if (ret)
 	goto out;
 
@@ -163,8 +163,8 @@ hkt_fetch_kvno(krb5_context context, HDB * db, krb5_const_principal principal,
 
  out:
     if (ret) {
-	free_HDB_entry(&entry->entry);
-	memset(&entry->entry, 0, sizeof(entry->entry));
+	free_HDB_entry(entry);
+	memset(entry, 0, sizeof(*entry));
     }
     krb5_kt_free_entry(context, &ktentry);
 
@@ -173,7 +173,7 @@ hkt_fetch_kvno(krb5_context context, HDB * db, krb5_const_principal principal,
 
 static krb5_error_code
 hkt_store(krb5_context context, HDB * db, unsigned flags,
-	  hdb_entry_ex * entry)
+	  hdb_entry * entry)
 {
     return HDB_ERR_DB_INUSE;
 }

--- a/lib/hdb/hdb-ldap.c
+++ b/lib/hdb/hdb-ldap.c
@@ -767,7 +767,7 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
     }
 
     if (msg)
-	hdb_free_entry(context, &orig);
+	hdb_free_entry(context, db, &orig);
 
     return ret;
 }
@@ -1467,7 +1467,7 @@ out:
     free(ntPasswordIN);
 
     if (ret)
-	hdb_free_entry(context, ent);
+	hdb_free_entry(context, db, ent);
 
     return ret;
 }
@@ -1552,7 +1552,7 @@ LDAP_seq(krb5_context context, HDB * db, unsigned flags, hdb_entry_ex * entry)
 	if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
 	    ret = hdb_unseal_keys(context, db, &entry->entry);
 	    if (ret)
-		hdb_free_entry(context, entry);
+		hdb_free_entry(context, db, entry);
 	}
     }
 
@@ -1712,7 +1712,7 @@ LDAP_fetch_kvno(krb5_context context, HDB * db, krb5_const_principal principal,
 	if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
 	    ret = hdb_unseal_keys(context, db, &entry->entry);
 	    if (ret)
-		hdb_free_entry(context, entry);
+		hdb_free_entry(context, db, entry);
 	}
     }
 

--- a/lib/hdb/hdb-ldap.c
+++ b/lib/hdb/hdb-ldap.c
@@ -47,7 +47,7 @@ static krb5_error_code LDAP_close(krb5_context context, HDB *);
 
 static krb5_error_code
 LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
-		   int flags, hdb_entry_ex * ent);
+		   int flags, hdb_entry * ent);
 
 static const char *default_structural_object = "account";
 static char *structural_object;
@@ -388,14 +388,14 @@ bervalstrcmp(struct berval *v, const char *str)
 
 
 static krb5_error_code
-LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
+LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry * ent,
 		LDAPMessage * msg, LDAPMod *** pmods, krb5_boolean *pis_new_entry)
 {
     krb5_error_code ret;
     krb5_boolean is_new_entry = FALSE;
     char *tmp = NULL;
     LDAPMod **mods = NULL;
-    hdb_entry_ex orig;
+    hdb_entry orig;
     unsigned long oflags, nflags;
     int i;
 
@@ -477,12 +477,12 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
     }
 
     if (is_new_entry ||
-	krb5_principal_compare(context, ent->entry.principal, orig.entry.principal)
+	krb5_principal_compare(context, ent->principal, orig.principal)
 	== FALSE)
     {
 	if (is_heimdal_principal || is_heimdal_entry) {
 
-	    ret = krb5_unparse_name(context, ent->entry.principal, &tmp);
+	    ret = krb5_unparse_name(context, ent->principal, &tmp);
 	    if (ret)
 		goto out;
 
@@ -496,7 +496,7 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 	}
 
 	if (is_account || is_samba_account) {
-	    ret = krb5_unparse_name_short(context, ent->entry.principal, &tmp);
+	    ret = krb5_unparse_name_short(context, ent->principal, &tmp);
 	    if (ret)
 		goto out;
 	    ret = LDAP_addmod(&mods, LDAP_MOD_REPLACE, "uid", tmp);
@@ -508,15 +508,15 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 	}
     }
 
-    if (is_heimdal_entry && (ent->entry.kvno != orig.entry.kvno || is_new_entry)) {
+    if (is_heimdal_entry && (ent->kvno != orig.kvno || is_new_entry)) {
 	ret = LDAP_addmod_integer(context, &mods, LDAP_MOD_REPLACE,
 			    "krb5KeyVersionNumber",
-			    ent->entry.kvno);
+			    ent->kvno);
 	if (ret)
 	    goto out;
     }
 
-    if (is_heimdal_entry && ent->entry.extensions) {
+    if (is_heimdal_entry && ent->extensions) {
 	if (!is_new_entry) {
 	    vals = ldap_get_values_len(HDB2LDAP(db), msg, "krb5ExtendedAttributes");
 	    if (vals) {
@@ -527,11 +527,11 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 	    }
 	}
 
-	for (i = 0; i < ent->entry.extensions->len; i++) {
+	for (i = 0; i < ent->extensions->len; i++) {
 	    unsigned char *buf;
 	    size_t size, sz = 0;
 
-	    ASN1_MALLOC_ENCODE(HDB_extension, buf, size, &ent->entry.extensions->val[i], &sz, ret);
+	    ASN1_MALLOC_ENCODE(HDB_extension, buf, size, &ent->extensions->val[i], &sz, ret);
 	    if (ret)
 		goto out;
 	    if (size != sz)
@@ -543,42 +543,42 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 	}
     }
 
-    if (is_heimdal_entry && ent->entry.valid_start) {
-	if (orig.entry.valid_end == NULL
-	    || (*(ent->entry.valid_start) != *(orig.entry.valid_start))) {
+    if (is_heimdal_entry && ent->valid_start) {
+	if (orig.valid_end == NULL
+	    || (*(ent->valid_start) != *(orig.valid_start))) {
 	    ret = LDAP_addmod_generalized_time(&mods, LDAP_MOD_REPLACE,
 					       "krb5ValidStart",
-					       ent->entry.valid_start);
+					       ent->valid_start);
 	    if (ret)
 		goto out;
 	}
     }
 
-    if (ent->entry.valid_end) {
- 	if (orig.entry.valid_end == NULL || (*(ent->entry.valid_end) != *(orig.entry.valid_end))) {
+    if (ent->valid_end) {
+ 	if (orig.valid_end == NULL || (*(ent->valid_end) != *(orig.valid_end))) {
 	    if (is_heimdal_entry) {
 		ret = LDAP_addmod_generalized_time(&mods, LDAP_MOD_REPLACE,
 						   "krb5ValidEnd",
-						   ent->entry.valid_end);
+						   ent->valid_end);
 		if (ret)
 		    goto out;
             }
 	    if (is_samba_account) {
 		ret = LDAP_addmod_integer(context, &mods,  LDAP_MOD_REPLACE,
 					  "sambaKickoffTime",
-					  *(ent->entry.valid_end));
+					  *(ent->valid_end));
 		if (ret)
 		    goto out;
 	    }
    	}
     }
 
-    if (ent->entry.pw_end) {
-	if (orig.entry.pw_end == NULL || (*(ent->entry.pw_end) != *(orig.entry.pw_end))) {
+    if (ent->pw_end) {
+	if (orig.pw_end == NULL || (*(ent->pw_end) != *(orig.pw_end))) {
 	    if (is_heimdal_entry) {
 		ret = LDAP_addmod_generalized_time(&mods, LDAP_MOD_REPLACE,
 						   "krb5PasswordEnd",
-						   ent->entry.pw_end);
+						   ent->pw_end);
 		if (ret)
 		    goto out;
 	    }
@@ -586,7 +586,7 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 	    if (is_samba_account) {
 		ret = LDAP_addmod_integer(context, &mods, LDAP_MOD_REPLACE,
 					  "sambaPwdMustChange",
-					  *(ent->entry.pw_end));
+					  *(ent->pw_end));
 		if (ret)
 		    goto out;
 	    }
@@ -595,43 +595,43 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 
 
 #if 0 /* we we have last_pw_change */
-    if (is_samba_account && ent->entry.last_pw_change) {
-	if (orig.entry.last_pw_change == NULL || (*(ent->entry.last_pw_change) != *(orig.entry.last_pw_change))) {
+    if (is_samba_account && ent->last_pw_change) {
+	if (orig.last_pw_change == NULL || (*(ent->last_pw_change) != *(orig.last_pw_change))) {
 	    ret = LDAP_addmod_integer(context, &mods, LDAP_MOD_REPLACE,
 				      "sambaPwdLastSet",
-				      *(ent->entry.last_pw_change));
+				      *(ent->last_pw_change));
 	    if (ret)
 		goto out;
 	}
     }
 #endif
 
-    if (is_heimdal_entry && ent->entry.max_life) {
-	if (orig.entry.max_life == NULL
-	    || (*(ent->entry.max_life) != *(orig.entry.max_life))) {
+    if (is_heimdal_entry && ent->max_life) {
+	if (orig.max_life == NULL
+	    || (*(ent->max_life) != *(orig.max_life))) {
 
 	    ret = LDAP_addmod_integer(context, &mods, LDAP_MOD_REPLACE,
 				      "krb5MaxLife",
-				      *(ent->entry.max_life));
+				      *(ent->max_life));
 	    if (ret)
 		goto out;
 	}
     }
 
-    if (is_heimdal_entry && ent->entry.max_renew) {
-	if (orig.entry.max_renew == NULL
-	    || (*(ent->entry.max_renew) != *(orig.entry.max_renew))) {
+    if (is_heimdal_entry && ent->max_renew) {
+	if (orig.max_renew == NULL
+	    || (*(ent->max_renew) != *(orig.max_renew))) {
 
 	    ret = LDAP_addmod_integer(context, &mods, LDAP_MOD_REPLACE,
 				      "krb5MaxRenew",
-				      *(ent->entry.max_renew));
+				      *(ent->max_renew));
 	    if (ret)
 		goto out;
 	}
     }
 
-    oflags = HDBFlags2int(orig.entry.flags);
-    nflags = HDBFlags2int(ent->entry.flags);
+    oflags = HDBFlags2int(orig.flags);
+    nflags = HDBFlags2int(ent->flags);
 
     if (is_heimdal_entry && oflags != nflags) {
 
@@ -643,7 +643,7 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
     }
 
     /* Remove keys if they exists, and then replace keys. */
-    if (!is_new_entry && orig.entry.keys.len > 0) {
+    if (!is_new_entry && orig.keys.len > 0) {
 	vals = ldap_get_values_len(HDB2LDAP(db), msg, "krb5Key");
 	if (vals) {
 	    ldap_value_free_len(vals);
@@ -654,21 +654,21 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 	}
     }
 
-    for (i = 0; i < ent->entry.keys.len; i++) {
+    for (i = 0; i < ent->keys.len; i++) {
 
 	if (is_samba_account
-	    && ent->entry.keys.val[i].key.keytype == ETYPE_ARCFOUR_HMAC_MD5) {
+	    && ent->keys.val[i].key.keytype == ETYPE_ARCFOUR_HMAC_MD5) {
 	    char *ntHexPassword;
 	    char *nt;
 	    time_t now = time(NULL);
 
 	    /* the key might have been 'sealed', but samba passwords
 	       are clear in the directory */
-	    ret = hdb_unseal_key(context, db, &ent->entry.keys.val[i]);
+	    ret = hdb_unseal_key(context, db, &ent->keys.val[i]);
 	    if (ret)
 		goto out;
 
-	    nt = ent->entry.keys.val[i].key.keyvalue.data;
+	    nt = ent->keys.val[i].key.keyvalue.data;
 	    /* store in ntPassword, not krb5key */
 	    ret = hex_encode(nt, 16, &ntHexPassword);
 	    if (ret < 0) {
@@ -701,7 +701,7 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 	    unsigned char *buf;
 	    size_t len, buf_size;
 
-	    ASN1_MALLOC_ENCODE(Key, buf, buf_size, &ent->entry.keys.val[i], &len, ret);
+	    ASN1_MALLOC_ENCODE(Key, buf, buf_size, &ent->keys.val[i], &len, ret);
 	    if (ret)
 		goto out;
 	    if(buf_size != len)
@@ -714,7 +714,7 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 	}
     }
 
-    if (ent->entry.etypes) {
+    if (ent->etypes) {
 	int add_krb5EncryptionType = 0;
 
 	/*
@@ -736,15 +736,15 @@ LDAP_entry2mods(krb5_context context, HDB * db, hdb_entry_ex * ent,
 	    add_krb5EncryptionType = 1;
 
 	if (add_krb5EncryptionType) {
-	    for (i = 0; i < ent->entry.etypes->len; i++) {
+	    for (i = 0; i < ent->etypes->len; i++) {
 		if (is_samba_account &&
-		    ent->entry.keys.val[i].key.keytype == ETYPE_ARCFOUR_HMAC_MD5)
+		    ent->keys.val[i].key.keytype == ETYPE_ARCFOUR_HMAC_MD5)
 		{
 		    ;
 		} else if (is_heimdal_entry) {
 		    ret = LDAP_addmod_integer(context, &mods, LDAP_MOD_ADD,
 					      "krb5EncryptionType",
-					      ent->entry.etypes->val[i]);
+					      ent->etypes->val[i]);
 		    if (ret)
 			goto out;
 		}
@@ -1005,7 +1005,7 @@ LDAP_principal2message(krb5_context context, HDB * db,
  */
 static krb5_error_code
 LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
-		   int flags, hdb_entry_ex * ent)
+		   int flags, hdb_entry * ent)
 {
     char *unparsed_name = NULL, *dn = NULL, *ntPasswordIN = NULL;
     char *samba_acct_flags = NULL;
@@ -1015,18 +1015,18 @@ LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
     int tmp, tmp_time, i, ret, have_arcfour = 0;
 
     memset(ent, 0, sizeof(*ent));
-    ent->entry.flags = int2HDBFlags(0);
+    ent->flags = int2HDBFlags(0);
 
     ret = LDAP_get_string_value(db, msg, "krb5PrincipalName", &unparsed_name);
     if (ret == 0) {
-	ret = krb5_parse_name(context, unparsed_name, &ent->entry.principal);
+	ret = krb5_parse_name(context, unparsed_name, &ent->principal);
 	if (ret)
 	    goto out;
     } else {
 	ret = LDAP_get_string_value(db, msg, "uid",
 				    &unparsed_name);
 	if (ret == 0) {
-	    ret = krb5_parse_name(context, unparsed_name, &ent->entry.principal);
+	    ret = krb5_parse_name(context, unparsed_name, &ent->principal);
 	    if (ret)
 		goto out;
 	} else {
@@ -1042,25 +1042,25 @@ LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
 	ret = LDAP_get_integer_value(db, msg, "krb5KeyVersionNumber",
 				     &integer);
 	if (ret)
-	    ent->entry.kvno = 0;
+	    ent->kvno = 0;
 	else
-	    ent->entry.kvno = integer;
+	    ent->kvno = integer;
     }
 
     keys = ldap_get_values_len(HDB2LDAP(db), msg, "krb5Key");
     if (keys != NULL) {
 	size_t l;
 
-	ent->entry.keys.len = ldap_count_values_len(keys);
-	ent->entry.keys.val = (Key *) calloc(ent->entry.keys.len, sizeof(Key));
-	if (ent->entry.keys.val == NULL) {
+	ent->keys.len = ldap_count_values_len(keys);
+	ent->keys.val = (Key *) calloc(ent->keys.len, sizeof(Key));
+	if (ent->keys.val == NULL) {
 	    ret = ENOMEM;
 	    krb5_set_error_message(context, ret, "calloc: out of memory");
 	    goto out;
 	}
-	for (i = 0; i < ent->entry.keys.len; i++) {
+	for (i = 0; i < ent->keys.len; i++) {
 	    decode_Key((unsigned char *) keys[i]->bv_val,
-		       (size_t) keys[i]->bv_len, &ent->entry.keys.val[i], &l);
+		       (size_t) keys[i]->bv_len, &ent->keys.val[i], &l);
 	}
 	ber_bvecfree(keys);
     } else {
@@ -1070,8 +1070,8 @@ LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
 	 * be related to a general directory entry without creating
 	 * the keys. Hopefully it's OK.
 	 */
-	ent->entry.keys.len = 0;
-	ent->entry.keys.val = NULL;
+	ent->keys.len = 0;
+	ent->keys.val = NULL;
 #else
 	ret = HDB_ERR_NOENTRY;
 	goto out;
@@ -1082,47 +1082,47 @@ LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
     if (extensions != NULL) {
 	size_t l;
 
-	ent->entry.extensions = calloc(1, sizeof(*(ent->entry.extensions)));
-	if (ent->entry.extensions == NULL) {
+	ent->extensions = calloc(1, sizeof(*(ent->extensions)));
+	if (ent->extensions == NULL) {
 	    ret = krb5_enomem(context);
 	    goto out;
 	}
-	ent->entry.extensions->len = ldap_count_values_len(extensions);
-	ent->entry.extensions->val = (HDB_extension *) calloc(ent->entry.extensions->len, sizeof(HDB_extension));
-	if (ent->entry.extensions->val == NULL) {
-	    ent->entry.extensions->len = 0;
+	ent->extensions->len = ldap_count_values_len(extensions);
+	ent->extensions->val = (HDB_extension *) calloc(ent->extensions->len, sizeof(HDB_extension));
+	if (ent->extensions->val == NULL) {
+	    ent->extensions->len = 0;
 	    ret = krb5_enomem(context);
 	    goto out;
 	}
-	for (i = 0; i < ent->entry.extensions->len; i++) {
+	for (i = 0; i < ent->extensions->len; i++) {
 	    ret = decode_HDB_extension((unsigned char *) extensions[i]->bv_val,
-		       (size_t) extensions[i]->bv_len, &ent->entry.extensions->val[i], &l);
+		       (size_t) extensions[i]->bv_len, &ent->extensions->val[i], &l);
 	    if (ret)
 		krb5_set_error_message(context, ret, "decode_HDB_extension failed");
 	}
 	ber_bvecfree(extensions);
     } else {
-	ent->entry.extensions = NULL;
+	ent->extensions = NULL;
     }
 
     vals = ldap_get_values_len(HDB2LDAP(db), msg, "krb5EncryptionType");
     if (vals != NULL) {
-	ent->entry.etypes = malloc(sizeof(*(ent->entry.etypes)));
-	if (ent->entry.etypes == NULL) {
+	ent->etypes = malloc(sizeof(*(ent->etypes)));
+	if (ent->etypes == NULL) {
 	    ret = ENOMEM;
 	    krb5_set_error_message(context, ret,"malloc: out of memory");
 	    goto out;
 	}
-	ent->entry.etypes->len = ldap_count_values_len(vals);
-	ent->entry.etypes->val = calloc(ent->entry.etypes->len,
-                                        sizeof(ent->entry.etypes->val[0]));
-	if (ent->entry.etypes->val == NULL) {
+	ent->etypes->len = ldap_count_values_len(vals);
+	ent->etypes->val = calloc(ent->etypes->len,
+                                        sizeof(ent->etypes->val[0]));
+	if (ent->etypes->val == NULL) {
 	    ret = ENOMEM;
 	    krb5_set_error_message(context, ret, "malloc: out of memory");
-	    ent->entry.etypes->len = 0;
+	    ent->etypes->len = 0;
 	    goto out;
 	}
-	for (i = 0; i < ent->entry.etypes->len; i++) {
+	for (i = 0; i < ent->etypes->len; i++) {
 	    char *buf;
 
 	    buf = malloc(vals[i]->bv_len + 1);
@@ -1133,14 +1133,14 @@ LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
 	    }
 	    memcpy(buf, vals[i]->bv_val, vals[i]->bv_len);
 	    buf[vals[i]->bv_len] = '\0';
-	    ent->entry.etypes->val[i] = atoi(buf);
+	    ent->etypes->val[i] = atoi(buf);
 	    free(buf);
 	}
 	ldap_value_free_len(vals);
     }
 
-    for (i = 0; i < ent->entry.keys.len; i++) {
-	if (ent->entry.keys.val[i].key.keytype == ETYPE_ARCFOUR_HMAC_MD5) {
+    for (i = 0; i < ent->keys.len; i++) {
+	if (ent->keys.val[i].key.keytype == ETYPE_ARCFOUR_HMAC_MD5) {
 	    have_arcfour = 1;
 	    break;
 	}
@@ -1152,151 +1152,151 @@ LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
 	unsigned *etypes;
         Key *ks;
 
-	ks = realloc(ent->entry.keys.val,
-		     (ent->entry.keys.len + 1) *
-                     sizeof(ent->entry.keys.val[0]));
+	ks = realloc(ent->keys.val,
+		     (ent->keys.len + 1) *
+                     sizeof(ent->keys.val[0]));
 	if (ks == NULL) {
 	    ret = ENOMEM;
 	    krb5_set_error_message(context, ret, "malloc: out of memory");
 	    goto out;
 	}
-	ent->entry.keys.val = ks;
-	memset(&ent->entry.keys.val[ent->entry.keys.len], 0, sizeof(Key));
-	ent->entry.keys.val[ent->entry.keys.len].key.keytype = ETYPE_ARCFOUR_HMAC_MD5;
-	ret = krb5_data_alloc (&ent->entry.keys.val[ent->entry.keys.len].key.keyvalue, 16);
+	ent->keys.val = ks;
+	memset(&ent->keys.val[ent->keys.len], 0, sizeof(Key));
+	ent->keys.val[ent->keys.len].key.keytype = ETYPE_ARCFOUR_HMAC_MD5;
+	ret = krb5_data_alloc (&ent->keys.val[ent->keys.len].key.keyvalue, 16);
 	if (ret) {
 	    krb5_set_error_message(context, ret, "malloc: out of memory");
 	    ret = ENOMEM;
 	    goto out;
 	}
 	ret = hex_decode(ntPasswordIN,
-			 ent->entry.keys.val[ent->entry.keys.len].key.keyvalue.data, 16);
-	ent->entry.keys.len++;
+			 ent->keys.val[ent->keys.len].key.keyvalue.data, 16);
+	ent->keys.len++;
         if (ret == -1) {
             krb5_set_error_message(context, ret = EINVAL,
                                    "invalid hex encoding of password");
             goto out;
         }
 
-	if (ent->entry.etypes == NULL) {
-	    ent->entry.etypes = malloc(sizeof(*(ent->entry.etypes)));
-	    if (ent->entry.etypes == NULL) {
+	if (ent->etypes == NULL) {
+	    ent->etypes = malloc(sizeof(*(ent->etypes)));
+	    if (ent->etypes == NULL) {
 		ret = ENOMEM;
 		krb5_set_error_message(context, ret, "malloc: out of memory");
 		goto out;
 	    }
-	    ent->entry.etypes->val = NULL;
-	    ent->entry.etypes->len = 0;
+	    ent->etypes->val = NULL;
+	    ent->etypes->len = 0;
 	}
 
-	for (i = 0; i < ent->entry.etypes->len; i++)
-	    if (ent->entry.etypes->val[i] == ETYPE_ARCFOUR_HMAC_MD5)
+	for (i = 0; i < ent->etypes->len; i++)
+	    if (ent->etypes->val[i] == ETYPE_ARCFOUR_HMAC_MD5)
 		break;
 	/* If there is no ARCFOUR enctype, add one */
-	if (i == ent->entry.etypes->len) {
-	    etypes = realloc(ent->entry.etypes->val,
-			     (ent->entry.etypes->len + 1) *
-			     sizeof(ent->entry.etypes->val[0]));
+	if (i == ent->etypes->len) {
+	    etypes = realloc(ent->etypes->val,
+			     (ent->etypes->len + 1) *
+			     sizeof(ent->etypes->val[0]));
 	    if (etypes == NULL) {
 		ret = ENOMEM;
 		krb5_set_error_message(context, ret, "malloc: out of memory");
 		goto out;
 	    }
-	    ent->entry.etypes->val = etypes;
-	    ent->entry.etypes->val[ent->entry.etypes->len] =
+	    ent->etypes->val = etypes;
+	    ent->etypes->val[ent->etypes->len] =
 		ETYPE_ARCFOUR_HMAC_MD5;
-	    ent->entry.etypes->len++;
+	    ent->etypes->len++;
 	}
     }
 
     ret = LDAP_get_generalized_time_value(db, msg, "createTimestamp",
-					  &ent->entry.created_by.time);
+					  &ent->created_by.time);
     if (ret)
-	ent->entry.created_by.time = time(NULL);
+	ent->created_by.time = time(NULL);
 
-    ent->entry.created_by.principal = NULL;
+    ent->created_by.principal = NULL;
 
     if (flags & HDB_F_ADMIN_DATA) {
 	ret = LDAP_get_string_value(db, msg, "creatorsName", &dn);
 	if (ret == 0) {
-	    LDAP_dn2principal(context, db, dn, &ent->entry.created_by.principal);
+	    LDAP_dn2principal(context, db, dn, &ent->created_by.principal);
 	    free(dn);
 	}
 
-	ent->entry.modified_by = calloc(1, sizeof(*ent->entry.modified_by));
-	if (ent->entry.modified_by == NULL) {
+	ent->modified_by = calloc(1, sizeof(*ent->modified_by));
+	if (ent->modified_by == NULL) {
 	    ret = ENOMEM;
 	    krb5_set_error_message(context, ret, "malloc: out of memory");
 	    goto out;
 	}
 
 	ret = LDAP_get_generalized_time_value(db, msg, "modifyTimestamp",
-					      &ent->entry.modified_by->time);
+					      &ent->modified_by->time);
 	if (ret == 0) {
 	    ret = LDAP_get_string_value(db, msg, "modifiersName", &dn);
 	    if (ret == 0) {
-		LDAP_dn2principal(context, db, dn, &ent->entry.modified_by->principal);
+		LDAP_dn2principal(context, db, dn, &ent->modified_by->principal);
 		free(dn);
 	    } else {
-		free(ent->entry.modified_by);
-		ent->entry.modified_by = NULL;
+		free(ent->modified_by);
+		ent->modified_by = NULL;
 	    }
 	}
     }
 
-    ent->entry.valid_start = malloc(sizeof(*ent->entry.valid_start));
-    if (ent->entry.valid_start == NULL) {
+    ent->valid_start = malloc(sizeof(*ent->valid_start));
+    if (ent->valid_start == NULL) {
 	ret = ENOMEM;
 	krb5_set_error_message(context, ret, "malloc: out of memory");
 	goto out;
     }
     ret = LDAP_get_generalized_time_value(db, msg, "krb5ValidStart",
-					  ent->entry.valid_start);
+					  ent->valid_start);
     if (ret) {
 	/* OPTIONAL */
-	free(ent->entry.valid_start);
-	ent->entry.valid_start = NULL;
+	free(ent->valid_start);
+	ent->valid_start = NULL;
     }
 
-    ent->entry.valid_end = malloc(sizeof(*ent->entry.valid_end));
-    if (ent->entry.valid_end == NULL) {
+    ent->valid_end = malloc(sizeof(*ent->valid_end));
+    if (ent->valid_end == NULL) {
 	ret = ENOMEM;
 	krb5_set_error_message(context, ret, "malloc: out of memory");
 	goto out;
     }
     ret = LDAP_get_generalized_time_value(db, msg, "krb5ValidEnd",
-					  ent->entry.valid_end);
+					  ent->valid_end);
     if (ret) {
 	/* OPTIONAL */
-	free(ent->entry.valid_end);
-	ent->entry.valid_end = NULL;
+	free(ent->valid_end);
+	ent->valid_end = NULL;
     }
 
     ret = LDAP_get_integer_value(db, msg, "sambaKickoffTime", &tmp_time);
     if (ret == 0) {
- 	if (ent->entry.valid_end == NULL) {
- 	    ent->entry.valid_end = malloc(sizeof(*ent->entry.valid_end));
- 	    if (ent->entry.valid_end == NULL) {
+ 	if (ent->valid_end == NULL) {
+ 	    ent->valid_end = malloc(sizeof(*ent->valid_end));
+ 	    if (ent->valid_end == NULL) {
  		ret = ENOMEM;
  		krb5_set_error_message(context, ret, "malloc: out of memory");
  		goto out;
  	    }
  	}
- 	*ent->entry.valid_end = tmp_time;
+ 	*ent->valid_end = tmp_time;
     }
 
-    ent->entry.pw_end = malloc(sizeof(*ent->entry.pw_end));
-    if (ent->entry.pw_end == NULL) {
+    ent->pw_end = malloc(sizeof(*ent->pw_end));
+    if (ent->pw_end == NULL) {
 	ret = ENOMEM;
 	krb5_set_error_message(context, ret, "malloc: out of memory");
 	goto out;
     }
     ret = LDAP_get_generalized_time_value(db, msg, "krb5PasswordEnd",
-					  ent->entry.pw_end);
+					  ent->pw_end);
     if (ret) {
 	/* OPTIONAL */
-	free(ent->entry.pw_end);
-	ent->entry.pw_end = NULL;
+	free(ent->pw_end);
+	ent->pw_end = NULL;
     }
 
     ret = LDAP_get_integer_value(db, msg, "sambaPwdLastSet", &tmp_time);
@@ -1310,76 +1310,76 @@ LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
 					     NULL);
 
 	if (delta) {
-		if (ent->entry.pw_end == NULL) {
-		    ent->entry.pw_end = malloc(sizeof(*ent->entry.pw_end));
-		    if (ent->entry.pw_end == NULL) {
+		if (ent->pw_end == NULL) {
+		    ent->pw_end = malloc(sizeof(*ent->pw_end));
+		    if (ent->pw_end == NULL) {
 			ret = ENOMEM;
 			krb5_set_error_message(context, ret, "malloc: out of memory");
 			goto out;
 		    }
 		}
 
-		*ent->entry.pw_end = tmp_time + delta;
+		*ent->pw_end = tmp_time + delta;
 	}
     }
 
     ret = LDAP_get_integer_value(db, msg, "sambaPwdMustChange", &tmp_time);
     if (ret == 0) {
-	if (ent->entry.pw_end == NULL) {
-	    ent->entry.pw_end = malloc(sizeof(*ent->entry.pw_end));
-	    if (ent->entry.pw_end == NULL) {
+	if (ent->pw_end == NULL) {
+	    ent->pw_end = malloc(sizeof(*ent->pw_end));
+	    if (ent->pw_end == NULL) {
 		ret = ENOMEM;
 		krb5_set_error_message(context, ret, "malloc: out of memory");
 		goto out;
 	    }
 	}
-	*ent->entry.pw_end = tmp_time;
+	*ent->pw_end = tmp_time;
     }
 
     /* OPTIONAL */
     ret = LDAP_get_integer_value(db, msg, "sambaPwdLastSet", &tmp_time);
     if (ret == 0)
-	hdb_entry_set_pw_change_time(context, &ent->entry, tmp_time);
+	hdb_entry_set_pw_change_time(context, ent, tmp_time);
 
     {
 	int max_life;
 
-	ent->entry.max_life = malloc(sizeof(*ent->entry.max_life));
-	if (ent->entry.max_life == NULL) {
+	ent->max_life = malloc(sizeof(*ent->max_life));
+	if (ent->max_life == NULL) {
 	    ret = ENOMEM;
 	    krb5_set_error_message(context, ret, "malloc: out of memory");
 	    goto out;
 	}
 	ret = LDAP_get_integer_value(db, msg, "krb5MaxLife", &max_life);
 	if (ret) {
-	    free(ent->entry.max_life);
-	    ent->entry.max_life = NULL;
+	    free(ent->max_life);
+	    ent->max_life = NULL;
 	} else
-	    *ent->entry.max_life = max_life;
+	    *ent->max_life = max_life;
     }
 
     {
 	int max_renew;
 
-	ent->entry.max_renew = malloc(sizeof(*ent->entry.max_renew));
-	if (ent->entry.max_renew == NULL) {
+	ent->max_renew = malloc(sizeof(*ent->max_renew));
+	if (ent->max_renew == NULL) {
 	    ret = ENOMEM;
 	    krb5_set_error_message(context, ret, "malloc: out of memory");
 	    goto out;
 	}
 	ret = LDAP_get_integer_value(db, msg, "krb5MaxRenew", &max_renew);
 	if (ret) {
-	    free(ent->entry.max_renew);
-	    ent->entry.max_renew = NULL;
+	    free(ent->max_renew);
+	    ent->max_renew = NULL;
 	} else
-	    *ent->entry.max_renew = max_renew;
+	    *ent->max_renew = max_renew;
     }
 
     ret = LDAP_get_integer_value(db, msg, "krb5KDCFlags", &tmp);
     if (ret)
 	tmp = 0;
 
-    ent->entry.flags = int2HDBFlags(tmp);
+    ent->flags = int2HDBFlags(tmp);
 
     /* Try and find Samba flags to put into the mix */
     ret = LDAP_get_string_value(db, msg, "sambaAcctFlags", &samba_acct_flags);
@@ -1411,7 +1411,7 @@ LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
 
 	/* Allow forwarding */
 	if (samba_forwardable)
-	    ent->entry.flags.forwardable = TRUE;
+	    ent->flags.forwardable = TRUE;
 
 	for (i=0; i < flags_len; i++) {
 	    switch (samba_acct_flags[i]) {
@@ -1423,36 +1423,36 @@ LDAP_message2entry(krb5_context context, HDB * db, LDAPMessage * msg,
 		/* how to handle no password in kerberos? */
 		break;
 	    case 'D':
-		ent->entry.flags.invalid = TRUE;
+		ent->flags.invalid = TRUE;
 		break;
 	    case 'H':
 		break;
 	    case 'T':
 		/* temp duplicate */
-		ent->entry.flags.invalid = TRUE;
+		ent->flags.invalid = TRUE;
 		break;
 	    case 'U':
-		ent->entry.flags.client = TRUE;
+		ent->flags.client = TRUE;
 		break;
 	    case 'M':
 		break;
 	    case 'W':
 	    case 'S':
-		ent->entry.flags.server = TRUE;
-		ent->entry.flags.client = TRUE;
+		ent->flags.server = TRUE;
+		ent->flags.client = TRUE;
 		break;
 	    case 'L':
-		ent->entry.flags.invalid = TRUE;
+		ent->flags.invalid = TRUE;
 		break;
 	    case 'X':
-		if (ent->entry.pw_end) {
-		    free(ent->entry.pw_end);
-		    ent->entry.pw_end = NULL;
+		if (ent->pw_end) {
+		    free(ent->pw_end);
+		    ent->pw_end = NULL;
 		}
 		break;
 	    case 'I':
-		ent->entry.flags.server = TRUE;
-		ent->entry.flags.client = TRUE;
+		ent->flags.server = TRUE;
+		ent->flags.client = TRUE;
 		break;
 	    }
 	}
@@ -1496,7 +1496,7 @@ LDAP_unlock(krb5_context context, HDB * db)
 }
 
 static krb5_error_code
-LDAP_seq(krb5_context context, HDB * db, unsigned flags, hdb_entry_ex * entry)
+LDAP_seq(krb5_context context, HDB * db, unsigned flags, hdb_entry * entry)
 {
     int msgid, rc, parserc;
     krb5_error_code ret;
@@ -1550,7 +1550,7 @@ LDAP_seq(krb5_context context, HDB * db, unsigned flags, hdb_entry_ex * entry)
 
     if (ret == 0) {
 	if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
-	    ret = hdb_unseal_keys(context, db, &entry->entry);
+	    ret = hdb_unseal_keys(context, db, entry);
 	    if (ret)
 		hdb_free_entry(context, db, entry);
 	}
@@ -1561,7 +1561,7 @@ LDAP_seq(krb5_context context, HDB * db, unsigned flags, hdb_entry_ex * entry)
 
 static krb5_error_code
 LDAP_firstkey(krb5_context context, HDB *db, unsigned flags,
-	      hdb_entry_ex *entry)
+	      hdb_entry *entry)
 {
     krb5_error_code ret;
     int msgid;
@@ -1589,7 +1589,7 @@ LDAP_firstkey(krb5_context context, HDB *db, unsigned flags,
 
 static krb5_error_code
 LDAP_nextkey(krb5_context context, HDB * db, unsigned flags,
-	     hdb_entry_ex * entry)
+	     hdb_entry * entry)
 {
     return LDAP_seq(context, db, flags, entry);
 }
@@ -1692,7 +1692,7 @@ LDAP_open(krb5_context context, HDB * db, int flags, mode_t mode)
 
 static krb5_error_code
 LDAP_fetch_kvno(krb5_context context, HDB * db, krb5_const_principal principal,
-		unsigned flags, krb5_kvno kvno, hdb_entry_ex * entry)
+		unsigned flags, krb5_kvno kvno, hdb_entry * entry)
 {
     LDAPMessage *msg, *e;
     krb5_error_code ret;
@@ -1710,7 +1710,7 @@ LDAP_fetch_kvno(krb5_context context, HDB * db, krb5_const_principal principal,
     ret = LDAP_message2entry(context, db, e, flags, entry);
     if (ret == 0) {
 	if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
-	    ret = hdb_unseal_keys(context, db, &entry->entry);
+	    ret = hdb_unseal_keys(context, db, entry);
 	    if (ret)
 		hdb_free_entry(context, db, entry);
 	}
@@ -1725,7 +1725,7 @@ LDAP_fetch_kvno(krb5_context context, HDB * db, krb5_const_principal principal,
 #if 0
 static krb5_error_code
 LDAP_fetch(krb5_context context, HDB * db, krb5_const_principal principal,
-	   unsigned flags, hdb_entry_ex * entry)
+	   unsigned flags, hdb_entry * entry)
 {
     return LDAP_fetch_kvno(context, db, principal,
 			   flags & (~HDB_F_KVNO_SPECIFIED), 0, entry);
@@ -1734,7 +1734,7 @@ LDAP_fetch(krb5_context context, HDB * db, krb5_const_principal principal,
 
 static krb5_error_code
 LDAP_store(krb5_context context, HDB * db, unsigned flags,
-	   hdb_entry_ex * entry)
+	   hdb_entry * entry)
 {
     LDAPMod **mods = NULL;
     krb5_error_code ret;
@@ -1747,17 +1747,17 @@ LDAP_store(krb5_context context, HDB * db, unsigned flags,
     if ((flags & HDB_F_PRECHECK))
         return 0; /* we can't guarantee whether we'll be able to perform it */
 
-    ret = LDAP_principal2message(context, db, entry->entry.principal, &msg);
+    ret = LDAP_principal2message(context, db, entry->principal, &msg);
     if (ret == 0)
 	e = ldap_first_entry(HDB2LDAP(db), msg);
 
-    ret = krb5_unparse_name(context, entry->entry.principal, &name);
+    ret = krb5_unparse_name(context, entry->principal, &name);
     if (ret) {
 	free(name);
 	return ret;
     }
 
-    ret = hdb_seal_keys(context, db, &entry->entry);
+    ret = hdb_seal_keys(context, db, entry);
     if (ret)
 	goto out;
 

--- a/lib/hdb/hdb-mdb.c
+++ b/lib/hdb/hdb-mdb.c
@@ -383,7 +383,7 @@ DB_unlock(krb5_context context, HDB *db)
 
 static krb5_error_code
 DB_seq(krb5_context context, HDB *db,
-       unsigned flags, hdb_entry_ex *entry, int flag)
+       unsigned flags, hdb_entry *entry, int flag)
 {
     mdb_info *mi = db->hdb_db;
     MDB_val key, value;
@@ -406,21 +406,21 @@ DB_seq(krb5_context context, HDB *db,
     data.data = value.mv_data;
     data.length = value.mv_size;
     memset(entry, 0, sizeof(*entry));
-    if (hdb_value2entry(context, &data, &entry->entry))
+    if (hdb_value2entry(context, &data, entry))
 	return DB_seq(context, db, flags, entry, MDB_NEXT);
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
-	code = hdb_unseal_keys (context, db, &entry->entry);
+	code = hdb_unseal_keys (context, db, entry);
 	if (code)
 	    hdb_free_entry (context, db, entry);
     }
-    if (entry->entry.principal == NULL) {
-	entry->entry.principal = malloc(sizeof(*entry->entry.principal));
-	if (entry->entry.principal == NULL) {
+    if (entry->principal == NULL) {
+	entry->principal = malloc(sizeof(*entry->principal));
+	if (entry->principal == NULL) {
 	    hdb_free_entry (context, db, entry);
 	    krb5_set_error_message(context, ENOMEM, "malloc: out of memory");
 	    return ENOMEM;
 	} else {
-	    hdb_key2principal(context, &key_data, entry->entry.principal);
+	    hdb_key2principal(context, &key_data, entry->principal);
 	}
     }
     return 0;
@@ -428,7 +428,7 @@ DB_seq(krb5_context context, HDB *db,
 
 
 static krb5_error_code
-DB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
+DB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry *entry)
 {
     krb5_error_code ret = 0;
     mdb_info *mi = db->hdb_db;
@@ -462,7 +462,7 @@ DB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
 
 
 static krb5_error_code
-DB_nextkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
+DB_nextkey(krb5_context context, HDB *db, unsigned flags, hdb_entry *entry)
 {
     return DB_seq(context, db, flags, entry, MDB_NEXT);
 }

--- a/lib/hdb/hdb-mdb.c
+++ b/lib/hdb/hdb-mdb.c
@@ -411,12 +411,12 @@ DB_seq(krb5_context context, HDB *db,
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
 	code = hdb_unseal_keys (context, db, &entry->entry);
 	if (code)
-	    hdb_free_entry (context, entry);
+	    hdb_free_entry (context, db, entry);
     }
     if (entry->entry.principal == NULL) {
 	entry->entry.principal = malloc(sizeof(*entry->entry.principal));
 	if (entry->entry.principal == NULL) {
-	    hdb_free_entry (context, entry);
+	    hdb_free_entry (context, db, entry);
 	    krb5_set_error_message(context, ENOMEM, "malloc: out of memory");
 	    return ENOMEM;
 	} else {

--- a/lib/hdb/hdb-mitdb.c
+++ b/lib/hdb/hdb-mitdb.c
@@ -802,7 +802,7 @@ mdb_seq(krb5_context context, HDB *db,
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
 	code = hdb_unseal_keys (context, db, &entry->entry);
 	if (code)
-	    hdb_free_entry (context, entry);
+	    hdb_free_entry (context, db, entry);
     }
 
     return code;
@@ -961,7 +961,7 @@ mdb_fetch_kvno(krb5_context context, HDB *db, krb5_const_principal principal,
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
 	ret = hdb_unseal_keys (context, db, &entry->entry);
 	if (ret) {
-	    hdb_free_entry(context, entry);
+	    hdb_free_entry(context, db, entry);
             return ret;
         }
     }

--- a/lib/hdb/hdb-sqlite.c
+++ b/lib/hdb/hdb-sqlite.c
@@ -548,7 +548,7 @@ hdb_sqlite_fetch_kvno(krb5_context context, HDB *db, krb5_const_principal princi
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
         ret = hdb_unseal_keys(context, db, &entry->entry);
         if(ret) {
-           hdb_free_entry(context, entry);
+           hdb_free_entry(context, db, entry);
            goto out;
         }
     }

--- a/lib/hdb/hdb.c
+++ b/lib/hdb/hdb.c
@@ -397,13 +397,13 @@ hdb_unlock(int fd)
 }
 
 void
-hdb_free_entry(krb5_context context, hdb_entry_ex *ent)
+hdb_free_entry(krb5_context context, HDB *db, hdb_entry_ex *ent)
 {
     Key *k;
     size_t i;
 
-    if (ent->free_entry)
-	(*ent->free_entry)(context, ent);
+    if (db && db->hdb_free_entry_context)
+	db->hdb_free_entry_context(context, db, ent);
 
     for(i = 0; i < ent->entry.keys.len; i++) {
 	k = &ent->entry.keys.val[i];
@@ -430,7 +430,7 @@ hdb_foreach(krb5_context context,
 	krb5_clear_error_message(context);
     while(ret == 0){
 	ret = (*func)(context, db, &entry, data);
-	hdb_free_entry(context, &entry);
+	hdb_free_entry(context, db, &entry);
 	if(ret == 0)
 	    ret = db->hdb_nextkey(context, db, flags, &entry);
     }

--- a/lib/hdb/hdb.c
+++ b/lib/hdb/hdb.c
@@ -397,7 +397,7 @@ hdb_unlock(int fd)
 }
 
 void
-hdb_free_entry(krb5_context context, HDB *db, hdb_entry_ex *ent)
+hdb_free_entry(krb5_context context, HDB *db, hdb_entry *ent)
 {
     Key *k;
     size_t i;
@@ -405,15 +405,15 @@ hdb_free_entry(krb5_context context, HDB *db, hdb_entry_ex *ent)
     if (db && db->hdb_free_entry_context)
 	db->hdb_free_entry_context(context, db, ent);
 
-    for(i = 0; i < ent->entry.keys.len; i++) {
-	k = &ent->entry.keys.val[i];
+    for(i = 0; i < ent->keys.len; i++) {
+	k = &ent->keys.val[i];
 
 	memset_s(k->key.keyvalue.data,
 		 k->key.keyvalue.length,
 		 0,
 		 k->key.keyvalue.length);
     }
-    free_HDB_entry(&ent->entry);
+    free_HDB_entry(ent);
 }
 
 krb5_error_code
@@ -424,7 +424,7 @@ hdb_foreach(krb5_context context,
 	    void *data)
 {
     krb5_error_code ret;
-    hdb_entry_ex entry;
+    hdb_entry entry;
     ret = db->hdb_firstkey(context, db, flags, &entry);
     if (ret == 0)
 	krb5_clear_error_message(context);
@@ -665,22 +665,22 @@ hdb_list_builtin(krb5_context context, char **list)
 krb5_error_code
 _hdb_keytab2hdb_entry(krb5_context context,
 		      const krb5_keytab_entry *ktentry,
-		      hdb_entry_ex *entry)
+		      hdb_entry *entry)
 {
-    entry->entry.kvno = ktentry->vno;
-    entry->entry.created_by.time = ktentry->timestamp;
+    entry->kvno = ktentry->vno;
+    entry->created_by.time = ktentry->timestamp;
 
-    entry->entry.keys.val = calloc(1, sizeof(entry->entry.keys.val[0]));
-    if (entry->entry.keys.val == NULL)
+    entry->keys.val = calloc(1, sizeof(entry->keys.val[0]));
+    if (entry->keys.val == NULL)
 	return ENOMEM;
-    entry->entry.keys.len = 1;
+    entry->keys.len = 1;
 
-    entry->entry.keys.val[0].mkvno = NULL;
-    entry->entry.keys.val[0].salt = NULL;
+    entry->keys.val[0].mkvno = NULL;
+    entry->keys.val[0].salt = NULL;
 
     return krb5_copy_keyblock_contents(context,
 				       &ktentry->keyblock,
-				       &entry->entry.keys.val[0].key);
+				       &entry->keys.val[0].key);
 }
 
 static krb5_error_code

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -110,9 +110,7 @@ typedef struct hdb_master_key_data *hdb_master_key;
  */
 
 typedef struct hdb_entry_ex {
-    void *ctx;
     hdb_entry entry;
-    void (*free_entry)(krb5_context, struct hdb_entry_ex *);
 } hdb_entry_ex;
 
 
@@ -165,9 +163,9 @@ typedef struct HDB {
      */
     krb5_error_code (*hdb_close)(krb5_context, struct HDB*);
     /**
-     * Free an entry after use.
+     * Free backend-specific entry context.
      */
-    void	    (*hdb_free)(krb5_context, struct HDB*, hdb_entry_ex*);
+    void	    (*hdb_free_entry_context)(krb5_context, struct HDB*, hdb_entry_ex*);
     /**
      * Fetch an entry from the backend
      *

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -103,18 +103,6 @@ typedef struct hdb_request_desc {
 typedef struct hdb_master_key_data *hdb_master_key;
 
 /**
- * hdb_entry_ex is a wrapper structure around the hdb_entry structure
- * that allows backends to keep a pointer to the backing store, ie in
- * ->hdb_fetch_kvno(), so that we the kadmin/kpasswd backend gets around to
- * ->hdb_store(), the backend doesn't need to lookup the entry again.
- */
-
-typedef struct hdb_entry_ex {
-    hdb_entry entry;
-} hdb_entry_ex;
-
-
-/**
  * HDB backend function pointer structure
  *
  * The HDB structure is what the KDC and kadmind framework uses to
@@ -165,7 +153,7 @@ typedef struct HDB {
     /**
      * Free backend-specific entry context.
      */
-    void	    (*hdb_free_entry_context)(krb5_context, struct HDB*, hdb_entry_ex*);
+    void	    (*hdb_free_entry_context)(krb5_context, struct HDB*, hdb_entry*);
     /**
      * Fetch an entry from the backend
      *
@@ -175,12 +163,12 @@ typedef struct HDB {
      */
     krb5_error_code (*hdb_fetch_kvno)(krb5_context, struct HDB*,
 				      krb5_const_principal, unsigned, krb5_kvno,
-				      hdb_entry_ex*);
+				      hdb_entry*);
     /**
      * Store an entry to database
      */
     krb5_error_code (*hdb_store)(krb5_context, struct HDB*,
-				 unsigned, hdb_entry_ex*);
+				 unsigned, hdb_entry*);
     /**
      * Remove an entry from the database.
      */
@@ -190,12 +178,12 @@ typedef struct HDB {
      * As part of iteration, fetch one entry
      */
     krb5_error_code (*hdb_firstkey)(krb5_context, struct HDB*,
-				    unsigned, hdb_entry_ex*);
+				    unsigned, hdb_entry*);
     /**
      * As part of iteration, fetch next entry
      */
     krb5_error_code (*hdb_nextkey)(krb5_context, struct HDB*,
-				   unsigned, hdb_entry_ex*);
+				   unsigned, hdb_entry*);
     /**
      * Lock database
      *
@@ -274,7 +262,7 @@ typedef struct HDB {
      * The backend needs to call _kadm5_set_keys() and perform password
      * quality checks.
      */
-    krb5_error_code (*hdb_password)(krb5_context, struct HDB*, hdb_entry_ex*, const char *, int);
+    krb5_error_code (*hdb_password)(krb5_context, struct HDB*, hdb_entry*, const char *, int);
 
     /**
      * Authentication auditing. Note that this function is called by
@@ -287,22 +275,22 @@ typedef struct HDB {
      * In case the entry is locked out, the backend should set the
      * hdb_entry.flags.locked-out flag.
      */
-    krb5_error_code (*hdb_audit)(krb5_context, struct HDB *, hdb_entry_ex *, hdb_request_t);
+    krb5_error_code (*hdb_audit)(krb5_context, struct HDB *, hdb_entry *, hdb_request_t);
 
     /**
      * Check if delegation is allowed.
      */
-    krb5_error_code (*hdb_check_constrained_delegation)(krb5_context, struct HDB *, hdb_entry_ex *, krb5_const_principal);
+    krb5_error_code (*hdb_check_constrained_delegation)(krb5_context, struct HDB *, hdb_entry *, krb5_const_principal);
 
     /**
      * Check if this name is an alias for the supplied client for PKINIT userPrinicpalName logins
      */
-    krb5_error_code (*hdb_check_pkinit_ms_upn_match)(krb5_context, struct HDB *, hdb_entry_ex *, krb5_const_principal);
+    krb5_error_code (*hdb_check_pkinit_ms_upn_match)(krb5_context, struct HDB *, hdb_entry *, krb5_const_principal);
 
     /**
      * Check if s4u2self is allowed from this client to this server or the SPN is a valid SPN of this client (for user2user)
      */
-    krb5_error_code (*hdb_check_client_matches_target_service)(krb5_context, struct HDB *, hdb_entry_ex *, hdb_entry_ex *);
+    krb5_error_code (*hdb_check_client_matches_target_service)(krb5_context, struct HDB *, hdb_entry *, hdb_entry *);
 
     /**
      * Enable/disable synchronous updates
@@ -337,7 +325,7 @@ struct hdb_print_entry_arg {
 };
 
 typedef krb5_error_code (*hdb_foreach_func_t)(krb5_context, HDB*,
-					      hdb_entry_ex*, void*);
+					      hdb_entry*, void*);
 extern krb5_kt_ops hdb_kt_ops;
 extern krb5_kt_ops hdb_get_kt_ops;
 

--- a/lib/hdb/hdb.opt
+++ b/lib/hdb/hdb.opt
@@ -1,0 +1,5 @@
+--sequence=HDB-extensions
+--sequence=HDB-Ext-KeyRotation
+--sequence=HDB-Ext-KeySet
+--sequence=Keys
+--decorate=HDB_entry:void:context?:::

--- a/lib/hdb/keytab.c
+++ b/lib/hdb/keytab.c
@@ -42,7 +42,7 @@ struct hdb_data {
 
 struct hdb_cursor {
     HDB *db;
-    hdb_entry_ex hdb_entry;
+    hdb_entry hdb_entry;
     int first, next;
     int key_idx;
 };
@@ -181,7 +181,7 @@ hdb_get_entry(krb5_context context,
 	      krb5_enctype enctype,
 	      krb5_keytab_entry *entry)
 {
-    hdb_entry_ex ent;
+    hdb_entry ent;
     krb5_error_code ret;
     struct hdb_data *d = id->data;
     const char *dbname = d->dbname;
@@ -226,21 +226,21 @@ hdb_get_entry(krb5_context context,
     }else if(ret)
 	goto out;
 
-    if(kvno && (krb5_kvno)ent.entry.kvno != kvno) {
+    if(kvno && (krb5_kvno)ent.kvno != kvno) {
 	hdb_free_entry(context, db, &ent);
  	ret = KRB5_KT_NOTFOUND;
 	goto out;
     }
     if(enctype == 0)
-	if(ent.entry.keys.len > 0)
-	    enctype = ent.entry.keys.val[0].key.keytype;
+	if(ent.keys.len > 0)
+	    enctype = ent.keys.val[0].key.keytype;
     ret = KRB5_KT_NOTFOUND;
-    for(i = 0; i < ent.entry.keys.len; i++) {
-	if(ent.entry.keys.val[i].key.keytype == enctype) {
+    for(i = 0; i < ent.keys.len; i++) {
+	if(ent.keys.val[i].key.keytype == enctype) {
 	    krb5_copy_principal(context, principal, &entry->principal);
-	    entry->vno = ent.entry.kvno;
+	    entry->vno = ent.kvno;
 	    krb5_copy_keyblock_contents(context,
-					&ent.entry.keys.val[i].key,
+					&ent.keys.val[i].key,
 					&entry->keyblock);
 	    ret = 0;
 	    break;
@@ -336,7 +336,7 @@ hdb_next_entry(krb5_context context,
 	else if (ret)
 	    return ret;
 
-	if (c->hdb_entry.entry.keys.len == 0)
+	if (c->hdb_entry.keys.len == 0)
 	    hdb_free_entry(context, c->db, &c->hdb_entry);
 	else
 	    c->next = FALSE;
@@ -353,7 +353,7 @@ hdb_next_entry(krb5_context context,
 	    return ret;
 
 	/* If no keys on this entry, try again */
-	if (c->hdb_entry.entry.keys.len == 0)
+	if (c->hdb_entry.keys.len == 0)
 	    hdb_free_entry(context, c->db, &c->hdb_entry);
 	else
 	    c->next = FALSE;
@@ -365,14 +365,14 @@ hdb_next_entry(krb5_context context,
      */
 
     ret = krb5_copy_principal(context,
-			      c->hdb_entry.entry.principal,
+			      c->hdb_entry.principal,
 			      &entry->principal);
     if (ret)
 	return ret;
 
-    entry->vno = c->hdb_entry.entry.kvno;
+    entry->vno = c->hdb_entry.kvno;
     ret = krb5_copy_keyblock_contents(context,
-				      &c->hdb_entry.entry.keys.val[c->key_idx].key,
+				      &c->hdb_entry.keys.val[c->key_idx].key,
 				      &entry->keyblock);
     if (ret) {
 	krb5_free_principal(context, entry->principal);
@@ -386,7 +386,7 @@ hdb_next_entry(krb5_context context,
      * next entry
      */
 
-    if ((size_t)c->key_idx == c->hdb_entry.entry.keys.len) {
+    if ((size_t)c->key_idx == c->hdb_entry.keys.len) {
 	hdb_free_entry(context, c->db, &c->hdb_entry);
 	c->next = TRUE;
 	c->key_idx = 0;

--- a/lib/hdb/keytab.c
+++ b/lib/hdb/keytab.c
@@ -227,7 +227,7 @@ hdb_get_entry(krb5_context context,
 	goto out;
 
     if(kvno && (krb5_kvno)ent.entry.kvno != kvno) {
-	hdb_free_entry(context, &ent);
+	hdb_free_entry(context, db, &ent);
  	ret = KRB5_KT_NOTFOUND;
 	goto out;
     }
@@ -246,7 +246,7 @@ hdb_get_entry(krb5_context context,
 	    break;
 	}
     }
-    hdb_free_entry(context, &ent);
+    hdb_free_entry(context, db, &ent);
  out:
     (*db->hdb_close)(context, db);
     (*db->hdb_destroy)(context, db);
@@ -337,7 +337,7 @@ hdb_next_entry(krb5_context context,
 	    return ret;
 
 	if (c->hdb_entry.entry.keys.len == 0)
-	    hdb_free_entry(context, &c->hdb_entry);
+	    hdb_free_entry(context, c->db, &c->hdb_entry);
 	else
 	    c->next = FALSE;
     }
@@ -354,7 +354,7 @@ hdb_next_entry(krb5_context context,
 
 	/* If no keys on this entry, try again */
 	if (c->hdb_entry.entry.keys.len == 0)
-	    hdb_free_entry(context, &c->hdb_entry);
+	    hdb_free_entry(context, c->db, &c->hdb_entry);
 	else
 	    c->next = FALSE;
     }
@@ -387,7 +387,7 @@ hdb_next_entry(krb5_context context,
      */
 
     if ((size_t)c->key_idx == c->hdb_entry.entry.keys.len) {
-	hdb_free_entry(context, &c->hdb_entry);
+	hdb_free_entry(context, c->db, &c->hdb_entry);
 	c->next = TRUE;
 	c->key_idx = 0;
     }
@@ -404,7 +404,7 @@ hdb_end_seq_get(krb5_context context,
     struct hdb_cursor *c = cursor->data;
 
     if (!c->next)
-	hdb_free_entry(context, &c->hdb_entry);
+	hdb_free_entry(context, c->db, &c->hdb_entry);
 
     (c->db->hdb_close)(context, c->db);
     (c->db->hdb_destroy)(context, c->db);

--- a/lib/hdb/ndbm.c
+++ b/lib/hdb/ndbm.c
@@ -104,12 +104,12 @@ NDBM_seq(krb5_context context, HDB *db,
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
 	ret = hdb_unseal_keys (context, db, &entry->entry);
 	if (ret)
-	    hdb_free_entry (context, entry);
+	    hdb_free_entry (context, db, entry);
     }
     if (ret == 0 && entry->entry.principal == NULL) {
 	entry->entry.principal = malloc (sizeof(*entry->entry.principal));
 	if (entry->entry.principal == NULL) {
-	    hdb_free_entry (context, entry);
+	    hdb_free_entry (context, db, entry);
 	    ret = ENOMEM;
 	    krb5_set_error_message(context, ret, "malloc: out of memory");
 	} else {

--- a/lib/hdb/ndbm.c
+++ b/lib/hdb/ndbm.c
@@ -76,7 +76,7 @@ NDBM_unlock(krb5_context context, HDB *db)
 
 static krb5_error_code
 NDBM_seq(krb5_context context, HDB *db,
-	 unsigned flags, hdb_entry_ex *entry, int first)
+	 unsigned flags, hdb_entry *entry, int first)
 
 {
     struct ndbm_db *d = (struct ndbm_db *)db->hdb_db;
@@ -99,21 +99,21 @@ NDBM_seq(krb5_context context, HDB *db,
     data.data = value.dptr;
     data.length = value.dsize;
     memset(entry, 0, sizeof(*entry));
-    if(hdb_value2entry(context, &data, &entry->entry))
+    if(hdb_value2entry(context, &data, entry))
 	return NDBM_seq(context, db, flags, entry, 0);
     if (db->hdb_master_key_set && (flags & HDB_F_DECRYPT)) {
-	ret = hdb_unseal_keys (context, db, &entry->entry);
+	ret = hdb_unseal_keys (context, db, entry);
 	if (ret)
 	    hdb_free_entry (context, db, entry);
     }
-    if (ret == 0 && entry->entry.principal == NULL) {
-	entry->entry.principal = malloc (sizeof(*entry->entry.principal));
-	if (entry->entry.principal == NULL) {
+    if (ret == 0 && entry->principal == NULL) {
+	entry->principal = malloc (sizeof(*entry->principal));
+	if (entry->principal == NULL) {
 	    hdb_free_entry (context, db, entry);
 	    ret = ENOMEM;
 	    krb5_set_error_message(context, ret, "malloc: out of memory");
 	} else {
-	    hdb_key2principal (context, &key_data, entry->entry.principal);
+	    hdb_key2principal (context, &key_data, entry->principal);
 	}
     }
     return ret;
@@ -121,14 +121,14 @@ NDBM_seq(krb5_context context, HDB *db,
 
 
 static krb5_error_code
-NDBM_firstkey(krb5_context context, HDB *db,unsigned flags,hdb_entry_ex *entry)
+NDBM_firstkey(krb5_context context, HDB *db,unsigned flags,hdb_entry *entry)
 {
     return NDBM_seq(context, db, flags, entry, 1);
 }
 
 
 static krb5_error_code
-NDBM_nextkey(krb5_context context, HDB *db, unsigned flags,hdb_entry_ex *entry)
+NDBM_nextkey(krb5_context context, HDB *db, unsigned flags,hdb_entry *entry)
 {
     return NDBM_seq(context, db, flags, entry, 0);
 }

--- a/lib/hdb/print.c
+++ b/lib/hdb/print.c
@@ -556,7 +556,7 @@ hdb_entry2string(krb5_context context, hdb_entry *ent, char **str)
 /* print a hdb_entry to (FILE*)data; suitable for hdb_foreach */
 
 krb5_error_code
-hdb_print_entry(krb5_context context, HDB *db, hdb_entry_ex *entry,
+hdb_print_entry(krb5_context context, HDB *db, hdb_entry *entry,
                 void *data)
 {
     struct hdb_print_entry_arg *parg = data;
@@ -572,10 +572,10 @@ hdb_print_entry(krb5_context context, HDB *db, hdb_entry_ex *entry,
 
     switch (parg->fmt) {
     case HDB_DUMP_HEIMDAL:
-        ret = entry2string_int(context, sp, &entry->entry);
+        ret = entry2string_int(context, sp, entry);
         break;
     case HDB_DUMP_MIT:
-        ret = entry2mit_string_int(context, sp, &entry->entry);
+        ret = entry2mit_string_int(context, sp, entry);
         break;
     default:
         heim_abort("Only two dump formats supported: Heimdal and MIT");

--- a/lib/hdb/test_concurrency.c
+++ b/lib/hdb/test_concurrency.c
@@ -70,7 +70,7 @@ threaded_reader(void *d)
     krb5_error_code ret;
     krb5_context context;
     struct tsync *s = d;
-    hdb_entry_ex entr;
+    hdb_entry entr;
     HDB *dbr = NULL;
 
     printf("Reader thread opening HDB\n");
@@ -101,7 +101,7 @@ threaded_reader(void *d)
         //(void) unlink(s->fname);
         krb5_err(context, 1, ret, "Could not iterate HDB %s", s->hdb_name);
     }
-    free_HDB_entry(&entr.entry);
+    free_HDB_entry(&entr);
 
     /* Tell the writer to go ahead and write */
     printf("Reader thread iterated one entry; telling writer to write more\n");
@@ -124,7 +124,7 @@ threaded_reader(void *d)
                  "Could not iterate while writing to HDB %s", s->hdb_name);
     }
     printf("Reader thread iterated another entry\n");
-    free_HDB_entry(&entr.entry);
+    free_HDB_entry(&entr);
     if ((ret = dbr->hdb_nextkey(context, dbr, 0, &entr)) == 0) {
         //(void) unlink(s->fname);
         krb5_warn(context, ret,
@@ -154,7 +154,7 @@ forked_reader(struct tsync *s)
 {
     krb5_error_code ret;
     krb5_context context;
-    hdb_entry_ex entr;
+    hdb_entry entr;
     ssize_t bytes;
     char b[1];
     HDB *dbr = NULL;
@@ -190,7 +190,7 @@ forked_reader(struct tsync *s)
         krb5_err(context, 1, ret, "Could not iterate HDB %s", s->hdb_name);
     }
     printf("Reader process iterated one entry\n");
-    free_HDB_entry(&entr.entry);
+    free_HDB_entry(&entr);
 
     /* Tell the writer to go ahead and write */
     printf("Reader process iterated one entry; telling writer to write more\n");
@@ -217,13 +217,13 @@ forked_reader(struct tsync *s)
         krb5_err(context, 1, ret,
                  "Could not iterate while writing to HDB %s", s->hdb_name);
     }
-    free_HDB_entry(&entr.entry);
+    free_HDB_entry(&entr);
     printf("Reader process iterated another entry\n");
     if ((ret = dbr->hdb_nextkey(context, dbr, 0, &entr)) == 0) {
         //(void) unlink(s->fname);
         krb5_warn(context, ret,
                  "HDB %s sees writes committed since starting iteration (%s)",
-                 s->hdb_name, entr.entry.principal->name.name_string.val[0]);
+                 s->hdb_name, entr.principal->name.name_string.val[0]);
     } else if (ret != HDB_ERR_NOENTRY) {
         //(void) unlink(s->fname);
         krb5_err(context, 1, ret,
@@ -248,27 +248,27 @@ forked_reader(struct tsync *s)
 }
 
 static krb5_error_code
-make_entry(krb5_context context, hdb_entry_ex *entry, const char *name)
+make_entry(krb5_context context, hdb_entry *entry, const char *name)
 {
     krb5_error_code ret;
 
     memset(entry, 0, sizeof(*entry));
-    entry->entry.kvno = 2;
-    entry->entry.keys.len = 0;
-    entry->entry.keys.val = NULL;
-    entry->entry.created_by.time = time(NULL);
-    entry->entry.modified_by = NULL;
-    entry->entry.valid_start = NULL;
-    entry->entry.valid_end = NULL;
-    entry->entry.max_life = NULL;
-    entry->entry.max_renew = NULL;
-    entry->entry.etypes = NULL;
-    entry->entry.generation = NULL;
-    entry->entry.extensions = NULL;
-    if ((ret = krb5_make_principal(context, &entry->entry.principal,
+    entry->kvno = 2;
+    entry->keys.len = 0;
+    entry->keys.val = NULL;
+    entry->created_by.time = time(NULL);
+    entry->modified_by = NULL;
+    entry->valid_start = NULL;
+    entry->valid_end = NULL;
+    entry->max_life = NULL;
+    entry->max_renew = NULL;
+    entry->etypes = NULL;
+    entry->generation = NULL;
+    entry->extensions = NULL;
+    if ((ret = krb5_make_principal(context, &entry->principal,
                                    "TEST.H5L.SE", name, NULL)))
         return ret;
-    if ((ret = krb5_make_principal(context, &entry->entry.created_by.principal,
+    if ((ret = krb5_make_principal(context, &entry->created_by.principal,
                                    "TEST.H5L.SE", "tester", NULL)))
         return ret;
     return 0;
@@ -326,7 +326,7 @@ test_hdb_concurrency(char *name, const char *ext, int threaded)
     char *fname_ext = NULL;
     pthread_t reader_thread;
     struct tsync ts;
-    hdb_entry_ex entw;
+    hdb_entry entw;
     pid_t child = getpid();
     HDB *dbw = NULL;
     int status;
@@ -393,14 +393,14 @@ test_hdb_concurrency(char *name, const char *ext, int threaded)
         krb5_err(context, 1, ret,
                  "Could not store entry for \"foo\" in HDB %s", name);
     }
-    free_HDB_entry(&entw.entry);
+    free_HDB_entry(&entw);
     if ((ret = make_entry(context, &entw, "bar")) ||
         (ret = dbw->hdb_store(context, dbw, 0, &entw))) {
         (void) unlink(fname_ext);
         krb5_err(context, 1, ret,
                  "Could not store entry for \"foo\" in HDB %s", name);
     }
-    free_HDB_entry(&entw.entry);
+    free_HDB_entry(&entw);
 
     /* Tell the reader to start reading */
     readers_turn(&ts, child, threaded);
@@ -413,7 +413,7 @@ test_hdb_concurrency(char *name, const char *ext, int threaded)
                  "Could not store entry for \"foobar\" in HDB %s "
                  "while iterating it", name);
     }
-    free_HDB_entry(&entw.entry);
+    free_HDB_entry(&entw);
 
     /* Tell the reader to go again */
     readers_turn(&ts, child, threaded);

--- a/lib/hdb/test_namespace.c
+++ b/lib/hdb/test_namespace.c
@@ -106,7 +106,7 @@ TDB_unlock(krb5_context context, HDB *db)
 }
 
 static krb5_error_code
-TDB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
+TDB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry *entry)
 {
     /* XXX Implement */
     /* Tricky thing: heim_dict_iterate_f() is inconvenient here */
@@ -115,7 +115,7 @@ TDB_firstkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
 }
 
 static krb5_error_code
-TDB_nextkey(krb5_context context, HDB *db, unsigned flags, hdb_entry_ex *entry)
+TDB_nextkey(krb5_context context, HDB *db, unsigned flags, hdb_entry *entry)
 {
     /* XXX Implement */
     /* Tricky thing: heim_dict_iterate_f() is inconvenient here */
@@ -337,7 +337,7 @@ static void
 make_namespace(krb5_context context, HDB *db, const char *name)
 {
     krb5_error_code ret = 0;
-    hdb_entry_ex e;
+    hdb_entry e;
     Key k;
 
     memset(&k, 0, sizeof(k));
@@ -346,76 +346,76 @@ make_namespace(krb5_context context, HDB *db, const char *name)
 
     /* Setup the HDB entry */
     memset(&e, 0, sizeof(e));
-    e.entry.created_by.time = krs[0].epoch;
-    e.entry.valid_start = e.entry.valid_end = e.entry.pw_end = 0;
-    e.entry.generation = 0;
-    e.entry.flags = int2HDBFlags(0);
-    e.entry.flags.server = e.entry.flags.client = 1;
-    e.entry.flags.virtual = 1;
+    e.created_by.time = krs[0].epoch;
+    e.valid_start = e.valid_end = e.pw_end = 0;
+    e.generation = 0;
+    e.flags = int2HDBFlags(0);
+    e.flags.server = e.flags.client = 1;
+    e.flags.virtual = 1;
 
     /* Setup etypes */
     if (ret == 0 &&
-        (e.entry.etypes = malloc(sizeof(*e.entry.etypes))) == NULL)
+        (e.etypes = malloc(sizeof(*e.etypes))) == NULL)
         ret = krb5_enomem(context);
     if (ret == 0)
-        e.entry.etypes->len = 3;
+        e.etypes->len = 3;
     if (ret == 0 &&
-        (e.entry.etypes->val = calloc(e.entry.etypes->len,
-                                      sizeof(e.entry.etypes->val[0]))) == NULL)
+        (e.etypes->val = calloc(e.etypes->len,
+                                      sizeof(e.etypes->val[0]))) == NULL)
         ret = krb5_enomem(context);
     if (ret == 0) {
-        e.entry.etypes->val[0] = KRB5_ENCTYPE_AES128_CTS_HMAC_SHA256_128;
-        e.entry.etypes->val[1] = KRB5_ENCTYPE_AES256_CTS_HMAC_SHA384_192;
-        e.entry.etypes->val[2] = KRB5_ENCTYPE_AES256_CTS_HMAC_SHA1_96;
+        e.etypes->val[0] = KRB5_ENCTYPE_AES128_CTS_HMAC_SHA256_128;
+        e.etypes->val[1] = KRB5_ENCTYPE_AES256_CTS_HMAC_SHA384_192;
+        e.etypes->val[2] = KRB5_ENCTYPE_AES256_CTS_HMAC_SHA1_96;
     }
 
     /* Setup max_life and max_renew */
     if (ret == 0 &&
-        (e.entry.max_life = malloc(sizeof(*e.entry.max_life))) == NULL)
+        (e.max_life = malloc(sizeof(*e.max_life))) == NULL)
         ret = krb5_enomem(context);
     if (ret == 0 &&
-        (e.entry.max_renew = malloc(sizeof(*e.entry.max_renew))) == NULL)
+        (e.max_renew = malloc(sizeof(*e.max_renew))) == NULL)
         ret = krb5_enomem(context);
     if (ret == 0)
         /* Make it long, so we see the clamped max */
-        *e.entry.max_renew = 2 * ((*e.entry.max_life = 15 * 24 * 3600));
+        *e.max_renew = 2 * ((*e.max_life = 15 * 24 * 3600));
 
     /* Setup principal name and created_by */
     if (ret == 0)
-        ret = krb5_parse_name(context, name, &e.entry.principal);
+        ret = krb5_parse_name(context, name, &e.principal);
     if (ret == 0)
         ret = krb5_parse_name(context, "admin@BAR.EXAMPLE",
-                              &e.entry.created_by.principal);
+                              &e.created_by.principal);
 
     /* Make base keys for first epoch */
     if (ret == 0)
-        ret = make_base_key(context, e.entry.principal, base_pw[0], &k.key);
+        ret = make_base_key(context, e.principal, base_pw[0], &k.key);
     if (ret == 0)
-        add_Keys(&e.entry.keys, &k);
+        add_Keys(&e.keys, &k);
     if (ret == 0)
-        ret = hdb_entry_set_pw_change_time(context, &e.entry, krs[0].epoch);
+        ret = hdb_entry_set_pw_change_time(context, &e, krs[0].epoch);
     free_Key(&k);
-    e.entry.kvno = krs[0].base_key_kvno;
+    e.kvno = krs[0].base_key_kvno;
 
     /* Move them to history */
     if (ret == 0)
-        ret = hdb_add_current_keys_to_history(context, &e.entry);
-    free_Keys(&e.entry.keys);
+        ret = hdb_add_current_keys_to_history(context, &e);
+    free_Keys(&e.keys);
 
     /* Make base keys for second epoch */
     if (ret == 0)
-        ret = make_base_key(context, e.entry.principal, base_pw[1], &k.key);
+        ret = make_base_key(context, e.principal, base_pw[1], &k.key);
     if (ret == 0)
-        add_Keys(&e.entry.keys, &k);
-    e.entry.kvno = krs[1].base_key_kvno;
+        add_Keys(&e.keys, &k);
+    e.kvno = krs[1].base_key_kvno;
     if (ret == 0)
-        ret = hdb_entry_set_pw_change_time(context, &e.entry, krs[1].epoch);
+        ret = hdb_entry_set_pw_change_time(context, &e, krs[1].epoch);
 
     /* Add the key rotation metadata */
     if (ret == 0)
-        ret = hdb_entry_add_key_rotation(context, &e.entry, 0, &krs[0]);
+        ret = hdb_entry_add_key_rotation(context, &e, 0, &krs[0]);
     if (ret == 0)
-        ret = hdb_entry_add_key_rotation(context, &e.entry, 0, &krs[1]);
+        ret = hdb_entry_add_key_rotation(context, &e, 0, &krs[1]);
 
     if (ret == 0)
         ret = db->hdb_store(context, db, 0, &e);
@@ -447,7 +447,7 @@ static const char *unexpected[] = {
  * different time offsets in each period.
  */
 #define NUM_OFFSETS 5
-static hdb_entry_ex e[
+static hdb_entry e[
     (sizeof(expected) / sizeof(expected[0])) *
     (sizeof(krs) / sizeof(krs[0])) *
     NUM_OFFSETS
@@ -479,8 +479,8 @@ fetch_entries(krb5_context context,
     krb5_error_code ret = 0;
     krb5_principal p = NULL;
     krb5_keyblock base_key, dk;
-    hdb_entry_ex *ep;
-    hdb_entry_ex no;
+    hdb_entry *ep;
+    hdb_entry no;
     size_t i, b;
     int toffset = 0;
 
@@ -541,14 +541,14 @@ fetch_entries(krb5_context context,
             }
         } else {
             if (ret == 0 &&
-                !krb5_principal_compare(context, p, ep->entry.principal))
+                !krb5_principal_compare(context, p, ep->principal))
             krb5_errx(context, 1, "wrong principal in fetched entry");
         }
 
         {
             HDB_Ext_KeySet *hist_keys;
             HDB_extension *ext;
-            ext = hdb_find_extension(&ep->entry,
+            ext = hdb_find_extension(ep,
                                      choice_HDB_extension_data_hist_keys);
             if (ext) {
                 /* Sort key history by kvno, why not */
@@ -611,23 +611,23 @@ fetch_entries(krb5_context context,
         if (ret)
             krb5_err(context, 1, ret, "deriving keys for comparison");
 
-        if (kvno != ep->entry.kvno)
-            krb5_errx(context, 1, "kvno mismatch (%u != %u)", kvno, ep->entry.kvno);
-        (void) hdb_entry_get_pw_change_time(&ep->entry, &chg_time);
+        if (kvno != ep->kvno)
+            krb5_errx(context, 1, "kvno mismatch (%u != %u)", kvno, ep->kvno);
+        (void) hdb_entry_get_pw_change_time(ep, &chg_time);
         if (set_time != chg_time)
             krb5_errx(context, 1, "key change time mismatch");
-        if (ep->entry.keys.len == 0)
+        if (ep->keys.len == 0)
             krb5_errx(context, 1, "no keys!");
-        if (ep->entry.keys.val[0].key.keytype != dk.keytype)
+        if (ep->keys.val[0].key.keytype != dk.keytype)
             krb5_errx(context, 1, "enctype mismatch!");
-        if (ep->entry.keys.val[0].key.keyvalue.length !=
+        if (ep->keys.val[0].key.keyvalue.length !=
             dk.keyvalue.length)
             krb5_errx(context, 1, "key length mismatch!");
-        if (memcmp(ep->entry.keys.val[0].key.keyvalue.data,
+        if (memcmp(ep->keys.val[0].key.keyvalue.data,
                    dk.keyvalue.data, dk.keyvalue.length) != 0)
             krb5_errx(context, 1, "key mismatch!");
-        if (memcmp(ep->entry.keys.val[0].key.keyvalue.data,
-                   e[b + i - 1].entry.keys.val[0].key.keyvalue.data,
+        if (memcmp(ep->keys.val[0].key.keyvalue.data,
+                   e[b + i - 1].keys.val[0].key.keyvalue.data,
                    dk.keyvalue.length) == 0)
             krb5_errx(context, 1, "different virtual principals have the same keys!");
         /* XXX Add check that we have the expected number of history keys */
@@ -653,14 +653,14 @@ check_kvnos(krb5_context context)
         for (k = 0; k < sizeof(e)/sizeof(e[0]); k++) {
             HDB_Ext_KeySet *hist_keys;
             HDB_extension *ext;
-            hdb_entry_ex *ep;
+            hdb_entry *ep;
             int match = 0;
 
             if ((k % NUM_OFFSETS) != i)
                 continue;
 
             ep = &e[k];
-            if (ep->entry.principal == NULL)
+            if (ep->principal == NULL)
                 continue; /* Didn't fetch this one */
 
             /*
@@ -668,15 +668,15 @@ check_kvnos(krb5_context context)
              * or else add them to `keysets'.
              */
             for (m = 0; m < keysets.len; m++) {
-                if (ep->entry.kvno == keysets.val[m].kvno) {
+                if (ep->kvno == keysets.val[m].kvno) {
                     /* Check the key is the same */
-                    if (ep->entry.keys.val[0].key.keytype !=
+                    if (ep->keys.val[0].key.keytype !=
                         keysets.val[m].keys.val[0].key.keytype ||
-                        ep->entry.keys.val[0].key.keyvalue.length !=
+                        ep->keys.val[0].key.keyvalue.length !=
                         keysets.val[m].keys.val[0].key.keyvalue.length ||
-                        memcmp(ep->entry.keys.val[0].key.keyvalue.data,
+                        memcmp(ep->keys.val[0].key.keyvalue.data,
                                keysets.val[m].keys.val[0].key.keyvalue.data,
-                               ep->entry.keys.val[0].key.keyvalue.length) != 0)
+                               ep->keys.val[0].key.keyvalue.length) != 0)
                         krb5_errx(context, 1,
                                   "key mismatch for same princ & kvno");
                     match = 1;
@@ -685,8 +685,8 @@ check_kvnos(krb5_context context)
             if (m == keysets.len) {
                 hdb_keyset ks;
 
-                ks.kvno = ep->entry.kvno;
-                ks.keys = ep->entry.keys;
+                ks.kvno = ep->kvno;
+                ks.keys = ep->keys;
                 ks.set_time = 0;
                 if (add_HDB_Ext_KeySet(&keysets, &ks))
                     krb5_err(context, 1, ENOMEM, "out of memory");
@@ -696,7 +696,7 @@ check_kvnos(krb5_context context)
                 continue;
 
             /* For all non-current keysets, repeat the above */
-            ext = hdb_find_extension(&ep->entry,
+            ext = hdb_find_extension(ep,
                                      choice_HDB_extension_data_hist_keys);
             if (!ext)
                 continue;
@@ -704,20 +704,20 @@ check_kvnos(krb5_context context)
             for (p = 0; p < hist_keys->len; p++) {
                 for (m = 0; m < keysets.len; m++) {
                     if (keysets.val[m].kvno == hist_keys->val[p].kvno)
-                        if (ep->entry.keys.val[0].key.keytype !=
+                        if (ep->keys.val[0].key.keytype !=
                             keysets.val[m].keys.val[0].key.keytype ||
-                            ep->entry.keys.val[0].key.keyvalue.length !=
+                            ep->keys.val[0].key.keyvalue.length !=
                             keysets.val[m].keys.val[0].key.keyvalue.length ||
-                            memcmp(ep->entry.keys.val[0].key.keyvalue.data,
+                            memcmp(ep->keys.val[0].key.keyvalue.data,
                                    keysets.val[m].keys.val[0].key.keyvalue.data,
-                                   ep->entry.keys.val[0].key.keyvalue.length) != 0)
+                                   ep->keys.val[0].key.keyvalue.length) != 0)
                             krb5_errx(context, 1,
                                       "key mismatch for same princ & kvno");
                 }
                 if (m == keysets.len) {
                     hdb_keyset ks;
-                    ks.kvno = ep->entry.kvno;
-                    ks.keys = ep->entry.keys;
+                    ks.kvno = ep->kvno;
+                    ks.keys = ep->keys;
                     ks.set_time = 0;
                     if (add_HDB_Ext_KeySet(&keysets, &ks))
                         krb5_err(context, 1, ENOMEM, "out of memory");
@@ -741,15 +741,14 @@ print_em(krb5_context context)
 
         if (0 == i % (sizeof(expected)/sizeof(expected[0])))
             continue;
-        if (e[i].entry.principal == NULL)
+        if (e[i].principal == NULL)
             continue;
-        hex_encode(e[i].entry.keys.val[0].key.keyvalue.data,
-                   e[i].entry.keys.val[0].key.keyvalue.length, &x);
-        printf("%s %u %s\n", x, e[i].entry.kvno, name);
+        hex_encode(e[i].keys.val[0].key.keyvalue.data,
+                   e[i].keys.val[0].key.keyvalue.length, &x);
+        printf("%s %u %s\n", x, e[i].kvno, name);
         free(x);
 
-        ext = hdb_find_extension(&e[i].entry,
-                                 choice_HDB_extension_data_hist_keys);
+        ext = hdb_find_extension(&e[i], choice_HDB_extension_data_hist_keys);
         if (!ext)
             continue;
         hist_keys = &ext->data.u.hist_keys;
@@ -771,12 +770,12 @@ check_expected_kvnos(krb5_context context)
 
     for (i = 0; i < sizeof(expected)/sizeof(expected[0]); i++) {
         for (k = 0; k < sizeof(krs)/sizeof(krs[0]); k++) {
-            hdb_entry_ex *ep = &e[k * sizeof(expected)/sizeof(expected[0]) + i];
+            hdb_entry *ep = &e[k * sizeof(expected)/sizeof(expected[0]) + i];
 
-            if (ep->entry.principal == NULL)
+            if (ep->principal == NULL)
                 continue;
             for (m = 0; m < NUM_OFFSETS; m++) {
-                ext = hdb_find_extension(&ep->entry,
+                ext = hdb_find_extension(ep,
                                          choice_HDB_extension_data_hist_keys);
                 if (!ext)
                     continue;
@@ -787,7 +786,7 @@ check_expected_kvnos(krb5_context context)
                 }
             }
             fprintf(stderr, "%s at %lu: kvno %u\n", expected[i], k,
-                    ep->entry.kvno);
+                    ep->kvno);
         }
     }
 }

--- a/lib/hdb/test_namespace.c
+++ b/lib/hdb/test_namespace.c
@@ -346,8 +346,6 @@ make_namespace(krb5_context context, HDB *db, const char *name)
 
     /* Setup the HDB entry */
     memset(&e, 0, sizeof(e));
-    e.ctx = 0;
-    e.free_entry = 0;
     e.entry.created_by.time = krs[0].epoch;
     e.entry.valid_start = e.entry.valid_end = e.entry.pw_end = 0;
     e.entry.generation = 0;
@@ -424,7 +422,7 @@ make_namespace(krb5_context context, HDB *db, const char *name)
     if (ret)
         krb5_err(context, 1, ret, "failed to setup a namespace principal");
     free_Key(&k);
-    hdb_free_entry(context, &e);
+    hdb_free_entry(context, db, &e);
 }
 
 #define WK_PREFIX "WELLKNOWN/" HDB_WK_NAMESPACE "/"
@@ -936,7 +934,7 @@ main(int argc, char **argv)
 
     /* Cleanup */
     for (i = 0; ret == 0 && i < sizeof(e) / sizeof(e[0]); i++)
-        hdb_free_entry(context, &e[i]);
+        hdb_free_entry(context, db, &e[i]);
     db->hdb_destroy(context, db);
     krb5_free_context(context);
     return 0;

--- a/lib/kadm5/chpass_s.c
+++ b/lib/kadm5/chpass_s.c
@@ -111,7 +111,7 @@ change(void *server_handle,
        int cond)
 {
     kadm5_server_context *context = server_handle;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_ret_t ret;
     Key *keys;
     size_t num_keys;
@@ -167,7 +167,7 @@ change(void *server_handle,
 	 * We save these for now so we can handle password history checking;
 	 * we handle keepold further below.
 	 */
-	ret = hdb_add_current_keys_to_history(context->context, &ent.entry);
+	ret = hdb_add_current_keys_to_history(context->context, &ent);
 	if (ret)
 	    goto out3;
     }
@@ -179,13 +179,13 @@ change(void *server_handle,
 	    goto out3;
     } else {
 
-	num_keys = ent.entry.keys.len;
-	keys     = ent.entry.keys.val;
+	num_keys = ent.keys.len;
+	keys     = ent.keys.val;
 
-	ent.entry.keys.len = 0;
-	ent.entry.keys.val = NULL;
+	ent.keys.len = 0;
+	ent.keys.val = NULL;
 
-	ret = _kadm5_set_keys(context, &ent.entry, n_ks_tuple, ks_tuple,
+	ret = _kadm5_set_keys(context, &ent, n_ks_tuple, ks_tuple,
 			      password);
 	if(ret) {
 	    _kadm5_free_keys(context->context, num_keys, keys);
@@ -196,10 +196,10 @@ change(void *server_handle,
 	if (cond) {
 	    HDB_extension *ext;
 
-	    ext = hdb_find_extension(&ent.entry, choice_HDB_extension_data_hist_keys);
+	    ext = hdb_find_extension(&ent, choice_HDB_extension_data_hist_keys);
 	    if (ext != NULL)
-		existsp = _kadm5_exists_keys_hist(ent.entry.keys.val,
-						  ent.entry.keys.len,
+		existsp = _kadm5_exists_keys_hist(ent.keys.val,
+						  ent.keys.len,
 						  &ext->data.u.hist_keys);
 	}
 
@@ -210,9 +210,9 @@ change(void *server_handle,
 	    goto out3;
 	}
     }
-    ent.entry.kvno++;
+    ent.kvno++;
 
-    ent.entry.flags.require_pwchange = 0;
+    ent.flags.require_pwchange = 0;
 
     if (!keepold) {
 	HDB_extension ext;
@@ -220,25 +220,25 @@ change(void *server_handle,
 	memset(&ext, 0, sizeof (ext));
         ext.mandatory = FALSE;
 	ext.data.element = choice_HDB_extension_data_hist_keys;
-	ret = hdb_replace_extension(context->context, &ent.entry, &ext);
+	ret = hdb_replace_extension(context->context, &ent, &ext);
 	if (ret)
 	    goto out3;
     }
 
-    ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+    ret = hdb_seal_keys(context->context, context->db, &ent);
     if (ret)
         goto out3;
 
-    ret = _kadm5_set_modifier(context, &ent.entry);
+    ret = _kadm5_set_modifier(context, &ent);
     if(ret)
 	goto out3;
 
-    ret = _kadm5_bump_pw_expire(context, &ent.entry);
+    ret = _kadm5_bump_pw_expire(context, &ent);
     if (ret)
 	goto out3;
 
     /* This logs the change for iprop and writes to the HDB */
-    ret = kadm5_log_modify(context, &ent.entry,
+    ret = kadm5_log_modify(context, &ent,
                            KADM5_ATTRIBUTES | KADM5_PRINCIPAL |
                            KADM5_MOD_NAME | KADM5_MOD_TIME |
                            KADM5_KEY_DATA | KADM5_KVNO |
@@ -367,7 +367,7 @@ kadm5_s_chpass_principal_with_key(void *server_handle,
 				  krb5_key_data *key_data)
 {
     kadm5_server_context *context = server_handle;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_ret_t ret;
     uint32_t hook_flags = 0;
 
@@ -396,23 +396,23 @@ kadm5_s_chpass_principal_with_key(void *server_handle,
 	goto out3;
 
     if (keepold) {
-	ret = hdb_add_current_keys_to_history(context->context, &ent.entry);
+	ret = hdb_add_current_keys_to_history(context->context, &ent);
 	if (ret)
 	    goto out3;
     }
-    ret = _kadm5_set_keys2(context, &ent.entry, n_key_data, key_data);
+    ret = _kadm5_set_keys2(context, &ent, n_key_data, key_data);
     if (ret)
 	goto out3;
-    ent.entry.kvno++;
-    ret = _kadm5_set_modifier(context, &ent.entry);
+    ent.kvno++;
+    ret = _kadm5_set_modifier(context, &ent);
     if (ret)
 	goto out3;
-    ret = _kadm5_bump_pw_expire(context, &ent.entry);
+    ret = _kadm5_bump_pw_expire(context, &ent);
     if (ret)
 	goto out3;
 
     if (keepold) {
-	ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+	ret = hdb_seal_keys(context->context, context->db, &ent);
 	if (ret)
 	    goto out3;
     } else {
@@ -423,11 +423,11 @@ kadm5_s_chpass_principal_with_key(void *server_handle,
 	ext.data.element = choice_HDB_extension_data_hist_keys;
 	ext.data.u.hist_keys.len = 0;
 	ext.data.u.hist_keys.val = NULL;
-	hdb_replace_extension(context->context, &ent.entry, &ext);
+	hdb_replace_extension(context->context, &ent, &ext);
     }
 
     /* This logs the change for iprop and writes to the HDB */
-    ret = kadm5_log_modify(context, &ent.entry,
+    ret = kadm5_log_modify(context, &ent,
                            KADM5_PRINCIPAL | KADM5_MOD_NAME |
                            KADM5_MOD_TIME | KADM5_KEY_DATA | KADM5_KVNO |
                            KADM5_PW_EXPIRATION | KADM5_TL_DATA);

--- a/lib/kadm5/chpass_s.c
+++ b/lib/kadm5/chpass_s.c
@@ -249,7 +249,7 @@ change(void *server_handle,
 				 n_ks_tuple, ks_tuple, password);
 
  out3:
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
  out2:
     (void) kadm5_log_end(context);
  out:
@@ -437,7 +437,7 @@ kadm5_s_chpass_principal_with_key(void *server_handle,
 					  n_key_data, key_data);
 
  out3:
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
  out2:
     (void) kadm5_log_end(context);
  out:

--- a/lib/kadm5/create_s.c
+++ b/lib/kadm5/create_s.c
@@ -194,7 +194,7 @@ kadm5_s_create_principal_with_key(void *server_handle,
     if (!context->keep_open) {
         ret = context->db->hdb_open(context->context, context->db, O_RDWR, 0);
         if (ret) {
-            hdb_free_entry(context->context, &ent);
+            hdb_free_entry(context->context, context->db, &ent);
             return ret;
         }
     }
@@ -227,7 +227,7 @@ kadm5_s_create_principal_with_key(void *server_handle,
         if (ret == 0 && ret2 != 0)
             ret = ret2;
     }
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
     return _kadm5_error_code(ret);
 }
 
@@ -315,7 +315,7 @@ kadm5_s_create_principal(void *server_handle,
     if (!context->keep_open) {
         ret = context->db->hdb_open(context->context, context->db, O_RDWR, 0);
         if (ret) {
-            hdb_free_entry(context->context, &ent);
+            hdb_free_entry(context->context, context->db, &ent);
             return ret;
         }
     }
@@ -351,7 +351,7 @@ kadm5_s_create_principal(void *server_handle,
         if (ret == 0 && ret2 != 0)
             ret = ret2;
     }
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
     return _kadm5_error_code(ret);
 }
 

--- a/lib/kadm5/create_s.c
+++ b/lib/kadm5/create_s.c
@@ -57,7 +57,7 @@ static kadm5_ret_t
 create_principal(kadm5_server_context *context,
 		 kadm5_principal_ent_t princ,
 		 uint32_t mask,
-		 hdb_entry_ex *ent,
+		 hdb_entry *ent,
 		 uint32_t required_mask,
 		 uint32_t forbidden_mask)
 {
@@ -74,7 +74,7 @@ create_principal(kadm5_server_context *context,
 	/* XXX no real policies for now */
 	return KADM5_UNK_POLICY;
     ret  = krb5_copy_principal(context->context, princ->principal,
-			       &ent->entry.principal);
+			       &ent->principal);
     if(ret)
 	return ret;
 
@@ -96,10 +96,10 @@ create_principal(kadm5_server_context *context,
     if (ret)
 	return ret;
 
-    ent->entry.created_by.time = time(NULL);
+    ent->created_by.time = time(NULL);
 
     return krb5_copy_principal(context->context, context->caller,
-			       &ent->entry.created_by.principal);
+			       &ent->created_by.principal);
 }
 
 struct create_principal_hook_ctx {
@@ -167,7 +167,7 @@ kadm5_s_create_principal_with_key(void *server_handle,
 				  uint32_t mask)
 {
     kadm5_ret_t ret;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_server_context *context = server_handle;
 
     if ((mask & KADM5_KVNO) == 0) {
@@ -203,7 +203,7 @@ kadm5_s_create_principal_with_key(void *server_handle,
     if (ret)
         goto out;
 
-    ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+    ret = hdb_seal_keys(context->context, context->db, &ent);
     if (ret)
 	goto out2;
 
@@ -213,7 +213,7 @@ kadm5_s_create_principal_with_key(void *server_handle,
      * Creation of would-be virtual principals w/o the materialize flag will be
      * rejected in kadm5_log_create().
      */
-    ret = kadm5_log_create(context, &ent.entry);
+    ret = kadm5_log_create(context, &ent);
 
     (void) create_principal_hook(context, KADM5_HOOK_STAGE_POSTCOMMIT,
 				 ret, princ, mask, NULL);
@@ -241,7 +241,7 @@ kadm5_s_create_principal(void *server_handle,
 			 const char *password)
 {
     kadm5_ret_t ret;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_server_context *context = server_handle;
     int use_pw = 1;
 
@@ -324,20 +324,20 @@ kadm5_s_create_principal(void *server_handle,
     if (ret)
         goto out;
 
-    free_Keys(&ent.entry.keys);
+    free_Keys(&ent.keys);
 
     if (use_pw) {
-        ret = _kadm5_set_keys(context, &ent.entry, n_ks_tuple, ks_tuple, password);
+        ret = _kadm5_set_keys(context, &ent, n_ks_tuple, ks_tuple, password);
         if (ret)
             goto out2;
     }
 
-    ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+    ret = hdb_seal_keys(context->context, context->db, &ent);
     if (ret)
 	goto out2;
 
     /* This logs the change for iprop and writes to the HDB */
-    ret = kadm5_log_create(context, &ent.entry);
+    ret = kadm5_log_create(context, &ent);
 
     (void) create_principal_hook(context, KADM5_HOOK_STAGE_POSTCOMMIT,
 				 ret, princ, mask, password);

--- a/lib/kadm5/delete_s.c
+++ b/lib/kadm5/delete_s.c
@@ -131,7 +131,7 @@ kadm5_s_delete_principal(void *server_handle, krb5_principal princ)
     (void) delete_principal_hook(context, KADM5_HOOK_STAGE_POSTCOMMIT, ret, princ);
 
  out3:
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
  out2:
     (void) kadm5_log_end(context);
  out:

--- a/lib/kadm5/delete_s.c
+++ b/lib/kadm5/delete_s.c
@@ -92,7 +92,7 @@ kadm5_s_delete_principal(void *server_handle, krb5_principal princ)
 {
     kadm5_server_context *context = server_handle;
     kadm5_ret_t ret;
-    hdb_entry_ex ent;
+    hdb_entry ent;
 
     memset(&ent, 0, sizeof(ent));
     if (!context->keep_open) {
@@ -112,7 +112,7 @@ kadm5_s_delete_principal(void *server_handle, krb5_principal princ)
                                       0, &ent);
     if (ret == HDB_ERR_NOENTRY)
 	goto out2;
-    if (ent.entry.flags.immutable) {
+    if (ent.flags.immutable) {
 	ret = KADM5_PROTECT_PRINCIPAL;
 	goto out3;
     }
@@ -121,7 +121,7 @@ kadm5_s_delete_principal(void *server_handle, krb5_principal princ)
     if (ret)
 	goto out3;
 
-    ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+    ret = hdb_seal_keys(context->context, context->db, &ent);
     if (ret)
 	goto out3;
 

--- a/lib/kadm5/get_princs_s.c
+++ b/lib/kadm5/get_princs_s.c
@@ -55,12 +55,12 @@ add_princ(krb5_context context, struct foreach_data *d, char *princ)
 }
 
 static krb5_error_code
-foreach(krb5_context context, HDB *db, hdb_entry_ex *ent, void *data)
+foreach(krb5_context context, HDB *db, hdb_entry *ent, void *data)
 {
     struct foreach_data *d = data;
     char *princ;
     krb5_error_code ret;
-    ret = krb5_unparse_name(context, ent->entry.principal, &princ);
+    ret = krb5_unparse_name(context, ent->principal, &princ);
     if(ret)
 	return ret;
     if(d->exp){

--- a/lib/kadm5/get_s.c
+++ b/lib/kadm5/get_s.c
@@ -404,7 +404,7 @@ kadm5_s_get_principal(void *server_handle,
  out:
     if (ret)
         kadm5_free_principal_ent(context, out);
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
 
     return _kadm5_error_code(ret);
 }

--- a/lib/kadm5/get_s.c
+++ b/lib/kadm5/get_s.c
@@ -122,7 +122,7 @@ kadm5_s_get_principal(void *server_handle,
 {
     kadm5_server_context *context = server_handle;
     kadm5_ret_t ret;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     unsigned int flags = HDB_F_GET_ANY | HDB_F_ADMIN_DATA;
 
     if ((mask & KADM5_KEY_DATA) || (mask & KADM5_KVNO))
@@ -157,57 +157,57 @@ kadm5_s_get_principal(void *server_handle,
 	return _kadm5_error_code(ret);
 
     if(mask & KADM5_PRINCIPAL)
-	ret  = krb5_copy_principal(context->context, ent.entry.principal,
+	ret  = krb5_copy_principal(context->context, ent.principal,
 				   &out->principal);
     if(ret)
 	goto out;
-    if(mask & KADM5_PRINC_EXPIRE_TIME && ent.entry.valid_end)
-	out->princ_expire_time = *ent.entry.valid_end;
-    if(mask & KADM5_PW_EXPIRATION && ent.entry.pw_end)
-	out->pw_expiration = *ent.entry.pw_end;
+    if(mask & KADM5_PRINC_EXPIRE_TIME && ent.valid_end)
+	out->princ_expire_time = *ent.valid_end;
+    if(mask & KADM5_PW_EXPIRATION && ent.pw_end)
+	out->pw_expiration = *ent.pw_end;
     if(mask & KADM5_LAST_PWD_CHANGE)
-	hdb_entry_get_pw_change_time(&ent.entry, &out->last_pwd_change);
+	hdb_entry_get_pw_change_time(&ent, &out->last_pwd_change);
     if(mask & KADM5_ATTRIBUTES){
-	out->attributes |= ent.entry.flags.postdate ? 0 : KRB5_KDB_DISALLOW_POSTDATED;
-	out->attributes |= ent.entry.flags.forwardable ? 0 : KRB5_KDB_DISALLOW_FORWARDABLE;
-	out->attributes |= ent.entry.flags.initial ? KRB5_KDB_DISALLOW_TGT_BASED : 0;
-	out->attributes |= ent.entry.flags.renewable ? 0 : KRB5_KDB_DISALLOW_RENEWABLE;
-	out->attributes |= ent.entry.flags.proxiable ? 0 : KRB5_KDB_DISALLOW_PROXIABLE;
-	out->attributes |= ent.entry.flags.invalid ? KRB5_KDB_DISALLOW_ALL_TIX : 0;
-	out->attributes |= ent.entry.flags.require_preauth ? KRB5_KDB_REQUIRES_PRE_AUTH : 0;
-	out->attributes |= ent.entry.flags.require_pwchange ? KRB5_KDB_REQUIRES_PWCHANGE : 0;
-	out->attributes |= ent.entry.flags.client ? 0 : KRB5_KDB_DISALLOW_CLIENT;
-	out->attributes |= ent.entry.flags.server ? 0 : KRB5_KDB_DISALLOW_SVR;
-	out->attributes |= ent.entry.flags.change_pw ? KRB5_KDB_PWCHANGE_SERVICE : 0;
-	out->attributes |= ent.entry.flags.ok_as_delegate ? KRB5_KDB_OK_AS_DELEGATE : 0;
-	out->attributes |= ent.entry.flags.trusted_for_delegation ? KRB5_KDB_TRUSTED_FOR_DELEGATION : 0;
-	out->attributes |= ent.entry.flags.allow_kerberos4 ? KRB5_KDB_ALLOW_KERBEROS4 : 0;
-	out->attributes |= ent.entry.flags.allow_digest ? KRB5_KDB_ALLOW_DIGEST : 0;
-	out->attributes |= ent.entry.flags.virtual_keys ? KRB5_KDB_VIRTUAL_KEYS : 0;
-	out->attributes |= ent.entry.flags.virtual ? KRB5_KDB_VIRTUAL : 0;
-	out->attributes |= ent.entry.flags.no_auth_data_reqd ? KRB5_KDB_NO_AUTH_DATA_REQUIRED : 0;
+	out->attributes |= ent.flags.postdate ? 0 : KRB5_KDB_DISALLOW_POSTDATED;
+	out->attributes |= ent.flags.forwardable ? 0 : KRB5_KDB_DISALLOW_FORWARDABLE;
+	out->attributes |= ent.flags.initial ? KRB5_KDB_DISALLOW_TGT_BASED : 0;
+	out->attributes |= ent.flags.renewable ? 0 : KRB5_KDB_DISALLOW_RENEWABLE;
+	out->attributes |= ent.flags.proxiable ? 0 : KRB5_KDB_DISALLOW_PROXIABLE;
+	out->attributes |= ent.flags.invalid ? KRB5_KDB_DISALLOW_ALL_TIX : 0;
+	out->attributes |= ent.flags.require_preauth ? KRB5_KDB_REQUIRES_PRE_AUTH : 0;
+	out->attributes |= ent.flags.require_pwchange ? KRB5_KDB_REQUIRES_PWCHANGE : 0;
+	out->attributes |= ent.flags.client ? 0 : KRB5_KDB_DISALLOW_CLIENT;
+	out->attributes |= ent.flags.server ? 0 : KRB5_KDB_DISALLOW_SVR;
+	out->attributes |= ent.flags.change_pw ? KRB5_KDB_PWCHANGE_SERVICE : 0;
+	out->attributes |= ent.flags.ok_as_delegate ? KRB5_KDB_OK_AS_DELEGATE : 0;
+	out->attributes |= ent.flags.trusted_for_delegation ? KRB5_KDB_TRUSTED_FOR_DELEGATION : 0;
+	out->attributes |= ent.flags.allow_kerberos4 ? KRB5_KDB_ALLOW_KERBEROS4 : 0;
+	out->attributes |= ent.flags.allow_digest ? KRB5_KDB_ALLOW_DIGEST : 0;
+	out->attributes |= ent.flags.virtual_keys ? KRB5_KDB_VIRTUAL_KEYS : 0;
+	out->attributes |= ent.flags.virtual ? KRB5_KDB_VIRTUAL : 0;
+	out->attributes |= ent.flags.no_auth_data_reqd ? KRB5_KDB_NO_AUTH_DATA_REQUIRED : 0;
     }
     if(mask & KADM5_MAX_LIFE) {
-	if(ent.entry.max_life)
-	    out->max_life = *ent.entry.max_life;
+	if(ent.max_life)
+	    out->max_life = *ent.max_life;
 	else
 	    out->max_life = INT_MAX;
     }
     if(mask & KADM5_MOD_TIME) {
-	if(ent.entry.modified_by)
-	    out->mod_date = ent.entry.modified_by->time;
+	if(ent.modified_by)
+	    out->mod_date = ent.modified_by->time;
 	else
-	    out->mod_date = ent.entry.created_by.time;
+	    out->mod_date = ent.created_by.time;
     }
     if(mask & KADM5_MOD_NAME) {
-	if(ent.entry.modified_by) {
-	    if (ent.entry.modified_by->principal != NULL)
+	if(ent.modified_by) {
+	    if (ent.modified_by->principal != NULL)
 		ret = krb5_copy_principal(context->context,
-					  ent.entry.modified_by->principal,
+					  ent.modified_by->principal,
 					  &out->mod_name);
-	} else if(ent.entry.created_by.principal != NULL)
+	} else if(ent.created_by.principal != NULL)
 	    ret = krb5_copy_principal(context->context,
-				      ent.entry.created_by.principal,
+				      ent.created_by.principal,
 				      &out->mod_name);
 	else
 	    out->mod_name = NULL;
@@ -216,13 +216,13 @@ kadm5_s_get_principal(void *server_handle,
 	goto out;
 
     if(mask & KADM5_KVNO)
-	out->kvno = ent.entry.kvno;
+	out->kvno = ent.kvno;
     if(mask & KADM5_MKVNO) {
 	size_t n;
 	out->mkvno = 0; /* XXX */
-	for(n = 0; n < ent.entry.keys.len; n++)
-	    if(ent.entry.keys.val[n].mkvno) {
-		out->mkvno = *ent.entry.keys.val[n].mkvno; /* XXX this isn't right */
+	for(n = 0; n < ent.keys.len; n++)
+	    if(ent.keys.val[n].mkvno) {
+		out->mkvno = *ent.keys.val[n].mkvno; /* XXX this isn't right */
 		break;
 	    }
     }
@@ -239,7 +239,7 @@ kadm5_s_get_principal(void *server_handle,
     if(mask & KADM5_POLICY) {
 	HDB_extension *ext;
 
-	ext = hdb_find_extension(&ent.entry, choice_HDB_extension_data_policy);
+	ext = hdb_find_extension(&ent, choice_HDB_extension_data_policy);
 	if (ext == NULL) {
 	    out->policy = strdup("default");
 	    /* It's OK if we retun NULL instead of "default" */
@@ -252,27 +252,27 @@ kadm5_s_get_principal(void *server_handle,
 	}
     }
     if(mask & KADM5_MAX_RLIFE) {
-	if(ent.entry.max_renew)
-	    out->max_renewable_life = *ent.entry.max_renew;
+	if(ent.max_renew)
+	    out->max_renewable_life = *ent.max_renew;
 	else
 	    out->max_renewable_life = INT_MAX;
     }
     if(mask & KADM5_KEY_DATA){
 	size_t i;
-	size_t n_keys = ent.entry.keys.len;
+	size_t n_keys = ent.keys.len;
 	krb5_salt salt;
 	HDB_extension *ext;
 	HDB_Ext_KeySet *hist_keys = NULL;
 
 	/* Don't return stale keys to kadm5 clients */
-	ret = hdb_prune_keys(context->context, &ent.entry);
+	ret = hdb_prune_keys(context->context, &ent);
 	if (ret)
 	    goto out;
-	ext = hdb_find_extension(&ent.entry, choice_HDB_extension_data_hist_keys);
+	ext = hdb_find_extension(&ent, choice_HDB_extension_data_hist_keys);
 	if (ext != NULL)
 	    hist_keys = &ext->data.u.hist_keys;
 
-	krb5_get_pw_salt(context->context, ent.entry.principal, &salt);
+	krb5_get_pw_salt(context->context, ent.principal, &salt);
 	for (i = 0; hist_keys != NULL && i < hist_keys->len; i++)
 	    n_keys += hist_keys->val[i].keys.len;
 	out->key_data = malloc(n_keys * sizeof(*out->key_data));
@@ -281,8 +281,8 @@ kadm5_s_get_principal(void *server_handle,
 	    goto out;
 	}
 	out->n_key_data = 0;
-	ret = copy_keyset_to_kadm5(context, ent.entry.kvno, ent.entry.keys.len,
-				   ent.entry.keys.val, &salt, out);
+	ret = copy_keyset_to_kadm5(context, ent.kvno, ent.keys.len,
+				   ent.keys.val, &salt, out);
 	if (ret)
 	    goto out;
 	for (i = 0; hist_keys != NULL && i < hist_keys->len; i++) {
@@ -305,12 +305,12 @@ kadm5_s_get_principal(void *server_handle,
         const HDB_Ext_KeyRotation *kr;
         heim_octet_string krb5_config;
 
-        if (ent.entry.etypes) {
+        if (ent.etypes) {
             krb5_data buf;
             size_t len;
 
             ASN1_MALLOC_ENCODE(HDB_EncTypeList, buf.data, buf.length,
-                               ent.entry.etypes, &len, ret);
+                               ent.etypes, &len, ret);
             if (ret == 0) {
                 ret = add_tl_data(out, KRB5_TL_ETYPES, buf.data, buf.length);
                 free(buf.data);
@@ -319,14 +319,14 @@ kadm5_s_get_principal(void *server_handle,
                 goto out;
         }
 
-	ret = hdb_entry_get_pw_change_time(&ent.entry, &last_pw_expire);
+	ret = hdb_entry_get_pw_change_time(&ent, &last_pw_expire);
 	if (ret == 0 && last_pw_expire) {
 	    unsigned char buf[4];
 	    _krb5_put_int(buf, last_pw_expire, sizeof(buf));
 	    ret = add_tl_data(out, KRB5_TL_LAST_PWD_CHANGE, buf, sizeof(buf));
 	}
 
-        ret = hdb_entry_get_krb5_config(&ent.entry, &krb5_config);
+        ret = hdb_entry_get_krb5_config(&ent, &krb5_config);
         if (ret == 0 && krb5_config.length) {
             ret = add_tl_data(out, KRB5_TL_KRB5_CONFIG, krb5_config.data,
                               krb5_config.length);
@@ -342,7 +342,7 @@ kadm5_s_get_principal(void *server_handle,
 
             /* XXX But not if the client doesn't have ext-keys */
 	    ret = hdb_entry_get_password(context->context,
-					 context->db, &ent.entry, &pw);
+					 context->db, &ent, &pw);
 	    if (ret == 0) {
 		ret = add_tl_data(out, KRB5_TL_PASSWORD, pw, strlen(pw) + 1);
 		free(pw);
@@ -352,7 +352,7 @@ kadm5_s_get_principal(void *server_handle,
 	    krb5_clear_error_message(context->context);
 	}
 
-        ret = hdb_entry_get_pkinit_acl(&ent.entry, &acl);
+        ret = hdb_entry_get_pkinit_acl(&ent, &acl);
 	if (ret == 0 && acl) {
 	    krb5_data buf;
 	    size_t len;
@@ -370,7 +370,7 @@ kadm5_s_get_principal(void *server_handle,
 		goto out;
 	}
 
-        ret = hdb_entry_get_aliases(&ent.entry, &aliases);
+        ret = hdb_entry_get_aliases(&ent, &aliases);
 	if (ret == 0 && aliases) {
 	    krb5_data buf;
 	    size_t len;
@@ -388,7 +388,7 @@ kadm5_s_get_principal(void *server_handle,
 		goto out;
 	}
 
-        ret = hdb_entry_get_key_rotation(context->context, &ent.entry, &kr);
+        ret = hdb_entry_get_key_rotation(context->context, &ent, &kr);
 	if (ret == 0 && kr) {
 	    krb5_data buf;
 	    size_t len;

--- a/lib/kadm5/ipropd_master.c
+++ b/lib/kadm5/ipropd_master.c
@@ -392,14 +392,14 @@ error:
 }
 
 static int
-dump_one (krb5_context context, HDB *db, hdb_entry_ex *entry, void *v)
+dump_one (krb5_context context, HDB *db, hdb_entry *entry, void *v)
 {
     krb5_error_code ret;
     krb5_storage *dump = (krb5_storage *)v;
     krb5_storage *sp;
     krb5_data data;
 
-    ret = hdb_entry2value (context, &entry->entry, &data);
+    ret = hdb_entry2value (context, entry, &data);
     if (ret)
 	return ret;
     ret = krb5_data_realloc (&data, data.length + 4);

--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -589,7 +589,7 @@ receive_everything(krb5_context context, int fd,
 	    if (ret)
 		krb5_err(context, IPROPD_RESTART_SLOW, ret, "hdb_store");
 
-	    hdb_free_entry(context, &entry);
+	    hdb_free_entry(context, mydb, &entry);
 	    krb5_data_free(&data);
 	} else if (opcode == NOW_YOU_HAVE)
 	    ;

--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -571,7 +571,7 @@ receive_everything(krb5_context context, int fd,
 	krb5_ret_uint32(sp, &opcode);
 	if (opcode == ONE_PRINC) {
 	    krb5_data fake_data;
-	    hdb_entry_ex entry;
+	    hdb_entry entry;
 
 	    krb5_storage_free(sp);
 
@@ -580,7 +580,7 @@ receive_everything(krb5_context context, int fd,
 
 	    memset(&entry, 0, sizeof(entry));
 
-	    ret = hdb_value2entry(context, &fake_data, &entry.entry);
+	    ret = hdb_value2entry(context, &fake_data, &entry);
 	    if (ret)
 		krb5_err(context, IPROPD_RESTART, ret, "hdb_value2entry");
 	    ret = mydb->hdb_store(server_context->context,

--- a/lib/kadm5/log.c
+++ b/lib/kadm5/log.c
@@ -974,12 +974,12 @@ kadm5_log_create(kadm5_server_context *context, hdb_entry *entry)
     krb5_ssize_t bytes;
     kadm5_ret_t ret;
     krb5_data value;
-    hdb_entry_ex ent, existing;
+    hdb_entry ent, existing;
     kadm5_log_context *log_context = &context->log_context;
 
     memset(&existing, 0, sizeof(existing));
     memset(&ent, 0, sizeof(ent));
-    ent.entry = *entry;
+    ent = *entry;
 
     /*
      * Do not allow creation of concrete entries within namespaces unless
@@ -989,14 +989,14 @@ kadm5_log_create(kadm5_server_context *context, hdb_entry *entry)
                          0, 0, 0, &existing);
     if (ret != 0 && ret != HDB_ERR_NOENTRY)
         return ret;
-    if (ret == 0 && !ent.entry.flags.materialize &&
-        (existing.entry.flags.virtual || existing.entry.flags.virtual_keys)) {
+    if (ret == 0 && !ent.flags.materialize &&
+        (existing.flags.virtual || existing.flags.virtual_keys)) {
         hdb_free_entry(context->context, context->db, &existing);
         return HDB_ERR_EXISTS;
     }
     if (ret == 0)
         hdb_free_entry(context->context, context->db, &existing);
-    ent.entry.flags.materialize = 0; /* Clear in stored entry */
+    ent.flags.materialize = 0; /* Clear in stored entry */
 
     /*
      * If we're not logging then we can't recover-to-perform, so just
@@ -1055,7 +1055,7 @@ kadm5_log_replay_create(kadm5_server_context *context,
 {
     krb5_error_code ret;
     krb5_data data;
-    hdb_entry_ex ent;
+    hdb_entry ent;
 
     memset(&ent, 0, sizeof(ent));
 
@@ -1065,7 +1065,7 @@ kadm5_log_replay_create(kadm5_server_context *context,
 	return ret;
     }
     krb5_storage_read(sp, data.data, len);
-    ret = hdb_value2entry(context->context, &data, &ent.entry);
+    ret = hdb_value2entry(context->context, &data, &ent);
     krb5_data_free(&data);
     if (ret) {
 	krb5_set_error_message(context->context, ret,
@@ -1196,11 +1196,11 @@ kadm5_log_rename(kadm5_server_context *context,
     off_t end_off = 0;  /* Ditto; this allows de-indentation by two levels */
     off_t off;
     krb5_data value;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_log_context *log_context = &context->log_context;
 
     memset(&ent, 0, sizeof(ent));
-    ent.entry = *entry;
+    ent = *entry;
 
     if (strcmp(log_context->log_file, "/dev/null") == 0) {
         ret = context->db->hdb_store(context->context, context->db, 0, &ent);
@@ -1306,7 +1306,7 @@ kadm5_log_replay_rename(kadm5_server_context *context,
 {
     krb5_error_code ret;
     krb5_principal source;
-    hdb_entry_ex target_ent;
+    hdb_entry target_ent;
     krb5_data value;
     off_t off;
     size_t princ_len, data_len;
@@ -1328,7 +1328,7 @@ kadm5_log_replay_rename(kadm5_server_context *context,
 	return ret;
     }
     krb5_storage_read(sp, value.data, data_len);
-    ret = hdb_value2entry(context->context, &value, &target_ent.entry);
+    ret = hdb_value2entry(context->context, &value, &target_ent);
     krb5_data_free(&value);
     if (ret) {
 	krb5_free_principal(context->context, source);
@@ -1360,11 +1360,11 @@ kadm5_log_modify(kadm5_server_context *context,
     kadm5_ret_t ret;
     krb5_data value;
     uint32_t len;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_log_context *log_context = &context->log_context;
 
     memset(&ent, 0, sizeof(ent));
-    ent.entry = *entry;
+    ent = *entry;
 
     if (strcmp(log_context->log_file, "/dev/null") == 0)
         return context->db->hdb_store(context->context, context->db,
@@ -1428,7 +1428,7 @@ kadm5_log_replay_modify(kadm5_server_context *context,
     krb5_error_code ret;
     uint32_t mask;
     krb5_data value;
-    hdb_entry_ex ent, log_ent;
+    hdb_entry ent, log_ent;
 
     memset(&log_ent, 0, sizeof(log_ent));
 
@@ -1446,7 +1446,7 @@ kadm5_log_replay_modify(kadm5_server_context *context,
         ret = errno ? errno : EIO;
         return ret;
     }
-    ret = hdb_value2entry (context->context, &value, &log_ent.entry);
+    ret = hdb_value2entry (context->context, &value, &log_ent);
     krb5_data_free(&value);
     if (ret)
 	return ret;
@@ -1454,37 +1454,37 @@ kadm5_log_replay_modify(kadm5_server_context *context,
     memset(&ent, 0, sizeof(ent));
     /* NOTE: We do not use hdb_fetch_kvno() here */
     ret = context->db->hdb_fetch_kvno(context->context, context->db,
-				      log_ent.entry.principal,
+				      log_ent.principal,
 				      HDB_F_DECRYPT|HDB_F_ALL_KVNOS|
 				      HDB_F_GET_ANY|HDB_F_ADMIN_DATA, 0, &ent);
     if (ret)
 	goto out;
     if (mask & KADM5_PRINC_EXPIRE_TIME) {
-	if (log_ent.entry.valid_end == NULL) {
-	    ent.entry.valid_end = NULL;
+	if (log_ent.valid_end == NULL) {
+	    ent.valid_end = NULL;
 	} else {
-	    if (ent.entry.valid_end == NULL) {
-		ent.entry.valid_end = malloc(sizeof(*ent.entry.valid_end));
-		if (ent.entry.valid_end == NULL) {
+	    if (ent.valid_end == NULL) {
+		ent.valid_end = malloc(sizeof(*ent.valid_end));
+		if (ent.valid_end == NULL) {
 		    ret = krb5_enomem(context->context);
 		    goto out;
 		}
 	    }
-	    *ent.entry.valid_end = *log_ent.entry.valid_end;
+	    *ent.valid_end = *log_ent.valid_end;
 	}
     }
     if (mask & KADM5_PW_EXPIRATION) {
-	if (log_ent.entry.pw_end == NULL) {
-	    ent.entry.pw_end = NULL;
+	if (log_ent.pw_end == NULL) {
+	    ent.pw_end = NULL;
 	} else {
-	    if (ent.entry.pw_end == NULL) {
-		ent.entry.pw_end = malloc(sizeof(*ent.entry.pw_end));
-		if (ent.entry.pw_end == NULL) {
+	    if (ent.pw_end == NULL) {
+		ent.pw_end = malloc(sizeof(*ent.pw_end));
+		if (ent.pw_end == NULL) {
 		    ret = krb5_enomem(context->context);
 		    goto out;
 		}
 	    }
-	    *ent.entry.pw_end = *log_ent.entry.pw_end;
+	    *ent.pw_end = *log_ent.pw_end;
 	}
     }
     if (mask & KADM5_LAST_PWD_CHANGE) {
@@ -1492,39 +1492,39 @@ kadm5_log_replay_modify(kadm5_server_context *context,
                     "Unimplemented mask KADM5_LAST_PWD_CHANGE");
     }
     if (mask & KADM5_ATTRIBUTES) {
-	ent.entry.flags = log_ent.entry.flags;
+	ent.flags = log_ent.flags;
     }
     if (mask & KADM5_MAX_LIFE) {
-	if (log_ent.entry.max_life == NULL) {
-	    ent.entry.max_life = NULL;
+	if (log_ent.max_life == NULL) {
+	    ent.max_life = NULL;
 	} else {
-	    if (ent.entry.max_life == NULL) {
-		ent.entry.max_life = malloc (sizeof(*ent.entry.max_life));
-		if (ent.entry.max_life == NULL) {
+	    if (ent.max_life == NULL) {
+		ent.max_life = malloc (sizeof(*ent.max_life));
+		if (ent.max_life == NULL) {
 		    ret = krb5_enomem(context->context);
 		    goto out;
 		}
 	    }
-	    *ent.entry.max_life = *log_ent.entry.max_life;
+	    *ent.max_life = *log_ent.max_life;
 	}
     }
     if ((mask & KADM5_MOD_TIME) && (mask & KADM5_MOD_NAME)) {
-	if (ent.entry.modified_by == NULL) {
-	    ent.entry.modified_by = malloc(sizeof(*ent.entry.modified_by));
-	    if (ent.entry.modified_by == NULL) {
+	if (ent.modified_by == NULL) {
+	    ent.modified_by = malloc(sizeof(*ent.modified_by));
+	    if (ent.modified_by == NULL) {
 		ret = krb5_enomem(context->context);
 		goto out;
 	    }
 	} else
-	    free_Event(ent.entry.modified_by);
-	ret = copy_Event(log_ent.entry.modified_by, ent.entry.modified_by);
+	    free_Event(ent.modified_by);
+	ret = copy_Event(log_ent.modified_by, ent.modified_by);
 	if (ret) {
 	    ret = krb5_enomem(context->context);
 	    goto out;
 	}
     }
     if (mask & KADM5_KVNO) {
-	ent.entry.kvno = log_ent.entry.kvno;
+	ent.kvno = log_ent.kvno;
     }
     if (mask & KADM5_MKVNO) {
         krb5_warnx(context->context, "Unimplemented mask KADM5_KVNO");
@@ -1537,17 +1537,17 @@ kadm5_log_replay_modify(kadm5_server_context *context,
         krb5_warnx(context->context, "Unimplemented mask KADM5_POLICY_CLR");
     }
     if (mask & KADM5_MAX_RLIFE) {
-	if (log_ent.entry.max_renew == NULL) {
-	    ent.entry.max_renew = NULL;
+	if (log_ent.max_renew == NULL) {
+	    ent.max_renew = NULL;
 	} else {
-	    if (ent.entry.max_renew == NULL) {
-		ent.entry.max_renew = malloc (sizeof(*ent.entry.max_renew));
-		if (ent.entry.max_renew == NULL) {
+	    if (ent.max_renew == NULL) {
+		ent.max_renew = malloc (sizeof(*ent.max_renew));
+		if (ent.max_renew == NULL) {
 		    ret = krb5_enomem(context->context);
 		    goto out;
 		}
 	    }
-	    *ent.entry.max_renew = *log_ent.entry.max_renew;
+	    *ent.max_renew = *log_ent.max_renew;
 	}
     }
     if (mask & KADM5_LAST_SUCCESS) {
@@ -1573,62 +1573,62 @@ kadm5_log_replay_modify(kadm5_server_context *context,
 	 */
 	mask |= KADM5_TL_DATA;
 
-	for (i = 0; i < ent.entry.keys.len; ++i)
-	    free_Key(&ent.entry.keys.val[i]);
-	free (ent.entry.keys.val);
+	for (i = 0; i < ent.keys.len; ++i)
+	    free_Key(&ent.keys.val[i]);
+	free (ent.keys.val);
 
-	num = log_ent.entry.keys.len;
+	num = log_ent.keys.len;
 
-	ent.entry.keys.len = num;
-	ent.entry.keys.val = malloc(len * sizeof(*ent.entry.keys.val));
-	if (ent.entry.keys.val == NULL) {
+	ent.keys.len = num;
+	ent.keys.val = malloc(len * sizeof(*ent.keys.val));
+	if (ent.keys.val == NULL) {
 	    krb5_enomem(context->context);
 	    goto out;
 	}
-	for (i = 0; i < ent.entry.keys.len; ++i) {
-	    ret = copy_Key(&log_ent.entry.keys.val[i],
-			   &ent.entry.keys.val[i]);
+	for (i = 0; i < ent.keys.len; ++i) {
+	    ret = copy_Key(&log_ent.keys.val[i],
+			   &ent.keys.val[i]);
 	    if (ret) {
 		krb5_set_error_message(context->context, ret, "out of memory");
 		goto out;
 	    }
 	}
     }
-    if ((mask & KADM5_TL_DATA) && log_ent.entry.etypes) {
-        if (ent.entry.etypes)
-            free_HDB_EncTypeList(ent.entry.etypes);
-        free(ent.entry.etypes);
-        ent.entry.etypes = calloc(1, sizeof(*ent.entry.etypes));
-        if (ent.entry.etypes == NULL)
+    if ((mask & KADM5_TL_DATA) && log_ent.etypes) {
+        if (ent.etypes)
+            free_HDB_EncTypeList(ent.etypes);
+        free(ent.etypes);
+        ent.etypes = calloc(1, sizeof(*ent.etypes));
+        if (ent.etypes == NULL)
             ret = ENOMEM;
         if (ret == 0)
-            ret = copy_HDB_EncTypeList(log_ent.entry.etypes, ent.entry.etypes);
+            ret = copy_HDB_EncTypeList(log_ent.etypes, ent.etypes);
         if (ret) {
             ret = krb5_enomem(context->context);
-            free(ent.entry.etypes);
-            ent.entry.etypes = NULL;
+            free(ent.etypes);
+            ent.etypes = NULL;
             goto out;
         }
     }
 
-    if ((mask & KADM5_TL_DATA) && log_ent.entry.extensions) {
-	if (ent.entry.extensions) {
-	    free_HDB_extensions(ent.entry.extensions);
-	    free(ent.entry.extensions);
-            ent.entry.extensions = NULL;
+    if ((mask & KADM5_TL_DATA) && log_ent.extensions) {
+	if (ent.extensions) {
+	    free_HDB_extensions(ent.extensions);
+	    free(ent.extensions);
+            ent.extensions = NULL;
 	}
 
-	ent.entry.extensions = calloc(1, sizeof(*ent.entry.extensions));
-	if (ent.entry.extensions == NULL)
+	ent.extensions = calloc(1, sizeof(*ent.extensions));
+	if (ent.extensions == NULL)
 	    ret = ENOMEM;
 
         if (ret == 0)
-            ret = copy_HDB_extensions(log_ent.entry.extensions,
-                                      ent.entry.extensions);
+            ret = copy_HDB_extensions(log_ent.extensions,
+                                      ent.extensions);
 	if (ret) {
 	    ret = krb5_enomem(context->context);
-	    free(ent.entry.extensions);
-	    ent.entry.extensions = NULL;
+	    free(ent.extensions);
+	    ent.extensions = NULL;
 	    goto out;
 	}
     }

--- a/lib/kadm5/log.c
+++ b/lib/kadm5/log.c
@@ -979,8 +979,6 @@ kadm5_log_create(kadm5_server_context *context, hdb_entry *entry)
 
     memset(&existing, 0, sizeof(existing));
     memset(&ent, 0, sizeof(ent));
-    ent.ctx = 0;
-    ent.free_entry = 0;
     ent.entry = *entry;
 
     /*
@@ -993,11 +991,11 @@ kadm5_log_create(kadm5_server_context *context, hdb_entry *entry)
         return ret;
     if (ret == 0 && !ent.entry.flags.materialize &&
         (existing.entry.flags.virtual || existing.entry.flags.virtual_keys)) {
-        hdb_free_entry(context->context, &existing);
+        hdb_free_entry(context->context, context->db, &existing);
         return HDB_ERR_EXISTS;
     }
     if (ret == 0)
-        hdb_free_entry(context->context, &existing);
+        hdb_free_entry(context->context, context->db, &existing);
     ent.entry.flags.materialize = 0; /* Clear in stored entry */
 
     /*
@@ -1076,7 +1074,7 @@ kadm5_log_replay_create(kadm5_server_context *context,
 	return ret;
     }
     ret = context->db->hdb_store(context->context, context->db, 0, &ent);
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
     return ret;
 }
 
@@ -1202,8 +1200,6 @@ kadm5_log_rename(kadm5_server_context *context,
     kadm5_log_context *log_context = &context->log_context;
 
     memset(&ent, 0, sizeof(ent));
-    ent.ctx = 0;
-    ent.free_entry = 0;
     ent.entry = *entry;
 
     if (strcmp(log_context->log_file, "/dev/null") == 0) {
@@ -1340,7 +1336,7 @@ kadm5_log_replay_rename(kadm5_server_context *context,
     }
     ret = context->db->hdb_store(context->context, context->db,
 				 0, &target_ent);
-    hdb_free_entry(context->context, &target_ent);
+    hdb_free_entry(context->context, context->db, &target_ent);
     if (ret) {
 	krb5_free_principal(context->context, source);
 	return ret;
@@ -1368,8 +1364,6 @@ kadm5_log_modify(kadm5_server_context *context,
     kadm5_log_context *log_context = &context->log_context;
 
     memset(&ent, 0, sizeof(ent));
-    ent.ctx = 0;
-    ent.free_entry = 0;
     ent.entry = *entry;
 
     if (strcmp(log_context->log_file, "/dev/null") == 0)
@@ -1641,8 +1635,8 @@ kadm5_log_replay_modify(kadm5_server_context *context,
     ret = context->db->hdb_store(context->context, context->db,
 				 HDB_F_REPLACE, &ent);
  out:
-    hdb_free_entry(context->context, &ent);
-    hdb_free_entry(context->context, &log_ent);
+    hdb_free_entry(context->context, context->db, &ent);
+    hdb_free_entry(context->context, context->db, &log_ent);
     return ret;
 }
 

--- a/lib/kadm5/modify_s.c
+++ b/lib/kadm5/modify_s.c
@@ -97,7 +97,7 @@ modify_principal(void *server_handle,
 		 uint32_t forbidden_mask)
 {
     kadm5_server_context *context = server_handle;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_ret_t ret;
 
     memset(&ent, 0, sizeof(ent));
@@ -139,7 +139,7 @@ modify_principal(void *server_handle,
     ret = _kadm5_setup_entry(context, &ent, mask, princ, mask, NULL, 0);
     if (ret)
 	goto out3;
-    ret = _kadm5_set_modifier(context, &ent.entry);
+    ret = _kadm5_set_modifier(context, &ent);
     if (ret)
 	goto out3;
 
@@ -157,7 +157,7 @@ modify_principal(void *server_handle,
 	goto out3;
     }
 
-    ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+    ret = hdb_seal_keys(context->context, context->db, &ent);
     if (ret)
 	goto out3;
 
@@ -174,14 +174,14 @@ modify_principal(void *server_handle,
 	    goto out3;
 	}
 	/* This calls free_HDB_extension(), freeing ext.data.u.policy */
-	ret = hdb_replace_extension(context->context, &ent.entry, &ext);
+	ret = hdb_replace_extension(context->context, &ent, &ext);
         free(ext.data.u.policy);
 	if (ret)
 	    goto out3;
     }
 
     /* This logs the change for iprop and writes to the HDB */
-    ret = kadm5_log_modify(context, &ent.entry,
+    ret = kadm5_log_modify(context, &ent,
                            mask | KADM5_MOD_NAME | KADM5_MOD_TIME);
 
     (void) modify_principal_hook(context, KADM5_HOOK_STAGE_POSTCOMMIT,

--- a/lib/kadm5/modify_s.c
+++ b/lib/kadm5/modify_s.c
@@ -188,7 +188,7 @@ modify_principal(void *server_handle,
 				 ret, princ, mask);
 
  out3:
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
  out2:
     (void) kadm5_log_end(context);
  out:

--- a/lib/kadm5/prune_s.c
+++ b/lib/kadm5/prune_s.c
@@ -135,7 +135,7 @@ kadm5_s_prune_principal(void *server_handle,
 				ret, princ, kvno);
 
 out3:
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
 out2:
     (void) kadm5_log_end(context);
 out:

--- a/lib/kadm5/prune_s.c
+++ b/lib/kadm5/prune_s.c
@@ -95,7 +95,7 @@ kadm5_s_prune_principal(void *server_handle,
                         int kvno)
 {
     kadm5_server_context *context = server_handle;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_ret_t ret;
 
     memset(&ent, 0, sizeof(ent));
@@ -121,15 +121,15 @@ kadm5_s_prune_principal(void *server_handle,
     if (ret)
         goto out3;
 
-    ret = hdb_prune_keys_kvno(context->context, &ent.entry, kvno);
+    ret = hdb_prune_keys_kvno(context->context, &ent, kvno);
     if (ret)
         goto out3;
 
-    ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+    ret = hdb_seal_keys(context->context, context->db, &ent);
     if (ret)
         goto out3;
 
-    ret = kadm5_log_modify(context, &ent.entry, KADM5_KEY_DATA);
+    ret = kadm5_log_modify(context, &ent, KADM5_KEY_DATA);
 
     (void) prune_principal_hook(context, KADM5_HOOK_STAGE_POSTCOMMIT,
 				ret, princ, kvno);

--- a/lib/kadm5/randkey_s.c
+++ b/lib/kadm5/randkey_s.c
@@ -102,7 +102,7 @@ kadm5_s_randkey_principal(void *server_handle,
 			  int *n_keys)
 {
     kadm5_server_context *context = server_handle;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_ret_t ret;
     size_t i;
 
@@ -129,36 +129,36 @@ kadm5_s_randkey_principal(void *server_handle,
 	goto out3;
 
     if (keepold) {
-	ret = hdb_add_current_keys_to_history(context->context, &ent.entry);
+	ret = hdb_add_current_keys_to_history(context->context, &ent);
         if (ret == 0 && keepold == 1)
-            ret = hdb_prune_keys_kvno(context->context, &ent.entry, 0);
+            ret = hdb_prune_keys_kvno(context->context, &ent, 0);
 	if (ret)
 	    goto out3;
     } else {
         /* Remove all key history */
-        ret = hdb_clear_extension(context->context, &ent.entry,
+        ret = hdb_clear_extension(context->context, &ent,
                                   choice_HDB_extension_data_hist_keys);
 	if (ret)
 	    goto out3;
     }
 
-    ret = _kadm5_set_keys_randomly(context, &ent.entry, n_ks_tuple, ks_tuple,
+    ret = _kadm5_set_keys_randomly(context, &ent, n_ks_tuple, ks_tuple,
                                    new_keys, n_keys);
     if (ret)
 	goto out3;
-    ent.entry.kvno++;
+    ent.kvno++;
 
-    ent.entry.flags.require_pwchange = 0;
+    ent.flags.require_pwchange = 0;
 
-    ret = _kadm5_set_modifier(context, &ent.entry);
+    ret = _kadm5_set_modifier(context, &ent);
     if(ret)
 	goto out4;
-    ret = _kadm5_bump_pw_expire(context, &ent.entry);
+    ret = _kadm5_bump_pw_expire(context, &ent);
     if (ret)
 	goto out4;
 
     if (keepold) {
-	ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+	ret = hdb_seal_keys(context->context, context->db, &ent);
 	if (ret)
 	    goto out4;
     } else {
@@ -169,11 +169,11 @@ kadm5_s_randkey_principal(void *server_handle,
 	ext.data.element = choice_HDB_extension_data_hist_keys;
 	ext.data.u.hist_keys.len = 0;
 	ext.data.u.hist_keys.val = NULL;
-	hdb_replace_extension(context->context, &ent.entry, &ext);
+	hdb_replace_extension(context->context, &ent, &ext);
     }
 
     /* This logs the change for iprop and writes to the HDB */
-    ret = kadm5_log_modify(context, &ent.entry,
+    ret = kadm5_log_modify(context, &ent,
                            KADM5_ATTRIBUTES | KADM5_PRINCIPAL |
                            KADM5_MOD_NAME | KADM5_MOD_TIME |
                            KADM5_KEY_DATA | KADM5_KVNO |

--- a/lib/kadm5/randkey_s.c
+++ b/lib/kadm5/randkey_s.c
@@ -190,7 +190,7 @@ kadm5_s_randkey_principal(void *server_handle,
 	*n_keys = 0;
     }
  out3:
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
  out2:
     (void) kadm5_log_end(context);
  out:

--- a/lib/kadm5/rename_s.c
+++ b/lib/kadm5/rename_s.c
@@ -97,7 +97,7 @@ kadm5_s_rename_principal(void *server_handle,
 {
     kadm5_server_context *context = server_handle;
     kadm5_ret_t ret;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     krb5_principal oldname;
     size_t i;
 
@@ -121,14 +121,14 @@ kadm5_s_rename_principal(void *server_handle,
                                       0, &ent);
     if (ret)
 	goto out2;
-    oldname = ent.entry.principal;
+    oldname = ent.principal;
 
     ret = rename_principal_hook(context, KADM5_HOOK_STAGE_PRECOMMIT,
 				0, source, target);
     if (ret)
 	goto out3;
 
-    ret = _kadm5_set_modifier(context, &ent.entry);
+    ret = _kadm5_set_modifier(context, &ent);
     if (ret)
 	goto out3;
     {
@@ -139,14 +139,14 @@ kadm5_s_rename_principal(void *server_handle,
 	krb5_get_pw_salt(context->context, source, &salt2);
 	salt.type = hdb_pw_salt;
 	salt.salt = salt2.saltvalue;
-	for(i = 0; i < ent.entry.keys.len; i++){
-	    if(ent.entry.keys.val[i].salt == NULL){
-		ent.entry.keys.val[i].salt =
-		    malloc(sizeof(*ent.entry.keys.val[i].salt));
-		if (ent.entry.keys.val[i].salt == NULL)
+	for(i = 0; i < ent.keys.len; i++){
+	    if(ent.keys.val[i].salt == NULL){
+		ent.keys.val[i].salt =
+		    malloc(sizeof(*ent.keys.val[i].salt));
+		if (ent.keys.val[i].salt == NULL)
 		    ret = krb5_enomem(context->context);
                 else
-                    ret = copy_Salt(&salt, ent.entry.keys.val[i].salt);
+                    ret = copy_Salt(&salt, ent.keys.val[i].salt);
 		if (ret)
 		    break;
 	    }
@@ -157,19 +157,19 @@ kadm5_s_rename_principal(void *server_handle,
 	goto out3;
 
     /* Borrow target */
-    ent.entry.principal = target;
-    ret = hdb_seal_keys(context->context, context->db, &ent.entry);
+    ent.principal = target;
+    ret = hdb_seal_keys(context->context, context->db, &ent);
     if (ret)
 	goto out3;
 
     /* This logs the change for iprop and writes to the HDB */
-    ret = kadm5_log_rename(context, source, &ent.entry);
+    ret = kadm5_log_rename(context, source, &ent);
 
     (void) rename_principal_hook(context, KADM5_HOOK_STAGE_POSTCOMMIT,
 				 ret, source, target);
 
  out3:
-    ent.entry.principal = oldname; /* Unborrow target */
+    ent.principal = oldname; /* Unborrow target */
     hdb_free_entry(context->context, context->db, &ent);
 
  out2:

--- a/lib/kadm5/rename_s.c
+++ b/lib/kadm5/rename_s.c
@@ -170,7 +170,7 @@ kadm5_s_rename_principal(void *server_handle,
 
  out3:
     ent.entry.principal = oldname; /* Unborrow target */
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
 
  out2:
     (void) kadm5_log_end(context);

--- a/lib/kadm5/setkey3_s.c
+++ b/lib/kadm5/setkey3_s.c
@@ -115,7 +115,7 @@ kadm5_s_setkey_principal_3(void *server_handle,
 			   krb5_keyblock *keyblocks, int n_keys)
 {
     kadm5_server_context *context = server_handle;
-    hdb_entry_ex ent;
+    hdb_entry ent;
     kadm5_ret_t ret = 0;
     size_t i;
 
@@ -154,9 +154,9 @@ kadm5_s_setkey_principal_3(void *server_handle,
     }
 
     if (keepold) {
-        ret = hdb_add_current_keys_to_history(context->context, &ent.entry);
+        ret = hdb_add_current_keys_to_history(context->context, &ent);
     } else
-	ret = hdb_clear_extension(context->context, &ent.entry,
+	ret = hdb_clear_extension(context->context, &ent,
 				  choice_HDB_extension_data_hist_keys);
 
     /*
@@ -167,7 +167,7 @@ kadm5_s_setkey_principal_3(void *server_handle,
      * each ks_tuple's enctype matches the corresponding key enctype.
      */
     if (ret == 0) {
-	free_Keys(&ent.entry.keys);
+	free_Keys(&ent.keys);
 	for (i = 0; i < n_keys; ++i) {
 	    Key k;
 	    Salt s;
@@ -186,22 +186,22 @@ kadm5_s_setkey_principal_3(void *server_handle,
 		s.opaque = 0;
 		k.salt = &s;
 	    }
-	    if ((ret = add_Keys(&ent.entry.keys, &k)) != 0)
+	    if ((ret = add_Keys(&ent.keys, &k)) != 0)
 		break;
 	}
     }
 
     if (ret == 0) {
-	ent.entry.kvno++;
-	ent.entry.flags.require_pwchange = 0;
-	hdb_entry_set_pw_change_time(context->context, &ent.entry, 0);
-	hdb_entry_clear_password(context->context, &ent.entry);
+	ent.kvno++;
+	ent.flags.require_pwchange = 0;
+	hdb_entry_set_pw_change_time(context->context, &ent, 0);
+	hdb_entry_clear_password(context->context, &ent);
 
 	if ((ret = hdb_seal_keys(context->context, context->db,
-				 &ent.entry)) == 0
-	    && (ret = _kadm5_set_modifier(context, &ent.entry)) == 0
-	    && (ret = _kadm5_bump_pw_expire(context, &ent.entry)) == 0)
-	    ret = kadm5_log_modify(context, &ent.entry,
+				 &ent)) == 0
+	    && (ret = _kadm5_set_modifier(context, &ent)) == 0
+	    && (ret = _kadm5_bump_pw_expire(context, &ent)) == 0)
+	    ret = kadm5_log_modify(context, &ent,
                                    KADM5_ATTRIBUTES | KADM5_PRINCIPAL |
                                    KADM5_MOD_NAME | KADM5_MOD_TIME |
                                    KADM5_KEY_DATA | KADM5_KVNO |

--- a/lib/kadm5/setkey3_s.c
+++ b/lib/kadm5/setkey3_s.c
@@ -212,7 +212,7 @@ kadm5_s_setkey_principal_3(void *server_handle,
 				 princ, keepold, n_ks_tuple, ks_tuple,
 				 n_keys, keyblocks);
 
-    hdb_free_entry(context->context, &ent);
+    hdb_free_entry(context->context, context->db, &ent);
     (void) kadm5_log_end(context);
     if (!context->keep_open)
 	context->db->hdb_close(context->context, context->db);

--- a/lib/krb5/Makefile.am
+++ b/lib/krb5/Makefile.am
@@ -4,7 +4,7 @@ include $(top_srcdir)/Makefile.am.common
 
 WFLAGS += $(WFLAGS_ENUM_CONV)
 
-AM_CPPFLAGS += -I../com_err -I$(srcdir)/../com_err $(INCLUDE_sqlite3) $(INCLUDE_libintl) $(INCLUDE_openssl_crypto)
+AM_CPPFLAGS += -I../com_err -I$(srcdir)/../com_err -I../base -I$(srcdir)/../base $(INCLUDE_sqlite3) $(INCLUDE_libintl) $(INCLUDE_openssl_crypto)
 
 bin_PROGRAMS = verify_krb5_conf
 

--- a/lib/krb5/NTMakefile
+++ b/lib/krb5/NTMakefile
@@ -31,6 +31,8 @@
 
 RELDIR=lib\krb5
 
+intcflags=-I$(SRCDIR) -I$(SRCDIR)\..\com_err -I$(SRCDIR)\..\base
+
 !include ../../windows/NTMakefile.w32
 
 libkrb5_OBJS =			\

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -35,7 +35,8 @@
  */
 
 #include "krb5_locl.h"
-#include "../base/heimbasepriv.h" /* XXX */
+
+#include <heimbasepriv.h>
 
 struct pa_info_data {
     krb5_enctype etype;

--- a/lib/krb5/principal.c
+++ b/lib/krb5/principal.c
@@ -102,13 +102,10 @@ KRB5_LIB_FUNCTION void KRB5_LIB_CALL
 krb5_free_principal(krb5_context context,
 		    krb5_principal p)
 {
-    if (p == NULL)
-	return;
-
-    if (p->nameattrs)
-	krb5_pac_free(context, p->nameattrs->pac);
-    free_Principal(p);
-    free(p);
+    if(p){
+	free_Principal(p);
+	free(p);
+    }
 }
 
 /**
@@ -929,24 +926,11 @@ krb5_copy_principal(krb5_context context,
 		    krb5_principal *outprinc)
 {
     krb5_principal p = malloc(sizeof(*p));
-    krb5_error_code ret;
-
     if (p == NULL)
 	return krb5_enomem(context);
     if(copy_Principal(inprinc, p)) {
 	free(p);
 	return krb5_enomem(context);
-    }
-    if (inprinc->nameattrs && inprinc->nameattrs->pac) {
-	krb5_pac pac;
-
-	ret = _krb5_pac_copy(context, inprinc->nameattrs->pac, &pac);
-	if (ret) {
-	    krb5_free_principal(context, p);
-	    return ret;
-	}
-	heim_assert(p->nameattrs, "nameattrs uninitialized");
-	p->nameattrs->pac = pac;
     }
     *outprinc = p;
     return 0;

--- a/lib/krb5/principal.c
+++ b/lib/krb5/principal.c
@@ -102,10 +102,13 @@ KRB5_LIB_FUNCTION void KRB5_LIB_CALL
 krb5_free_principal(krb5_context context,
 		    krb5_principal p)
 {
-    if(p){
-	free_Principal(p);
-	free(p);
-    }
+    if (p == NULL)
+	return;
+
+    if (p->nameattrs)
+	krb5_pac_free(context, p->nameattrs->pac);
+    free_Principal(p);
+    free(p);
 }
 
 /**
@@ -926,11 +929,24 @@ krb5_copy_principal(krb5_context context,
 		    krb5_principal *outprinc)
 {
     krb5_principal p = malloc(sizeof(*p));
+    krb5_error_code ret;
+
     if (p == NULL)
 	return krb5_enomem(context);
     if(copy_Principal(inprinc, p)) {
 	free(p);
 	return krb5_enomem(context);
+    }
+    if (inprinc->nameattrs && inprinc->nameattrs->pac) {
+	krb5_pac pac;
+
+	ret = _krb5_pac_copy(context, inprinc->nameattrs->pac, &pac);
+	if (ret) {
+	    krb5_free_principal(context, p);
+	    return ret;
+	}
+	heim_assert(p->nameattrs, "nameattrs uninitialized");
+	p->nameattrs->pac = pac;
     }
     *outprinc = p;
     return 0;

--- a/lib/krb5/rd_req.c
+++ b/lib/krb5/rd_req.c
@@ -1080,9 +1080,11 @@ krb5_rd_req_ctx(krb5_context context,
 		} else if (ret2 != ENOENT)
 		    ret = ret2;
 	    }
-	    krb5_pac_free(context, pac);
-	    if (ret)
+	    if (ret) {
+		krb5_pac_free(context, pac);
 		goto out;
+	    }
+	    o->ticket->client->nameattrs->pac = pac;
 	} else
 	  ret = 0;
     }

--- a/tests/plugin/kdc_test_plugin.c
+++ b/tests/plugin/kdc_test_plugin.c
@@ -19,9 +19,11 @@ fini(void *ctx)
 }
 
 static krb5_error_code KRB5_CALLCONV
-pac_generate(void *ctx, krb5_context context,
-	     struct hdb_entry_ex *client,
-	     struct hdb_entry_ex *server,
+pac_generate(void *ctx,
+	     krb5_context context,
+	     krb5_kdc_configuration *config,
+	     hdb_entry *client,
+	     hdb_entry *server,
 	     const krb5_keyblock *pk_replykey,
 	     uint64_t pac_attributes,
 	     krb5_pac *pac)
@@ -52,12 +54,14 @@ pac_generate(void *ctx, krb5_context context,
 }
 
 static krb5_error_code KRB5_CALLCONV
-pac_verify(void *ctx, krb5_context context,
+pac_verify(void *ctx,
+	   krb5_context context,
+	   krb5_kdc_configuration *config,
 	   const krb5_principal new_ticket_client,
 	   const krb5_principal delegation_proxy,
-	   struct hdb_entry_ex * client,
-	   struct hdb_entry_ex * server,
-	   struct hdb_entry_ex * krbtgt,
+	   hdb_entry * client,
+	   hdb_entry * server,
+	   hdb_entry * krbtgt,
 	   krb5_pac *pac)
 {
     krb5_error_code ret;
@@ -78,7 +82,7 @@ pac_verify(void *ctx, krb5_context context,
     if (ret)
 	return ret;
 
-    if (rodc_id == 0 || rodc_id != krbtgt->entry.kvno >> 16) {
+    if (rodc_id == 0 || rodc_id != krbtgt->kvno >> 16) {
 	krb5_warnx(context, "Wrong RODCIdentifier");
 	return EINVAL;
     }
@@ -87,7 +91,7 @@ pac_verify(void *ctx, krb5_context context,
     if (ret)
 	return ret;
 
-    ret = hdb_enctype2key(context, &krbtgt->entry, NULL, etype, &key);
+    ret = hdb_enctype2key(context, krbtgt, NULL, etype, &key);
     if (ret)
 	return ret;
 
@@ -152,7 +156,7 @@ audit(void *ctx, astgs_request_t r)
 }
 
 static krb5plugin_kdc_ftable kdc_plugin = {
-    KRB5_PLUGIN_KDC_VERSION_9,
+    KRB5_PLUGIN_KDC_VERSION_10,
     init,
     fini,
     pac_generate,


### PR DESCRIPTION
PREVIOUSLY:

> This adds support for asn1_compile --decorate=... variation that causes decoration of an ASN.1 SET/SEQUENCE type with a field of a non-ASN.1 type.
> 
> This means we can now have an ASN.1 type to represent a request that can then have a "hidden" field -- hidden in that it is neither encoded nor decoded.  This field will be copied and freed when the decoration is of an ASN.1 type or of a external, C type that comes with copy constructor and destructor functions.  Decoration with a `void *` field which is neither copied nor freed is also supported.

That was reviewed by @lhoward.

NOW:

> Follow-up commits add a `krb5_pac` to `PrincipalNameAttrs` and also replaces `hdb_entry_ex` by decorating `HDB_entry` with a C type that points to the backend-specific context.