### PR TITLE
Make most of KDC configuration private

### DIFF
--- a/kdc/announce.c
+++ b/kdc/announce.c
@@ -40,7 +40,7 @@
 #include <dns_sd.h>
 #include <err.h>
 
-static krb5_kdc_configuration *announce_config;
+static krb5_kdc_configuration_t announce_config;
 static krb5_context announce_context;
 
 struct entry {
@@ -528,7 +528,7 @@ register_notification(void)
 #endif
 
 void
-bonjour_announce(krb5_context context, krb5_kdc_configuration *config)
+bonjour_announce(krb5_context context, krb5_kdc_configuration_t config)
 {
 #if defined(__APPLE__) && defined(HAVE_GCD)
     g_queue = dispatch_queue_create("com.apple.kdc_announce", NULL);

--- a/kdc/config.c
+++ b/kdc/config.c
@@ -151,10 +151,10 @@ add_one_address (krb5_context context, const char *str, int first)
     krb5_free_addresses (context, &tmp);
 }
 
-krb5_kdc_configuration *
+krb5_kdc_configuration_t 
 configure(krb5_context context, int argc, char **argv, int *optidx)
 {
-    krb5_kdc_configuration *config;
+    krb5_kdc_configuration_t config;
     krb5_error_code ret;
     
     const char *p;

--- a/kdc/connect.c
+++ b/kdc/connect.c
@@ -126,7 +126,7 @@ add_port_string (krb5_context context,
 
 static void
 add_standard_ports (krb5_context context,
-		    krb5_kdc_configuration *config,
+		    krb5_kdc_configuration_t config,
 		    int family)
 {
     add_port_service(context, family, "kerberos", 88, "udp");
@@ -150,7 +150,7 @@ add_standard_ports (krb5_context context,
 
 static void
 parse_ports(krb5_context context,
-	    krb5_kdc_configuration *config,
+	    krb5_kdc_configuration_t config,
 	    const char *str)
 {
     char *pos = NULL;
@@ -232,7 +232,7 @@ reinit_descrs (struct descr *d, int n)
 
 static void
 init_socket(krb5_context context,
-	    krb5_kdc_configuration *config,
+	    krb5_kdc_configuration_t config,
 	    struct descr *d, krb5_address *a, int family, int type, int port)
 {
     krb5_error_code ret;
@@ -301,7 +301,7 @@ init_socket(krb5_context context,
 
 static int
 init_sockets(krb5_context context,
-	     krb5_kdc_configuration *config,
+	     krb5_kdc_configuration_t config,
 	     struct descr **desc)
 {
     krb5_error_code ret;
@@ -388,7 +388,7 @@ addr_to_string(krb5_context context,
 
 static void
 send_reply(krb5_context context,
-	   krb5_kdc_configuration *config,
+	   krb5_kdc_configuration_t config,
 	   krb5_boolean prependlength,
 	   struct descr *d,
 	   krb5_data *reply)
@@ -422,7 +422,7 @@ send_reply(krb5_context context,
 
 static void
 do_request(krb5_context context,
-	   krb5_kdc_configuration *config,
+	   krb5_kdc_configuration_t config,
 	   void *buf, size_t len, krb5_boolean prependlength,
 	   struct descr *d)
 {
@@ -455,7 +455,7 @@ do_request(krb5_context context,
 
 static void
 handle_udp(krb5_context context,
-	   krb5_kdc_configuration *config,
+	   krb5_kdc_configuration_t config,
 	   struct descr *d)
 {
     unsigned char *buf;
@@ -544,7 +544,7 @@ de_http(char *buf)
 
 static void
 add_new_tcp (krb5_context context,
-	     krb5_kdc_configuration *config,
+	     krb5_kdc_configuration_t config,
 	     struct descr *d, int parent, int child)
 {
     krb5_socket_t s;
@@ -583,7 +583,7 @@ add_new_tcp (krb5_context context,
 
 static int
 grow_descr (krb5_context context,
-	    krb5_kdc_configuration *config,
+	    krb5_kdc_configuration_t config,
 	    struct descr *d, size_t n)
 {
     if (d->size - d->len < n) {
@@ -617,7 +617,7 @@ grow_descr (krb5_context context,
 
 static int
 handle_vanilla_tcp (krb5_context context,
-		    krb5_kdc_configuration *config,
+		    krb5_kdc_configuration_t config,
 		    struct descr *d)
 {
     krb5_storage *sp;
@@ -645,7 +645,7 @@ handle_vanilla_tcp (krb5_context context,
 
 static int
 handle_http_tcp (krb5_context context,
-		 krb5_kdc_configuration *config,
+		 krb5_kdc_configuration_t config,
 		 struct descr *d)
 {
     char *s, *p, *t;
@@ -790,7 +790,7 @@ http1_request_is_complete(const unsigned char *req, size_t len)
 
 static void
 handle_tcp(krb5_context context,
-	   krb5_kdc_configuration *config,
+	   krb5_kdc_configuration_t config,
 	   struct descr *d, int idx, int min_free)
 {
     unsigned char buf[1024];
@@ -931,7 +931,7 @@ next_min_free(krb5_context context, struct descr **d, unsigned int *ndescr)
 }
 
 static void
-loop(krb5_context context, krb5_kdc_configuration *config,
+loop(krb5_context context, krb5_kdc_configuration_t config,
      struct descr **dp, unsigned int *ndescrp, int islive)
 {
     struct descr *d = *dp;
@@ -1021,7 +1021,7 @@ loop(krb5_context context, krb5_kdc_configuration *config,
 
 #ifdef __APPLE__
 static void
-bonjour_kid(krb5_context context, krb5_kdc_configuration *config, const char *argv0, int *islive)
+bonjour_kid(krb5_context context, krb5_kdc_configuration_t config, const char *argv0, int *islive)
 {
     char buf;
 
@@ -1060,7 +1060,7 @@ kill_kids(pid_t *pids, int max_kids, int sig)
 }
 
 static int
-reap_kid(krb5_context context, krb5_kdc_configuration *config,
+reap_kid(krb5_context context, krb5_kdc_configuration_t config,
 	 pid_t *pids, int max_kids, int options)
 {
     pid_t pid;
@@ -1113,7 +1113,7 @@ reap_kid(krb5_context context, krb5_kdc_configuration *config,
 }
 
 static int
-reap_kids(krb5_context context, krb5_kdc_configuration *config,
+reap_kids(krb5_context context, krb5_kdc_configuration_t config,
 	  pid_t *pids, int max_kids)
 {
     int reaped = 0;
@@ -1140,7 +1140,7 @@ select_sleep(int microseconds)
 
 void
 start_kdc(krb5_context context,
-	  krb5_kdc_configuration *config, const char *argv0)
+	  krb5_kdc_configuration_t config, const char *argv0)
 {
     struct timeval tv1;
     struct timeval tv2;

--- a/kdc/default_config.c
+++ b/kdc/default_config.c
@@ -70,10 +70,10 @@ load_kdc_plugins_once(void *ctx)
 }
 
 KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
-krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
+krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration_t *config)
 {
     static heim_base_once_t load_kdc_plugins = HEIM_BASE_ONCE_INIT;
-    krb5_kdc_configuration *c;
+    krb5_kdc_configuration_t c;
     krb5_error_code ret;
 
     heim_base_once_f(&load_kdc_plugins, context, load_kdc_plugins_once);
@@ -392,7 +392,7 @@ krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
 }
 
 KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
-krb5_kdc_pkinit_config(krb5_context context, krb5_kdc_configuration *config)
+krb5_kdc_pkinit_config(krb5_context context, krb5_kdc_configuration_t config)
 {
 #ifdef PKINIT
 #ifdef __APPLE__

--- a/kdc/digest-service.c
+++ b/kdc/digest-service.c
@@ -48,7 +48,7 @@ struct Kx509Request;
 
 #include <kdc-private.h>
 
-krb5_kdc_configuration *config;
+krb5_kdc_configuration_t config;
 
 static void
 ntlm_service(void *ctx, const heim_idata *req,

--- a/kdc/digest.c
+++ b/kdc/digest.c
@@ -56,7 +56,7 @@ const struct units _kdc_digestunits[] = {
 
 static krb5_error_code
 get_digest_key(krb5_context context,
-	       krb5_kdc_configuration *config,
+	       krb5_kdc_configuration_t config,
 	       hdb_entry_ex *server,
 	       krb5_crypto *crypto)
 {
@@ -162,7 +162,7 @@ static const unsigned char ms_rfc3079_magic1[27] = {
 
 static krb5_error_code
 get_password_entry(krb5_context context,
-		   krb5_kdc_configuration *config,
+		   krb5_kdc_configuration_t config,
 		   const char *username,
 		   char **password)
 {
@@ -200,7 +200,7 @@ get_password_entry(krb5_context context,
 
 krb5_error_code
 _kdc_do_digest(krb5_context context,
-	       krb5_kdc_configuration *config,
+	       krb5_kdc_configuration_t config,
 	       const struct DigestREQ *req, krb5_data *reply,
 	       const char *from, struct sockaddr *addr)
 {

--- a/kdc/kdc-replay.c
+++ b/kdc/kdc-replay.c
@@ -55,7 +55,7 @@ main(int argc, char **argv)
 {
     krb5_error_code ret;
     krb5_context context;
-    krb5_kdc_configuration *config;
+    krb5_kdc_configuration_t config;
     krb5_storage *sp;
     int fd, optidx = 0;
 

--- a/kdc/kdc-tester.c
+++ b/kdc/kdc-tester.c
@@ -48,7 +48,7 @@ int detach_from_console = -1;
 int daemon_child = -1;
 int do_bonjour = -1;
 
-static krb5_kdc_configuration *kdc_config;
+static krb5_kdc_configuration_t kdc_config;
 static krb5_context kdc_context;
 
 static struct sockaddr_storage sa;

--- a/kdc/kdc.h
+++ b/kdc/kdc.h
@@ -47,7 +47,7 @@
 #include <gssapi/gssapi.h>
 
 #define heim_pcontext krb5_context
-#define heim_pconfig krb5_kdc_configuration *
+#define heim_pconfig krb5_kdc_configuration_t
 #include <heimbase-svc.h>
 
 enum krb5_kdc_trpolicy {
@@ -63,14 +63,14 @@ enum krb5_kdc_trpolicy {
     const char *app
 
 #ifndef __KDC_LOCL_H__
-struct krb5_kdc_configuration {
+struct krb5_kdc_configuration_desc {
     KRB5_KDC_CONFIGURATION_COMMON_ELEMENTS;
 };
 #else
-struct krb5_kdc_configuration;
+struct krb5_kdc_configuration_desc;
 #endif
 
-typedef struct krb5_kdc_configuration krb5_kdc_configuration;
+typedef struct krb5_kdc_configuration_desc *krb5_kdc_configuration_t;
 
 #define ASTGS_REQUEST_DESC_COMMON_ELEMENTS			\
     HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;			\

--- a/kdc/kdc.h
+++ b/kdc/kdc.h
@@ -56,77 +56,21 @@ enum krb5_kdc_trpolicy {
     TRPOLICY_ALWAYS_HONOUR_REQUEST
 };
 
-typedef struct krb5_kdc_configuration {
-    krb5_boolean require_preauth; /* require preauth for all principals */
-    time_t kdc_warn_pwexpire; /* time before expiration to print a warning */
+#define KRB5_KDC_CONFIGURATION_COMMON_ELEMENTS			\
+    struct HDB **db;						\
+    int num_db;							\
+    krb5_log_facility *logf;					\
+    const char *app
 
-    struct HDB **db;
-    int num_db;
+#ifndef __KDC_LOCL_H__
+struct krb5_kdc_configuration {
+    KRB5_KDC_CONFIGURATION_COMMON_ELEMENTS;
+};
+#else
+struct krb5_kdc_configuration;
+#endif
 
-    int num_kdc_processes;
-
-    krb5_boolean encode_as_rep_as_tgs_rep; /* bug compatibility */
-
-    /*
-     * Windows 2019 (and earlier versions) always sends the salt
-     * and Samba has testsuites that check this behaviour, so a
-     * Samba AD DC will set this flag to match the AS-REP packet
-     * exactly.
-     */
-    krb5_boolean force_include_pa_etype_salt;
-
-    krb5_boolean tgt_use_strongest_session_key;
-    krb5_boolean preauth_use_strongest_session_key;
-    krb5_boolean svc_use_strongest_session_key;
-    krb5_boolean use_strongest_server_key;
-
-    krb5_boolean check_ticket_addresses;
-    krb5_boolean warn_ticket_addresses;
-    krb5_boolean allow_null_ticket_addresses;
-    krb5_boolean allow_anonymous;
-    krb5_boolean historical_anon_realm;
-    krb5_boolean strict_nametypes;
-    enum krb5_kdc_trpolicy trpolicy;
-
-    krb5_boolean require_pac;
-    krb5_boolean enable_armored_pa_enc_timestamp;
-    krb5_boolean enable_unarmored_pa_enc_timestamp;
-
-    krb5_boolean enable_pkinit;
-    krb5_boolean pkinit_princ_in_cert;
-    const char *pkinit_kdc_identity;
-    const char *pkinit_kdc_anchors;
-    const char *pkinit_kdc_friendly_name;
-    const char *pkinit_kdc_ocsp_file;
-    char **pkinit_kdc_cert_pool;
-    char **pkinit_kdc_revoke;
-    int pkinit_dh_min_bits;
-    /* XXX Turn these into bit-fields */
-    int pkinit_require_binding;
-    int pkinit_allow_proxy_certs;
-    int synthetic_clients;
-    int pkinit_max_life_from_cert_extension;
-    krb5_timestamp pkinit_max_life_from_cert;
-    krb5_timestamp pkinit_max_life_bound;
-    krb5_timestamp synthetic_clients_max_life;
-    krb5_timestamp synthetic_clients_max_renew;
-
-    krb5_log_facility *logf;
-
-    int enable_digest;
-    int digests_allowed;
-
-    int enable_gss_preauth;
-    int enable_gss_auth_data;
-    gss_OID_set gss_mechanisms_allowed;
-    gss_OID_set gss_cross_realm_mechanisms_allowed;
-
-    size_t max_datagram_reply_length;
-
-    int enable_kx509;
-
-    const char *app;
-} krb5_kdc_configuration;
+typedef struct krb5_kdc_configuration krb5_kdc_configuration;
 
 #define ASTGS_REQUEST_DESC_COMMON_ELEMENTS			\
     HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;			\

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -53,20 +53,14 @@ typedef struct gss_client_params gss_client_params;
 #define KFE_USE_CLIENT	0x4
 
 #define heim_pcontext krb5_context
-#define heim_pconfig krb5_kdc_configuration *
+#define heim_pconfig krb5_kdc_configuration_t 
 #include <heimbase-svc.h>
 
 #define KDC_AUDIT_EATWHITE      HEIM_SVC_AUDIT_EATWHITE
 #define KDC_AUDIT_VIS           HEIM_SVC_AUDIT_VIS
 #define KDC_AUDIT_VISLAST       HEIM_SVC_AUDIT_VISLAST
 
-struct kdc_request_desc {
-    HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;
-};
-
-struct kdc_patypes;
-
-struct krb5_kdc_configuration {
+struct krb5_kdc_configuration_desc {
     KRB5_KDC_CONFIGURATION_COMMON_ELEMENTS;
 
     time_t kdc_warn_pwexpire; /* time before expiration to print a warning */
@@ -131,6 +125,12 @@ struct krb5_kdc_configuration {
 
     size_t max_datagram_reply_length;
 };
+
+struct kdc_request_desc {
+    HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;
+};
+
+struct kdc_patypes;
 
 struct astgs_request_desc {
     ASTGS_REQUEST_DESC_COMMON_ELEMENTS;
@@ -203,13 +203,13 @@ extern char *runas_string;
 extern char *chroot_string;
 
 void
-start_kdc(krb5_context context, krb5_kdc_configuration *config, const char *argv0);
+start_kdc(krb5_context context, krb5_kdc_configuration_t config, const char *argv0);
 
-krb5_kdc_configuration *
+krb5_kdc_configuration_t 
 configure(krb5_context context, int argc, char **argv, int *optidx);
 
 #ifdef __APPLE__
-void bonjour_announce(krb5_context, krb5_kdc_configuration *);
+void bonjour_announce(krb5_context, krb5_kdc_configuration_t );
 #endif
 
 #endif /* __KDC_LOCL_H__ */

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -66,6 +66,71 @@ struct kdc_request_desc {
 
 struct kdc_patypes;
 
+struct krb5_kdc_configuration {
+    KRB5_KDC_CONFIGURATION_COMMON_ELEMENTS;
+
+    krb5_boolean require_preauth; /* require preauth for all principals */
+    time_t kdc_warn_pwexpire; /* time before expiration to print a warning */
+    int num_kdc_processes;
+    krb5_boolean encode_as_rep_as_tgs_rep; /* bug compatibility */
+
+    /*
+     * Windows 2019 (and earlier versions) always sends the salt
+     * and Samba has testsuites that check this behaviour, so a
+     * Samba AD DC will set this flag to match the AS-REP packet
+     * exactly.
+     */
+    krb5_boolean force_include_pa_etype_salt;
+
+    krb5_boolean tgt_use_strongest_session_key;
+    krb5_boolean preauth_use_strongest_session_key;
+    krb5_boolean svc_use_strongest_session_key;
+    krb5_boolean use_strongest_server_key;
+
+    krb5_boolean check_ticket_addresses;
+    krb5_boolean warn_ticket_addresses;
+    krb5_boolean allow_null_ticket_addresses;
+    krb5_boolean allow_anonymous;
+    krb5_boolean historical_anon_realm;
+    krb5_boolean strict_nametypes;
+    enum krb5_kdc_trpolicy trpolicy;
+
+    krb5_boolean require_pac;
+    krb5_boolean enable_armored_pa_enc_timestamp;
+    krb5_boolean enable_unarmored_pa_enc_timestamp;
+
+    krb5_boolean enable_pkinit;
+    krb5_boolean pkinit_princ_in_cert;
+    const char *pkinit_kdc_identity;
+    const char *pkinit_kdc_anchors;
+    const char *pkinit_kdc_friendly_name;
+    const char *pkinit_kdc_ocsp_file;
+    char **pkinit_kdc_cert_pool;
+    char **pkinit_kdc_revoke;
+    int pkinit_dh_min_bits;
+    /* XXX Turn these into bit-fields */
+    int pkinit_require_binding;
+    int pkinit_allow_proxy_certs;
+    int synthetic_clients;
+    int pkinit_max_life_from_cert_extension;
+    krb5_timestamp pkinit_max_life_from_cert;
+    krb5_timestamp pkinit_max_life_bound;
+    krb5_timestamp synthetic_clients_max_life;
+    krb5_timestamp synthetic_clients_max_renew;
+
+    int enable_digest;
+    int digests_allowed;
+
+    int enable_gss_preauth;
+    int enable_gss_auth_data;
+    gss_OID_set gss_mechanisms_allowed;
+    gss_OID_set gss_cross_realm_mechanisms_allowed;
+
+    size_t max_datagram_reply_length;
+
+    int enable_kx509;
+};
+
 struct astgs_request_desc {
     ASTGS_REQUEST_DESC_COMMON_ELEMENTS;
 

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -69,10 +69,13 @@ struct kdc_patypes;
 struct krb5_kdc_configuration {
     KRB5_KDC_CONFIGURATION_COMMON_ELEMENTS;
 
-    krb5_boolean require_preauth; /* require preauth for all principals */
     time_t kdc_warn_pwexpire; /* time before expiration to print a warning */
     int num_kdc_processes;
-    krb5_boolean encode_as_rep_as_tgs_rep; /* bug compatibility */
+
+    enum krb5_kdc_trpolicy trpolicy;
+
+    unsigned int require_preauth : 1; /* require preauth for all principals */
+    unsigned int encode_as_rep_as_tgs_rep : 1; /* bug compatibility */
 
     /*
      * Windows 2019 (and earlier versions) always sends the salt
@@ -80,27 +83,30 @@ struct krb5_kdc_configuration {
      * Samba AD DC will set this flag to match the AS-REP packet
      * exactly.
      */
-    krb5_boolean force_include_pa_etype_salt;
+    unsigned int force_include_pa_etype_salt : 1;
 
-    krb5_boolean tgt_use_strongest_session_key;
-    krb5_boolean preauth_use_strongest_session_key;
-    krb5_boolean svc_use_strongest_session_key;
-    krb5_boolean use_strongest_server_key;
+    unsigned int tgt_use_strongest_session_key : 1;
+    unsigned int preauth_use_strongest_session_key : 1;
+    unsigned int svc_use_strongest_session_key : 1;
+    unsigned int use_strongest_server_key : 1;
 
-    krb5_boolean check_ticket_addresses;
-    krb5_boolean warn_ticket_addresses;
-    krb5_boolean allow_null_ticket_addresses;
-    krb5_boolean allow_anonymous;
-    krb5_boolean historical_anon_realm;
-    krb5_boolean strict_nametypes;
-    enum krb5_kdc_trpolicy trpolicy;
+    unsigned int check_ticket_addresses : 1;
+    unsigned int warn_ticket_addresses : 1;
+    unsigned int allow_null_ticket_addresses : 1;
+    unsigned int allow_anonymous : 1;
+    unsigned int historical_anon_realm : 1;
+    unsigned int strict_nametypes : 1;
 
-    krb5_boolean require_pac;
-    krb5_boolean enable_armored_pa_enc_timestamp;
-    krb5_boolean enable_unarmored_pa_enc_timestamp;
+    unsigned int require_pac : 1;
+    unsigned int enable_armored_pa_enc_timestamp : 1;
+    unsigned int enable_unarmored_pa_enc_timestamp : 1;
 
-    krb5_boolean enable_pkinit;
-    krb5_boolean pkinit_princ_in_cert;
+    unsigned int enable_pkinit : 1;
+    unsigned int pkinit_princ_in_cert : 1;
+    unsigned int pkinit_require_binding : 1;
+    unsigned int pkinit_allow_proxy_certs : 1;
+    unsigned int synthetic_clients : 1;
+    unsigned int pkinit_max_life_from_cert_extension : 1;
     const char *pkinit_kdc_identity;
     const char *pkinit_kdc_anchors;
     const char *pkinit_kdc_friendly_name;
@@ -108,27 +114,22 @@ struct krb5_kdc_configuration {
     char **pkinit_kdc_cert_pool;
     char **pkinit_kdc_revoke;
     int pkinit_dh_min_bits;
-    /* XXX Turn these into bit-fields */
-    int pkinit_require_binding;
-    int pkinit_allow_proxy_certs;
-    int synthetic_clients;
-    int pkinit_max_life_from_cert_extension;
     krb5_timestamp pkinit_max_life_from_cert;
     krb5_timestamp pkinit_max_life_bound;
     krb5_timestamp synthetic_clients_max_life;
     krb5_timestamp synthetic_clients_max_renew;
 
-    int enable_digest;
     int digests_allowed;
 
-    int enable_gss_preauth;
-    int enable_gss_auth_data;
+    unsigned int enable_digest : 1;
+    unsigned int enable_kx509 : 1;
+
+    unsigned int enable_gss_preauth : 1;
+    unsigned int enable_gss_auth_data : 1;
     gss_OID_set gss_mechanisms_allowed;
     gss_OID_set gss_cross_realm_mechanisms_allowed;
 
     size_t max_datagram_reply_length;
-
-    int enable_kx509;
 };
 
 struct astgs_request_desc {

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -437,7 +437,7 @@ _kdc_log_timestamp(astgs_request_t r, const char *type,
 		   KerberosTime authtime, KerberosTime *starttime,
 		   KerberosTime endtime, KerberosTime *renew_till)
 {
-    krb5_kdc_configuration *config = r->config;
+    krb5_kdc_configuration_t config = r->config;
     char authtime_str[100], starttime_str[100],
 	endtime_str[100], renewtime_str[100];
 
@@ -1004,7 +1004,7 @@ static const struct kdc_patypes pat[] = {
 static void
 log_patypes(astgs_request_t r, METHOD_DATA *padata)
 {
-    krb5_kdc_configuration *config = r->config;
+    krb5_kdc_configuration_t config = r->config;
     struct rk_strpool *p = NULL;
     char *str;
     size_t n, m;
@@ -1050,7 +1050,7 @@ pa_used_flag_isset(astgs_request_t r, unsigned int flag)
 
 krb5_error_code
 _kdc_encode_reply(krb5_context context,
-		  krb5_kdc_configuration *config,
+		  krb5_kdc_configuration_t config,
 		  astgs_request_t r, uint32_t nonce,
 		  krb5_enctype etype,
 		  int skvno, const EncryptionKey *skey,
@@ -1291,7 +1291,7 @@ make_etype_info_entry(krb5_context context,
 
 static krb5_error_code
 get_pa_etype_info(krb5_context context,
-		  krb5_kdc_configuration *config,
+		  krb5_kdc_configuration_t config,
 		  METHOD_DATA *md, Key *ckey,
 		  krb5_boolean include_salt)
 {
@@ -1413,7 +1413,7 @@ make_etype_info2_entry(ETYPE_INFO2_ENTRY *ent,
 
 static krb5_error_code
 get_pa_etype_info2(krb5_context context,
-		   krb5_kdc_configuration *config,
+		   krb5_kdc_configuration_t config,
 		   METHOD_DATA *md, Key *ckey,
 		   krb5_boolean include_salt)
 {
@@ -1468,7 +1468,7 @@ newer_enctype_present(krb5_context context,
 
 static krb5_error_code
 get_pa_etype_info_both(krb5_context context,
-		       krb5_kdc_configuration *config,
+		       krb5_kdc_configuration_t config,
 		       struct KDC_REQ_BODY_etype *etype_list,
 		       METHOD_DATA *md, Key *ckey,
 		       krb5_boolean include_salt)
@@ -1735,7 +1735,7 @@ krb5_boolean
 _kdc_check_addresses(astgs_request_t r, HostAddresses *addresses,
 		     const struct sockaddr *from)
 {
-    krb5_kdc_configuration *config = r->config;
+    krb5_kdc_configuration_t config = r->config;
     krb5_error_code ret;
     krb5_address addr;
     krb5_boolean result;
@@ -2020,7 +2020,7 @@ add_synthetic_princ_ad(astgs_request_t r)
 
 static krb5_error_code
 get_local_tgs(krb5_context context,
-	      krb5_kdc_configuration *config,
+	      krb5_kdc_configuration_t config,
 	      krb5_const_realm realm,
 	      hdb_entry_ex **krbtgt)
 {
@@ -2052,7 +2052,7 @@ get_local_tgs(krb5_context context,
 krb5_error_code
 _kdc_as_rep(astgs_request_t r)
 {
-    krb5_kdc_configuration *config = r->config;
+    krb5_kdc_configuration_t config = r->config;
     KDC_REQ *req = &r->req;
     const char *from = r->from;
     KDC_REQ_BODY *b = NULL;

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -77,7 +77,7 @@ _kdc_synthetic_princ_used_p(krb5_context context, krb5_ticket *ticket)
 
 krb5_error_code
 _kdc_check_pac(krb5_context context,
-	       krb5_kdc_configuration *config,
+	       krb5_kdc_configuration_t config,
 	       const krb5_principal client_principal,
 	       const krb5_principal delegated_proxy_principal,
 	       hdb_entry_ex *client,
@@ -357,7 +357,7 @@ check_tgs_flags(astgs_request_t r, KDC_REQ_BODY *b,
 
 krb5_error_code
 _kdc_check_client_matches_target_service(krb5_context context,
-					 krb5_kdc_configuration *config,
+					 krb5_kdc_configuration_t config,
 					 HDB *clientdb,
 					 hdb_entry_ex *client,
 					 hdb_entry_ex *target_server,
@@ -394,7 +394,7 @@ _kdc_check_client_matches_target_service(krb5_context context,
 
 krb5_error_code
 _kdc_verify_flags(krb5_context context,
-		  krb5_kdc_configuration *config,
+		  krb5_kdc_configuration_t config,
 		  const EncTicketPart *et,
 		  const char *pstr)
 {
@@ -415,7 +415,7 @@ _kdc_verify_flags(krb5_context context,
 
 static krb5_error_code
 fix_transited_encoding(krb5_context context,
-		       krb5_kdc_configuration *config,
+		       krb5_kdc_configuration_t config,
 		       krb5_boolean check_policy,
 		       const TransitedEncoding *tr,
 		       EncTicketPart *et,
@@ -800,7 +800,7 @@ out:
 
 static krb5_error_code
 tgs_check_authenticator(krb5_context context,
-			krb5_kdc_configuration *config,
+			krb5_kdc_configuration_t config,
 	                krb5_auth_context ac,
 			KDC_REQ_BODY *b,
 			krb5_keyblock *key)
@@ -855,7 +855,7 @@ out:
 }
 
 static krb5_boolean
-need_referral(krb5_context context, krb5_kdc_configuration *config,
+need_referral(krb5_context context, krb5_kdc_configuration_t config,
 	      const KDCOptions * const options, krb5_principal server,
 	      krb5_realm **realms)
 {
@@ -913,7 +913,7 @@ tgs_parse_request(astgs_request_t r,
 		  int **cusec,
 		  AuthorizationData **auth_data)
 {
-    krb5_kdc_configuration *config = r->config;
+    krb5_kdc_configuration_t config = r->config;
     KDC_REQ_BODY *b = &r->req.req_body;
     static char failed[] = "<unparse_name failed>";
     krb5_ap_req ap_req;
@@ -1215,7 +1215,7 @@ out:
 
 static krb5_error_code
 build_server_referral(krb5_context context,
-		      krb5_kdc_configuration *config,
+		      krb5_kdc_configuration_t config,
 		      krb5_crypto session,
 		      krb5_const_realm referred_realm,
 		      const PrincipalName *true_principal_name,
@@ -1295,7 +1295,7 @@ eout:
  */
 krb5_error_code
 _kdc_db_fetch_client(krb5_context context,
-		     krb5_kdc_configuration *config,
+		     krb5_kdc_configuration_t config,
 		     int flags,
 		     krb5_principal cp,
 		     const char *cpn,
@@ -1351,7 +1351,7 @@ tgs_build_reply(astgs_request_t priv,
 		const struct sockaddr *from_addr)
 {
     krb5_context context = priv->context;
-    krb5_kdc_configuration *config = priv->config;
+    krb5_kdc_configuration_t config = priv->config;
     KDC_REQ_BODY *b = &priv->req.req_body;
     const char *from = priv->from;
     krb5_error_code ret, ret2;
@@ -2070,7 +2070,7 @@ out:
 krb5_error_code
 _kdc_tgs_rep(astgs_request_t r)
 {
-    krb5_kdc_configuration *config = r->config;
+    krb5_kdc_configuration_t config = r->config;
     KDC_REQ *req = &r->req;
     krb5_data *data = r->reply;
     const char *from = r->from;

--- a/kdc/log.c
+++ b/kdc/log.c
@@ -38,7 +38,7 @@
 KDC_LIB_FUNCTION void KDC_LIB_CALL
 kdc_openlog(krb5_context context,
 	    const char *service,
-	    krb5_kdc_configuration *config)
+	    krb5_kdc_configuration_t config)
 {
     char **s = NULL, **p;
     krb5_initlog(context, "kdc", &config->logf);
@@ -65,7 +65,7 @@ kdc_openlog(krb5_context context,
 
 KDC_LIB_FUNCTION char * KDC_LIB_CALL
 kdc_log_msg_va(krb5_context context,
-	       krb5_kdc_configuration *config,
+	       krb5_kdc_configuration_t config,
 	       int level, const char *fmt, va_list ap)
     __attribute__ ((__format__ (__printf__, 4, 0)))
 {
@@ -76,7 +76,7 @@ kdc_log_msg_va(krb5_context context,
 
 KDC_LIB_FUNCTION char * KDC_LIB_CALL
 kdc_log_msg(krb5_context context,
-	    krb5_kdc_configuration *config,
+	    krb5_kdc_configuration_t config,
 	    int level, const char *fmt, ...)
     __attribute__ ((__format__ (__printf__, 4, 5)))
 {
@@ -90,7 +90,7 @@ kdc_log_msg(krb5_context context,
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
 kdc_vlog(krb5_context context,
-         krb5_kdc_configuration *config,
+         krb5_kdc_configuration_t config,
          int level, const char *fmt, va_list ap)
     __attribute__ ((__format__ (__printf__, 4, 0)))
 {
@@ -99,7 +99,7 @@ kdc_vlog(krb5_context context,
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
 kdc_log(krb5_context context,
-	krb5_kdc_configuration *config,
+	krb5_kdc_configuration_t config,
 	int level, const char *fmt, ...)
     __attribute__ ((__format__ (__printf__, 4, 5)))
 {

--- a/kdc/main.c
+++ b/kdc/main.c
@@ -115,7 +115,7 @@ main(int argc, char **argv)
 {
     krb5_error_code ret;
     krb5_context context;
-    krb5_kdc_configuration *config;
+    krb5_kdc_configuration_t config;
     int optidx = 0;
 
     setprogname(argv[0]);

--- a/kdc/misc.c
+++ b/kdc/misc.c
@@ -35,7 +35,7 @@
 
 static int
 name_type_ok(krb5_context context,
-             krb5_kdc_configuration *config,
+             krb5_kdc_configuration_t config,
              krb5_const_principal principal)
 {
     int nt = krb5_principal_get_type(context, principal);
@@ -64,7 +64,7 @@ synthesize_hdb_close(krb5_context context, struct HDB *db)
  */
 static krb5_error_code
 synthesize_client(krb5_context context,
-                  krb5_kdc_configuration *config,
+                  krb5_kdc_configuration_t config,
                   krb5_const_principal princ,
                   HDB **db,
                   hdb_entry_ex **h)
@@ -124,7 +124,7 @@ synthesize_client(krb5_context context,
 
 KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 _kdc_db_fetch(krb5_context context,
-	      krb5_kdc_configuration *config,
+	      krb5_kdc_configuration_t config,
 	      krb5_const_principal principal,
 	      unsigned flags,
 	      krb5uint32 *kvno_ptr,
@@ -259,7 +259,7 @@ _kdc_free_ent(krb5_context context, hdb_entry_ex *ent)
 
 krb5_error_code
 _kdc_get_preferred_key(krb5_context context,
-		       krb5_kdc_configuration *config,
+		       krb5_kdc_configuration_t config,
 		       hdb_entry_ex *h,
 		       const char *name,
 		       krb5_enctype *enctype,

--- a/kdc/mssfu.c
+++ b/kdc/mssfu.c
@@ -45,7 +45,7 @@
 
 static krb5_error_code
 check_constrained_delegation(krb5_context context,
-			     krb5_kdc_configuration *config,
+			     krb5_kdc_configuration_t config,
 			     HDB *clientdb,
 			     hdb_entry_ex *client,
 			     hdb_entry_ex *server,

--- a/kdc/pkinit-ec.c
+++ b/kdc/pkinit-ec.c
@@ -186,7 +186,7 @@ _kdc_generate_ecdh_keyblock(krb5_context context,
 #ifdef HAVE_HCRYPTO_W_OPENSSL
 static krb5_error_code
 get_ecdh_param(krb5_context context,
-               krb5_kdc_configuration *config,
+               krb5_kdc_configuration_t config,
                SubjectPublicKeyInfo *dh_key_info,
                EC_KEY **out)
 {
@@ -248,7 +248,7 @@ get_ecdh_param(krb5_context context,
 
 krb5_error_code
 _kdc_get_ecdh_param(krb5_context context,
-                    krb5_kdc_configuration *config,
+                    krb5_kdc_configuration_t config,
                     SubjectPublicKeyInfo *dh_key_info,
                     void **out)
 {

--- a/kdc/pkinit.c
+++ b/kdc/pkinit.c
@@ -284,7 +284,7 @@ integer_to_BN(krb5_context context, const char *field, heim_integer *f)
 
 static krb5_error_code
 get_dh_param(krb5_context context,
-	     krb5_kdc_configuration *config,
+	     krb5_kdc_configuration_t config,
 	     SubjectPublicKeyInfo *dh_key_info,
 	     pk_client_params *client_params)
 {
@@ -388,7 +388,7 @@ _kdc_pk_rd_padata(astgs_request_t priv,
 {
     /* XXXrcd: we use priv vs r due to a conflict */
     krb5_context context = priv->context;
-    krb5_kdc_configuration *config = priv->config;
+    krb5_kdc_configuration_t config = priv->config;
     const KDC_REQ *req = &priv->req;
     hdb_entry_ex *client = priv->client;
     pk_client_params *cp;
@@ -822,7 +822,7 @@ BN_to_integer(krb5_context context, BIGNUM *bn, heim_integer *integer)
 
 static krb5_error_code
 pk_mk_pa_reply_enckey(krb5_context context,
-		      krb5_kdc_configuration *config,
+		      krb5_kdc_configuration_t config,
 		      pk_client_params *cp,
 		      const KDC_REQ *req,
 		      const krb5_data *req_buffer,
@@ -1002,7 +1002,7 @@ out:
 
 static krb5_error_code
 pk_mk_pa_reply_dh(krb5_context context,
-		  krb5_kdc_configuration *config,
+		  krb5_kdc_configuration_t config,
       		  pk_client_params *cp,
 		  ContentInfo *content_info,
 		  hx509_cert *kdc_cert)
@@ -1131,7 +1131,7 @@ pk_mk_pa_reply_dh(krb5_context context,
 krb5_error_code
 _kdc_pk_mk_pa_reply(astgs_request_t r, pk_client_params *cp)
 {
-    krb5_kdc_configuration *config = r->config;
+    krb5_kdc_configuration_t config = r->config;
     krb5_enctype sessionetype = r->sessionetype;
     const KDC_REQ *req = &r->req;
     const krb5_data *req_buffer = &r->request;
@@ -1535,7 +1535,7 @@ out:
 
 static int
 match_rfc_san(krb5_context context,
-	      krb5_kdc_configuration *config,
+	      krb5_kdc_configuration_t config,
 	      hx509_context hx509ctx,
 	      hx509_cert client_cert,
 	      krb5_const_principal match)
@@ -1596,7 +1596,7 @@ out:
 
 static int
 match_ms_upn_san(krb5_context context,
-		 krb5_kdc_configuration *config,
+		 krb5_kdc_configuration_t config,
 		 hx509_context hx509ctx,
 		 hx509_cert client_cert,
 		 HDB *clientdb,
@@ -1671,7 +1671,7 @@ _kdc_pk_check_client(astgs_request_t r,
 		     pk_client_params *cp,
 		     char **subject_name)
 {
-    krb5_kdc_configuration *config = r->config;
+    krb5_kdc_configuration_t config = r->config;
     HDB *clientdb = r->clientdb;
     hdb_entry_ex *client = r->client;
     const HDB_Ext_PKINIT_acl *acl;
@@ -1848,7 +1848,7 @@ add_principal_mapping(krb5_context context,
 
 krb5_error_code
 _kdc_add_initial_verified_cas(krb5_context context,
-			      krb5_kdc_configuration *config,
+			      krb5_kdc_configuration_t config,
 			      pk_client_params *cp,
 			      EncTicketPart *tkt)
 {
@@ -1928,7 +1928,7 @@ load_mappings(krb5_context context, const char *fn)
 
 KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 krb5_kdc_pk_initialize(krb5_context context,
-		       krb5_kdc_configuration *config,
+		       krb5_kdc_configuration_t config,
 		       const char *user_id,
 		       const char *anchors,
 		       char **pool,

--- a/kdc/process.c
+++ b/kdc/process.c
@@ -341,7 +341,7 @@ static struct krb5_kdc_service services[] =  {
 
 static int
 process_request(krb5_context context,
-		krb5_kdc_configuration *config,
+		krb5_kdc_configuration_t config,
 		unsigned int krb5_only,
 		unsigned char *buf,
 		size_t len,
@@ -420,7 +420,7 @@ process_request(krb5_context context,
 
 KDC_LIB_FUNCTION int KDC_LIB_CALL
 krb5_kdc_process_request(krb5_context context,
-			 krb5_kdc_configuration *config,
+			 krb5_kdc_configuration_t config,
 			 unsigned char *buf,
 			 size_t len,
 			 krb5_data *reply,
@@ -442,7 +442,7 @@ krb5_kdc_process_request(krb5_context context,
 
 KDC_LIB_FUNCTION int KDC_LIB_CALL
 krb5_kdc_process_krb5_request(krb5_context context,
-			      krb5_kdc_configuration *config,
+			      krb5_kdc_configuration_t config,
 			      unsigned char *buf,
 			      size_t len,
 			      krb5_data *reply,

--- a/kdc/set_dbinfo.c
+++ b/kdc/set_dbinfo.c
@@ -36,7 +36,7 @@
 #include "kdc_locl.h"
 
 static krb5_error_code
-add_db(krb5_context context, struct krb5_kdc_configuration *c,
+add_db(krb5_context context, krb5_kdc_configuration_t c,
        const char *conf, const char *master_key)
 {
     krb5_error_code ret;
@@ -65,7 +65,7 @@ add_db(krb5_context context, struct krb5_kdc_configuration *c,
 }
 
 KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
-krb5_kdc_set_dbinfo(krb5_context context, struct krb5_kdc_configuration *c)
+krb5_kdc_set_dbinfo(krb5_context context, krb5_kdc_configuration_t c)
 {
     struct hdb_dbinfo *info, *d;
     krb5_error_code ret;


### PR DESCRIPTION
Only expose a small part of `krb5_kdc_configuration` outside KDC.