### PR TITLE
gsskrb5: Do not leak authenticator on retry

### DIFF
--- a/lib/gssapi/krb5/accept_sec_context.c
+++ b/lib/gssapi/krb5/accept_sec_context.c
@@ -478,6 +478,10 @@ gsskrb5_acceptor_start(OM_uint32 * minor_status,
 	     * lets only send the error token on clock skew, that
 	     * limit when send error token for non-MUTUAL.
 	     */
+            krb5_auth_con_free(context, ctx->auth_context);
+            krb5_auth_con_free(context, ctx->deleg_auth_context);
+            ctx->deleg_auth_context = NULL;
+            ctx->auth_context = NULL;
 	    return send_error_token(minor_status, context, kret,
 				    server, &indata, output_token);
 	} else if (kret) {


### PR DESCRIPTION
We have a Heimdal special where when the acceptor sends back an error
token for clock skew or ticket-not-yet-valid errors then the acceptor
application will get GSS_S_CONTINUE_NEEDED from gss_accept_sec_context()
so that the initiator may retry with the same context.

But we were retaining the auth_context, which means that when the
initiator does send a new token, the acceptor leaks memory because
krb5_verify_ap_req2() doesn't clean up the auth_context on reuse.  The
end result is that we leak a lot in those cases.