### PR TITLE
gss: Make krb5 name attrs table-driven

### DIFF
--- a/lib/asn1/krb5.asn1
+++ b/lib/asn1/krb5.asn1
@@ -476,10 +476,11 @@ PrincipalNameAttrs ::= SEQUENCE {
         -- True if the PAC was verified
         pac-verified        [5]     BOOLEAN,
         -- True if any AD-KDC-ISSUEDs in the Ticket were validated
-        kdc-issued-verified [6]     BOOLEAN
+        kdc-issued-verified [6]     BOOLEAN,
         -- TODO: Add requested attributes, for gss_set_name_attribute(), which
         --       should cause corresponding authz-data elements to be added to
         --       any TGS-REQ or to the AP-REQ's Authenticator as appropriate.
+        want-ad             [7]     AuthorizationData OPTIONAL
 }
 -- This is our type for exported composite name tokens for GSS [RFC6680].
 -- It's the same as Principal (below) as decorated with (see krb5.opt file and

--- a/lib/gssapi/Makefile.am
+++ b/lib/gssapi/Makefile.am
@@ -385,7 +385,7 @@ LDADD = libgssapi.la \
 	$(LIB_roken)
 
 test_names_LDADD = $(LDADD) $(top_builddir)/lib/asn1/libasn1.la
-test_context_LDADD = $(LDADD) $(top_builddir)/lib/wind/libwind.la
+test_context_LDADD = $(LDADD) $(top_builddir)/lib/asn1/libasn1.la $(top_builddir)/lib/wind/libwind.la
 
 # gss
 

