### PR TITLE
kdc: move auth event definitions into KDC header

### DIFF
--- a/kdc/Makefile.am
+++ b/kdc/Makefile.am
@@ -244,7 +244,7 @@ include_HEADERS = kdc.h $(srcdir)/kdc-protos.h
 noinst_HEADERS = $(srcdir)/kdc-private.h
 
 krb5dir = $(includedir)/krb5
-krb5_HEADERS = kdc-plugin.h token_validator_plugin.h csr_authorizer_plugin.h
+krb5_HEADERS = kdc-audit.h kdc-plugin.h token_validator_plugin.h csr_authorizer_plugin.h
 
 build_HEADERZ = $(krb5_HEADERS) # XXX
 

--- a/kdc/NTMakefile
+++ b/kdc/NTMakefile
@@ -51,6 +51,7 @@ INCFILES=\
 	$(INCDIR)\kdc.h		\
 	$(INCDIR)\kdc-protos.h	\
 	$(INCDIR)\kdc-private.h	\
+	$(INCDIR)\krb5\kdc-audit.h \
 	$(INCDIR)\krb5\kdc-plugin.h
 
 all:: $(INCFILES) $(LIBKDC) $(BINPROGRAMS) $(SBINPROGRAMS) $(LIBEXECPROGRAMS)

--- a/kdc/headers.h
+++ b/kdc/headers.h
@@ -105,6 +105,7 @@
 #endif
 #include <kdc.h>
 #include <kdc-plugin.h>
+#include <kdc-audit.h>
 
 #include <heimbase.h>
 

--- a/kdc/kdc-audit.h
+++ b/kdc/kdc-audit.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2006 Kungliga Tekniska Högskolan
+ * (Royal Institute of Technology, Stockholm, Sweden).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/* $Id$ */
+
+#ifndef HEIMDAL_KDC_KDC_AUDIT_H
+#define HEIMDAL_KDC_KDC_AUDIT_H 1
+
+#include <heimbase.h>
+
+/*
+ * KDC auditing
+ */
+
+/* auth event type enumeration, currently for AS only */
+#define KDC_AUTH_EVENT_INVALID			0   /* no event logged */
+#define KDC_AUTH_EVENT_CLIENT_AUTHORIZED	1   /* all authn/authz checks passed */
+#define KDC_AUTH_EVENT_CLIENT_UNKNOWN	        2   /* client unknown */
+#define KDC_AUTH_EVENT_CLIENT_LOCKED_OUT	3   /* client locked out */
+#define KDC_AUTH_EVENT_CLIENT_TIME_SKEW		4   /* client time skew */
+#define KDC_AUTH_EVENT_WRONG_LONG_TERM_KEY	5   /* PA failed to validate long term key */
+#define KDC_AUTH_EVENT_VALIDATED_LONG_TERM_KEY	6   /* PA validated long term key */
+#define KDC_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED	7   /* couldn't map GSS/PKINIT name to principal */
+#define KDC_AUTH_EVENT_PREAUTH_FAILED		8   /* generic PA failure */
+#define KDC_AUTH_EVENT_PREAUTH_SUCCEEDED	9   /* generic (non-long term key) PA success */
+
+/*
+ * Audit keys to be queried using heim_audit_getkv(). There are other keys
+ * intended for logging that are not defined below; the constants below are
+ * there to ease migration from the older auth_status HDB API.
+ */
+
+#define KDC_REQUEST_KV_AUTH_EVENT		"#auth_event"		/* heim_number_t */
+#define KDC_REQUEST_KV_PA_NAME			"pa"			/* heim_string_t */
+#define KDC_REQUEST_KV_PA_ETYPE			"pa-etype"		/* heim_number_t */
+#define KDC_REQUEST_KV_GSS_INITIATOR		"gss_initiator"		/* heim_string_t */
+#define KDC_REQUEST_KV_PKINIT_CLIENT_CERT	"pkinit_client_cert"	/* heim_string_t */
+
+#endif /* HEIMDAL_KDC_KDC_AUDIT_H */

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -493,13 +493,13 @@ pa_pkinit_validate(astgs_request_t r, const PA_DATA *pa)
 
     ret = _kdc_pk_check_client(r, pkp, &client_cert);
     if (client_cert)
-	_kdc_audit_addkv((kdc_request_t)r, 0, HDB_REQUEST_KV_PKINIT_CLIENT_CERT,
+	_kdc_audit_addkv((kdc_request_t)r, 0, KDC_REQUEST_KV_PKINIT_CLIENT_CERT,
 			 "%s", client_cert);
     if (ret) {
 	_kdc_set_e_text(r, "PKINIT certificate not allowed to "
 			"impersonate principal");
-	_kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-				HDB_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED);
+	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+				KDC_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED);
 	goto out;
     }
 
