### PR TITLE
hcrypto: Fix return type for null_Init, null_Update and null_Final

### DIFF
--- a/lib/hcrypto/evp.c
+++ b/lib/hcrypto/evp.c
@@ -485,17 +485,20 @@ EVP_md2(void) HC_DEPRECATED_CRYPTO
  *
  */
 
-static void
+static int
 null_Init (void *m)
 {
+    return 1;
 }
-static void
+static int
 null_Update (void *m, const void * data, size_t size)
 {
+    return 1;
 }
-static void
+static int
 null_Final(void *res, void *m)
 {
+    return 1;
 }
 
 /**


### PR DESCRIPTION
The hc_evp_md_init, hc_evp_md_update and hc_evp_md_final typedefs
are defined as functions returning an int, but null_Init, null_Update
and null_Final are defined as void, and cast with the typedef when
assigned to the function vector.

This might result in some uninitialized value being returned to the
caller, if some of them make use of the return value.  It also causes
warnings if the -Wcast-function-type warning is enabled.

Change the type to in to match the typedef, and return 1 (success).