--- a/lib/gssapi/krb5/external.c
+++ b/lib/gssapi/krb5/external.c
@@ -393,8 +393,8 @@ static gssapi_mech_interface_desc krb5_mech = {
     _gsskrb5_display_name_ext,
     _gsskrb5_inquire_name,
     _gsskrb5_get_name_attribute,
-    NULL, /* gm_set_name_attribute */
-    NULL, /* gm_delete_name_attribute */
+    _gsskrb5_set_name_attribute,
+    _gsskrb5_delete_name_attribute,
     _gsskrb5_export_name_composite,
     _gsskrb5_duplicate_cred,
     _gsskrb5_add_cred_from,

--- a/lib/gssapi/krb5/init_sec_context.c
+++ b/lib/gssapi/krb5/init_sec_context.c
@@ -33,6 +33,12 @@
 
 #include "gsskrb5_locl.h"
 
+static OM_uint32
+gsskrb5_set_authorization_data(OM_uint32 *,
+                               krb5_context,
+                               krb5_auth_context,
+                               gss_const_name_t);
+
 /*
  * copy the addresses from `input_chan_bindings' (if any) to
  * the auth context `ac'
@@ -415,6 +421,11 @@ init_auth
 
     ret = gsskrb5_get_creds(minor_status, context, ctx->ccache,
 			    ctx, name, time_req, time_rec);
+    if (ret)
+	goto failure;
+
+    ret = gsskrb5_set_authorization_data(minor_status, context,
+                                         ctx->auth_context, name);
     if (ret)
 	goto failure;
 
@@ -976,4 +987,32 @@ OM_uint32 GSSAPI_CALLCONV _gsskrb5_init_sec_context
 
     return ret;
 
+}
+
+static OM_uint32
+gsskrb5_set_authorization_data(OM_uint32 *minor_status,
+                               krb5_context context,
+                               krb5_auth_context auth_context,
+                               gss_const_name_t gn)
+{
+    const CompositePrincipal *name = (const void *)gn;
+    AuthorizationData *ad;
+    krb5_error_code kret = 0;
+    size_t i;
+
+    if (name->nameattrs == NULL || name->nameattrs->want_ad == NULL)
+        return GSS_S_COMPLETE;
+
+    ad = name->nameattrs->want_ad;
+    for (i = 0; kret == 0 && i < ad->len; i++) {
+        kret = krb5_auth_con_add_AuthorizationData(context, auth_context,
+                                                   ad->val[0].ad_type,
+                                                   &ad->val[0].ad_data);
+    }
+
+    if (kret) {
+        *minor_status = kret;
+        return GSS_S_FAILURE;
+    }
+    return GSS_S_COMPLETE;
 }

--- a/lib/gssapi/test_context.c
+++ b/lib/gssapi/test_context.c
@@ -56,6 +56,7 @@ static char *localname_string;
 static char *client_name;
 static char *client_password;
 static char *localname_string;
+static char *on_behalf_of_string;
 static int dns_canon_flag = -1;
 static int mutual_auth_flag = 0;
 static int dce_style_flag = 0;
@@ -294,6 +295,31 @@ loop(gss_OID mechoid,
     if (GSS_ERROR(maj_stat))
 	err(1, "import name creds failed with: %d", maj_stat);
 
+    if (on_behalf_of_string) {
+        AuthorizationDataElement e;
+        gss_buffer_desc attr, value;
+        int32_t kret;
+        size_t sz;
+
+        memset(&e, 0, sizeof(e));
+        e.ad_type = KRB5_AUTHDATA_ON_BEHALF_OF;
+        e.ad_data.length = strlen(on_behalf_of_string);
+        e.ad_data.data = on_behalf_of_string;
+        ASN1_MALLOC_ENCODE(AuthorizationDataElement, value.value, value.length,
+                           &e, &sz, kret);
+        if (kret)
+            errx(1, "Could not encode AD-ON-BEHALF-OF AuthorizationDataElement");
+        attr.value =
+            GSS_KRB5_NAME_ATTRIBUTE_BASE_URN "authenticator-authz-data";
+        attr.length =
+            sizeof(GSS_KRB5_NAME_ATTRIBUTE_BASE_URN "authenticator-authz-data") - 1;
+        maj_stat = gss_set_name_attribute(&min_stat, gss_target_name, 1, &attr,
+                                          &value);
+        if (maj_stat != GSS_S_COMPLETE)
+            errx(1, "gss_set_name_attribute() failed with: %s",
+                 gssapi_err(maj_stat, min_stat, GSS_KRB5_MECHANISM));
+    }
+
     input_token.length = 0;
     input_token.value = NULL;
 
@@ -457,6 +483,24 @@ loop(gss_OID mechoid,
 	errx(1, "mech mismatch");
     *actual_mech = actual_mech_server;
 
+    if (on_behalf_of_string) {
+        gss_buffer_desc attr, value;
+
+        attr.value =
+            GSS_KRB5_NAME_ATTRIBUTE_BASE_URN "authz-data#580";
+        attr.length =
+            sizeof(GSS_KRB5_NAME_ATTRIBUTE_BASE_URN "authz-data#580") - 1;
+        maj_stat = gss_get_name_attribute(&min_stat, src_name, &attr, NULL,
+                                          NULL, &value, NULL, NULL);
+        if (maj_stat != GSS_S_COMPLETE)
+            errx(1, "gss_get_name_attribute(authz-data#580) failed with %s",
+                 gssapi_err(maj_stat, min_stat, GSS_KRB5_MECHANISM));
+
+        if (value.length != strlen(on_behalf_of_string) ||
+            strncmp(value.value, on_behalf_of_string,
+                    strlen(on_behalf_of_string)) != 0)
+            errx(1, "AD-ON-BEHALF-OF did not match");
+    }
     if (localname_string) {
         gss_buffer_desc lname;
 
@@ -864,6 +908,8 @@ static struct getargs args[] = {
     {"server-time-offset",	0, arg_integer,	&server_time_offset, "time", NULL },
     {"max-loops",	0, arg_integer,	&max_loops, "time", NULL },
     {"token-split",	0, arg_integer, &token_split, "bytes", NULL },
+    {"on-behalf-of",	0, arg_string, &on_behalf_of_string, "principal",
+        "send authenticator authz-data AD-ON-BEHALF-OF" },
     {"version",	0,	arg_flag,	&version_flag, "print version", NULL },
     {"verbose",	'v',	arg_flag,	&verbose_flag, "verbose", NULL },
     {"help",	0,	arg_flag,	&help_flag,  NULL, NULL }

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -23,6 +23,8 @@ EXPORTS
 	krb5_appdefault_time
 	krb5_append_addresses
 	krb5_auth_con_addflags
+	krb5_auth_con_add_AuthorizationData
+	krb5_auth_con_add_AuthorizationDataIfRelevant
 	krb5_auth_con_free
 	krb5_auth_con_genaddrs
 	krb5_auth_con_generatelocalsubkey

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -24,6 +24,8 @@ HEIMDAL_KRB5_2.0 {
 		krb5_appdefault_time;
 		krb5_append_addresses;
 		krb5_auth_con_addflags;
+		krb5_auth_con_add_AuthorizationData;
+		krb5_auth_con_add_AuthorizationDataIfRelevant;
 		krb5_auth_con_free;
 		krb5_auth_con_genaddrs;
 		krb5_auth_con_generatelocalsubkey;

--- a/tests/gss/check-context.in
+++ b/tests/gss/check-context.in
@@ -245,6 +245,14 @@ for mech in krb5 krb5iov spnego spnegoiov; do
 		{ eval "$testfailed"; }
 done
 
+echo "======test authz-data (krb5)"
+${context} --mech-type=krb5 \
+    --mutual \
+    --wrapunwrap \
+    --on-behalf-of=foo@BAR.TEST.H5L.SE \
+    --name-type=hostbased-service host@lucid.test.h5l.se ||
+    { eval "$testfailed"; }
+
 echo "======dce-style"
 for mech in krb5 krb5iov spnego; do
 	iov=""


### PR DESCRIPTION
The implementation of GSS name attributes for Kerberos (or any mechanism
with more than a tiny handful) is much nicer as a table-driven
implementation.