@@ -518,8 +518,8 @@ pa_pkinit_validate(astgs_request_t r, const PA_DATA *pa)
     ret = _kdc_add_initial_verified_cas(r->context, r->config,
 					pkp, &r->et);
 
-    _kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-			    HDB_AUTH_EVENT_PREAUTH_SUCCEEDED);
+    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			    KDC_AUTH_EVENT_PREAUTH_SUCCEEDED);
 
  out:
     if (pkp)
@@ -546,13 +546,13 @@ pa_gss_validate(astgs_request_t r, const PA_DATA *pa)
     if (open) {
 	ret = _kdc_gss_check_client(r, gcp, &client_name);
 	if (client_name)
-	    _kdc_audit_addkv((kdc_request_t)r, 0, HDB_REQUEST_KV_GSS_INITIATOR,
+	    _kdc_audit_addkv((kdc_request_t)r, 0, KDC_REQUEST_KV_GSS_INITIATOR,
 			     "%s", client_name);
 	if (ret) {
 	    _kdc_set_e_text(r, "GSS-API client not allowed to "
 			    "impersonate principal");
-	    _kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-				    HDB_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED);
+	    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+				    KDC_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED);
 	    goto out;
 	}
 
@@ -560,8 +560,8 @@ pa_gss_validate(astgs_request_t r, const PA_DATA *pa)
 
 	_kdc_r_log(r, 4, "GSS pre-authentication succeeded -- %s using %s",
 		   r->cname, client_name);
-	_kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-				HDB_AUTH_EVENT_PREAUTH_SUCCEEDED);
+	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+				KDC_AUTH_EVENT_PREAUTH_SUCCEEDED);
 
 	ret = _kdc_gss_mk_composite_name_ad(r, gcp);
 	if (ret) {
@@ -625,8 +625,8 @@ pa_enc_chal_validate(astgs_request_t r, const PA_DATA *pa)
        ret = KRB5KDC_ERR_CLIENT_REVOKED;
        kdc_log(r->context, r->config, 0,
                "Client (%s) is locked out", r->cname);
-       _kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-			       HDB_AUTH_EVENT_CLIENT_LOCKED_OUT);
+       _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			       KDC_AUTH_EVENT_CLIENT_LOCKED_OUT);
        return ret;
     }
 
@@ -752,14 +752,14 @@ pa_enc_chal_validate(astgs_request_t r, const PA_DATA *pa)
 	/*
 	 * Success
 	 */
-	_kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-				HDB_AUTH_EVENT_VALIDATED_LONG_TERM_KEY);
+	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+				KDC_AUTH_EVENT_VALIDATED_LONG_TERM_KEY);
 	goto out;
     }
 
     if (invalidPassword) {
-	_kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-				HDB_AUTH_EVENT_WRONG_LONG_TERM_KEY);
+	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+				KDC_AUTH_EVENT_WRONG_LONG_TERM_KEY);
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;
     } else {
 	ret = KRB5KDC_ERR_ETYPE_NOSUPP;
@@ -798,8 +798,8 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
        ret = KRB5KDC_ERR_CLIENT_REVOKED;
        kdc_log(r->context, r->config, 0,
                "Client (%s) is locked out", r->cname);
-       _kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-			       HDB_AUTH_EVENT_CLIENT_LOCKED_OUT);
+       _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			       KDC_AUTH_EVENT_CLIENT_LOCKED_OUT);
        return ret;
     }
 
@@ -869,10 +869,10 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
 		   r->cname, str ? str : "unknown enctype", msg);
 	krb5_xfree(str);
 	krb5_free_error_message(r->context, msg);
-	_kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_PA_ETYPE,
+	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_PA_ETYPE,
 				pa_key->key.keytype);
-	_kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-				HDB_AUTH_EVENT_WRONG_LONG_TERM_KEY);
+	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+				KDC_AUTH_EVENT_WRONG_LONG_TERM_KEY);
 	if(hdb_next_enctype2key(r->context, &r->client->entry, NULL,
 				enc_data.etype, &pa_key) == 0)
 	    goto try_next_key;
@@ -907,8 +907,8 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
 		   (unsigned)labs(kdc_time - p.patimestamp),
 		   r->context->max_skew,
 		   r->cname);
-	_kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-				HDB_AUTH_EVENT_CLIENT_TIME_SKEW);
+	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+				KDC_AUTH_EVENT_CLIENT_TIME_SKEW);
 
 	/*
 	 * The following is needed to make windows clients to
@@ -933,10 +933,10 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
     _kdc_r_log(r, 4, "ENC-TS Pre-authentication succeeded -- %s using %s",
 	       r->cname, str ? str : "unknown enctype");
     krb5_xfree(str);
-    _kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_PA_ETYPE,
+    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_PA_ETYPE,
 			    pa_key->key.keytype);
-    _kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-			    HDB_AUTH_EVENT_VALIDATED_LONG_TERM_KEY);
+    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			    KDC_AUTH_EVENT_VALIDATED_LONG_TERM_KEY);
 
     ret = 0;
 
@@ -2174,8 +2174,8 @@ _kdc_as_rep(astgs_request_t r)
 	kdc_log(r->context, config, 4, "UNKNOWN -- %s: %s", r->cname, msg);
 	krb5_free_error_message(r->context, msg);
 	ret = KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN;
-	_kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-				HDB_AUTH_EVENT_CLIENT_UNKNOWN);
+	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+				KDC_AUTH_EVENT_CLIENT_UNKNOWN);
 	goto out;
     }
     }
@@ -2251,9 +2251,9 @@ _kdc_as_rep(astgs_request_t r)
 		    krb5_boolean default_salt;
 
 		    if (ret != KRB5_KDC_ERR_MORE_PREAUTH_DATA_REQUIRED &&
-			!_kdc_audit_getkv((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT))
-			_kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-						HDB_AUTH_EVENT_PREAUTH_FAILED);
+			!_kdc_audit_getkv((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT))
+			_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+						KDC_AUTH_EVENT_PREAUTH_FAILED);
 
 		    /*
 		     * If there is a client key, send ETYPE_INFO{,2}
@@ -2269,9 +2269,9 @@ _kdc_as_rep(astgs_request_t r)
 		    }
 		    goto out;
 		}
-		if (!_kdc_audit_getkv((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT))
-		    _kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-					    HDB_AUTH_EVENT_PREAUTH_SUCCEEDED);
+		if (!_kdc_audit_getkv((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT))
+		    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+					    KDC_AUTH_EVENT_PREAUTH_SUCCEEDED);
 		kdc_log(r->context, config, 4,
 			"%s pre-authentication succeeded -- %s",
 			pat[n].name, r->cname);
@@ -2367,8 +2367,8 @@ _kdc_as_rep(astgs_request_t r)
 	r->et.flags.anonymous = 1;
     }
 
-    _kdc_audit_setkv_number((kdc_request_t)r, HDB_REQUEST_KV_AUTH_EVENT,
-			    HDB_AUTH_EVENT_CLIENT_AUTHORIZED);
+    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			    KDC_AUTH_EVENT_CLIENT_AUTHORIZED);
 
     /*
      * Select the best encryption type for the KDC with out regard to

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -81,38 +81,8 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
 #define HDB_CAP_F_PASSWORD_UPDATE_KEYS	4
 #define HDB_CAP_F_SHARED_DIRECTORY      8
 
-/*
- * HDB auditing
- */
-
-/* auth event type enumeration, currently for AS only */
-#define HDB_AUTH_EVENT_INVALID			0   /* no event logged */
-#define HDB_AUTH_EVENT_CLIENT_AUTHORIZED	1   /* all authn/authz checks passed */
-#define HDB_AUTH_EVENT_CLIENT_UNKNOWN	        2   /* client unknown */
-#define HDB_AUTH_EVENT_CLIENT_LOCKED_OUT	3   /* client locked out */
-#define HDB_AUTH_EVENT_CLIENT_TIME_SKEW		4   /* client time skew */
-#define HDB_AUTH_EVENT_WRONG_LONG_TERM_KEY	5   /* PA failed to validate long term key */
-#define HDB_AUTH_EVENT_VALIDATED_LONG_TERM_KEY	6   /* PA validated long term key */
-#define HDB_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED	7   /* couldn't map GSS/PKINIT name to principal */
-#define HDB_AUTH_EVENT_PREAUTH_FAILED		8   /* generic PA failure */
-#define HDB_AUTH_EVENT_PREAUTH_SUCCEEDED	9   /* generic (non-long term key) PA success */
-
-/*
- * Audit keys to be queried using heim_audit_getkv(). There are other keys
- * intended for logging that are not defined below; the constants below are
- * there to ease migration from the older auth_status HDB API.
- */
-
-#define HDB_REQUEST_KV_AUTH_EVENT		"#auth_event"		/* heim_number_t */
-#define HDB_REQUEST_KV_PA_NAME			"pa"			/* heim_string_t */
-#define HDB_REQUEST_KV_PA_ETYPE			"pa-etype"		/* heim_number_t */
-#define HDB_REQUEST_KV_GSS_INITIATOR		"gss_initiator"		/* heim_string_t */
-#define HDB_REQUEST_KV_PKINIT_CLIENT_CERT	"pkinit_client_cert"	/* heim_string_t */
-
 #define heim_pcontext krb5_context
-#define heim_pconfig struct krb5_kdc_configuration *
-
-struct krb5_kdc_configuration;
+#define heim_pconfig void *
 
 typedef struct hdb_request_desc {
     HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;


### PR DESCRIPTION
Move KDC auth event macro definitions out of `hdb.h` and into a new KDC header, `kdc-audit.h`.