### PR TITLE
kdc: make auditing API public

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -596,8 +596,8 @@ fast_unwrap_request(astgs_request_t r,
 				&r->armor_ticket->ticket,
 				armor_server_principal_name);
 	if (ret) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-				 "Armor TGT expired or invalid");
+	    kdc_audit_addreason((kdc_request_t)r,
+				"Armor TGT expired or invalid");
 	    goto out;
 	}
 	ticket = r->armor_ticket;
@@ -608,8 +608,8 @@ fast_unwrap_request(astgs_request_t r,
     }
 
     krb5_unparse_name(r->context, ticket->client, &armor_client_principal_name);
-    _kdc_audit_addkv((kdc_request_t)r, 0, "armor_client_name", "%s",
-		      armor_client_principal_name ? armor_client_principal_name : "<unknown>");
+    kdc_audit_addkv((kdc_request_t)r, 0, "armor_client_name", "%s",
+		    armor_client_principal_name ? armor_client_principal_name : "<unknown>");
 
     if (ac->remote_subkey == NULL) {
 	krb5_auth_con_free(r->context, ac);

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -459,13 +459,13 @@ _kdc_log_timestamp(astgs_request_t r, const char *type,
 	endtime_str[100], renewtime_str[100];
 
     if (authtime)
-	_kdc_audit_setkv_number((kdc_request_t)r, "auth", authtime);
+	kdc_audit_setkv_number((kdc_request_t)r, "auth", authtime);
     if (starttime && *starttime)
-	_kdc_audit_setkv_number((kdc_request_t)r, "start", *starttime);
+	kdc_audit_setkv_number((kdc_request_t)r, "start", *starttime);
     if (endtime)
-	_kdc_audit_setkv_number((kdc_request_t)r, "end", endtime);
+	kdc_audit_setkv_number((kdc_request_t)r, "end", endtime);
     if (renew_till && *renew_till)
-	_kdc_audit_setkv_number((kdc_request_t)r, "renew", *renew_till);
+	kdc_audit_setkv_number((kdc_request_t)r, "renew", *renew_till);
 
     krb5_format_time(r->context, authtime,
 		     authtime_str, sizeof(authtime_str), TRUE);
@@ -510,13 +510,13 @@ pa_pkinit_validate(astgs_request_t r, const PA_DATA *pa)
 
     ret = _kdc_pk_check_client(r, pkp, &client_cert);
     if (client_cert)
-	_kdc_audit_addkv((kdc_request_t)r, 0, KDC_REQUEST_KV_PKINIT_CLIENT_CERT,
-			 "%s", client_cert);
+	kdc_audit_addkv((kdc_request_t)r, 0, KDC_REQUEST_KV_PKINIT_CLIENT_CERT,
+			"%s", client_cert);
     if (ret) {
 	_kdc_set_e_text(r, "PKINIT certificate not allowed to "
 			"impersonate principal");
-	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-				KDC_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED);
+	kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			       KDC_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED);
 	goto out;
     }
 
@@ -535,8 +535,8 @@ pa_pkinit_validate(astgs_request_t r, const PA_DATA *pa)
     ret = _kdc_add_initial_verified_cas(r->context, r->config,
 					pkp, &r->et);
 
-    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-			    KDC_AUTH_EVENT_PREAUTH_SUCCEEDED);
+    kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			   KDC_AUTH_EVENT_PREAUTH_SUCCEEDED);
 
  out:
     if (pkp)
@@ -563,13 +563,13 @@ pa_gss_validate(astgs_request_t r, const PA_DATA *pa)
     if (open) {
 	ret = _kdc_gss_check_client(r, gcp, &client_name);
 	if (client_name)
-	    _kdc_audit_addkv((kdc_request_t)r, 0, KDC_REQUEST_KV_GSS_INITIATOR,
-			     "%s", client_name);
+	    kdc_audit_addkv((kdc_request_t)r, 0, KDC_REQUEST_KV_GSS_INITIATOR,
+			    "%s", client_name);
 	if (ret) {
 	    _kdc_set_e_text(r, "GSS-API client not allowed to "
 			    "impersonate principal");
-	    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-				    KDC_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED);
+	    kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+				   KDC_AUTH_EVENT_CLIENT_NAME_UNAUTHORIZED);
 	    goto out;
 	}
 
@@ -577,8 +577,8 @@ pa_gss_validate(astgs_request_t r, const PA_DATA *pa)
 
 	_kdc_r_log(r, 4, "GSS pre-authentication succeeded -- %s using %s",
 		   r->cname, client_name);
-	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-				KDC_AUTH_EVENT_PREAUTH_SUCCEEDED);
+	kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			       KDC_AUTH_EVENT_PREAUTH_SUCCEEDED);
 
 	ret = _kdc_gss_mk_composite_name_ad(r, gcp);
 	if (ret) {
@@ -642,8 +642,8 @@ pa_enc_chal_validate(astgs_request_t r, const PA_DATA *pa)
        ret = KRB5KDC_ERR_CLIENT_REVOKED;
        kdc_log(r->context, r->config, 0,
                "Client (%s) is locked out", r->cname);
-       _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-			       KDC_AUTH_EVENT_CLIENT_LOCKED_OUT);
+       kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			      KDC_AUTH_EVENT_CLIENT_LOCKED_OUT);
        return ret;
     }
 
@@ -769,14 +769,14 @@ pa_enc_chal_validate(astgs_request_t r, const PA_DATA *pa)
 	/*
 	 * Success
 	 */
-	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-				KDC_AUTH_EVENT_VALIDATED_LONG_TERM_KEY);
+	kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			       KDC_AUTH_EVENT_VALIDATED_LONG_TERM_KEY);
 	goto out;
     }
 
     if (invalidPassword) {
-	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-				KDC_AUTH_EVENT_WRONG_LONG_TERM_KEY);
+	kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			       KDC_AUTH_EVENT_WRONG_LONG_TERM_KEY);
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;
     } else {
 	ret = KRB5KDC_ERR_ETYPE_NOSUPP;
@@ -815,8 +815,8 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
        ret = KRB5KDC_ERR_CLIENT_REVOKED;
        kdc_log(r->context, r->config, 0,
                "Client (%s) is locked out", r->cname);
-       _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-			       KDC_AUTH_EVENT_CLIENT_LOCKED_OUT);
+       kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			      KDC_AUTH_EVENT_CLIENT_LOCKED_OUT);
        return ret;
     }
 
@@ -886,10 +886,10 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
 		   r->cname, str ? str : "unknown enctype", msg);
 	krb5_xfree(str);
 	krb5_free_error_message(r->context, msg);
-	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_PA_ETYPE,
-				pa_key->key.keytype);
-	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-				KDC_AUTH_EVENT_WRONG_LONG_TERM_KEY);
+	kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_PA_ETYPE,
+			       pa_key->key.keytype);
+	kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			       KDC_AUTH_EVENT_WRONG_LONG_TERM_KEY);
 	if(hdb_next_enctype2key(r->context, r->client, NULL,
 				enc_data.etype, &pa_key) == 0)
 	    goto try_next_key;
@@ -924,8 +924,8 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
 		   (unsigned)labs(kdc_time - p.patimestamp),
 		   r->context->max_skew,
 		   r->cname);
-	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-				KDC_AUTH_EVENT_CLIENT_TIME_SKEW);
+	kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			       KDC_AUTH_EVENT_CLIENT_TIME_SKEW);
 
 	/*
 	 * The following is needed to make windows clients to
@@ -950,10 +950,10 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
     _kdc_r_log(r, 4, "ENC-TS Pre-authentication succeeded -- %s using %s",
 	       r->cname, str ? str : "unknown enctype");
     krb5_xfree(str);
-    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_PA_ETYPE,
-			    pa_key->key.keytype);
-    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-			    KDC_AUTH_EVENT_VALIDATED_LONG_TERM_KEY);
+    kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_PA_ETYPE,
+			   pa_key->key.keytype);
+    kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			   KDC_AUTH_EVENT_VALIDATED_LONG_TERM_KEY);
 
     ret = 0;
 
@@ -1047,8 +1047,8 @@ log_patypes(astgs_request_t r, METHOD_DATA *padata)
 
     str = rk_strpoolcollect(p);
     kdc_log(r->context, config, 4, "Client sent patypes: %s", str);
-    _kdc_audit_addkv((kdc_request_t)r, KDC_AUDIT_EATWHITE,
-		     "client-pa", "%s", str);
+    kdc_audit_addkv((kdc_request_t)r, KDC_AUDIT_EATWHITE,
+		    "client-pa", "%s", str);
     free(str);
 }
 
@@ -1586,8 +1586,8 @@ _log_astgs_req(astgs_request_t r, krb5_enctype setype)
 
     str = rk_strpoolcollect(s);
     if (str)
-        _kdc_audit_addkv((kdc_request_t)r, KDC_AUDIT_EATWHITE, "etypes", "%s",
-                         str);
+        kdc_audit_addkv((kdc_request_t)r, KDC_AUDIT_EATWHITE, "etypes", "%s",
+                        str);
     free(str);
 
     ret = krb5_enctype_to_string(r->context, cetype, &cet);
@@ -1608,7 +1608,7 @@ _log_astgs_req(astgs_request_t r, krb5_enctype setype)
 	_kdc_r_log(r, 4, "%s", str);
     free(str);
 
-    _kdc_audit_addkv((kdc_request_t)r, 0, "etype", "%d/%d", cetype, setype);
+    kdc_audit_addkv((kdc_request_t)r, 0, "etype", "%d/%d", cetype, setype);
 
     {
 	char fixedstr[128];
@@ -1618,8 +1618,8 @@ _log_astgs_req(astgs_request_t r, krb5_enctype setype)
 			       fixedstr, sizeof(fixedstr));
 	if (result > 0) {
 	    _kdc_r_log(r, 4, "Requested flags: %s", fixedstr);
-	    _kdc_audit_addkv((kdc_request_t)r, KDC_AUDIT_EATWHITE,
-			     "flags", "%s", fixedstr);
+	    kdc_audit_addkv((kdc_request_t)r, KDC_AUDIT_EATWHITE,
+			    "flags", "%s", fixedstr);
 	}
     }
 }
@@ -1639,19 +1639,19 @@ kdc_check_flags(astgs_request_t r,
     if (client != NULL) {
 	/* check client */
 	if (client->flags.locked_out) {
-	    _kdc_audit_addreason((kdc_request_t)r, "Client is locked out");
+	    kdc_audit_addreason((kdc_request_t)r, "Client is locked out");
 	    return KRB5KDC_ERR_CLIENT_REVOKED;
 	}
 
 	if (client->flags.invalid) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Client has invalid bit set");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Client has invalid bit set");
 	    return KRB5KDC_ERR_POLICY;
 	}
 
 	if (!client->flags.client) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Principal may not act as client");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Principal may not act as client");
 	    return KRB5KDC_ERR_POLICY;
 	}
 
@@ -1659,8 +1659,8 @@ kdc_check_flags(astgs_request_t r,
 	    char starttime_str[100];
 	    krb5_format_time(r->context, *client->valid_start,
 			     starttime_str, sizeof(starttime_str), TRUE);
-	    _kdc_audit_addreason((kdc_request_t)r, "Client not yet valid "
-                                 "until %s", starttime_str);
+	    kdc_audit_addreason((kdc_request_t)r, "Client not yet valid "
+                                "until %s", starttime_str);
 	    return KRB5KDC_ERR_CLIENT_NOTYET;
 	}
 
@@ -1668,8 +1668,8 @@ kdc_check_flags(astgs_request_t r,
 	    char endtime_str[100];
 	    krb5_format_time(r->context, *client->valid_end,
 			     endtime_str, sizeof(endtime_str), TRUE);
-	    _kdc_audit_addreason((kdc_request_t)r, "Client expired at %s",
-                                 endtime_str);
+	    kdc_audit_addreason((kdc_request_t)r, "Client expired at %s",
+                                endtime_str);
 	    return  KRB5KDC_ERR_NAME_EXP;
 	}
 
@@ -1682,8 +1682,8 @@ kdc_check_flags(astgs_request_t r,
 	    char pwend_str[100];
 	    krb5_format_time(r->context, *client->pw_end,
 			     pwend_str, sizeof(pwend_str), TRUE);
-	    _kdc_audit_addreason((kdc_request_t)r, "Client's key has expired "
-                                 "at %s", pwend_str);
+	    kdc_audit_addreason((kdc_request_t)r, "Client's key has expired "
+                                "at %s", pwend_str);
 	    return KRB5KDC_ERR_KEY_EXPIRED;
 	}
     }
@@ -1692,23 +1692,23 @@ kdc_check_flags(astgs_request_t r,
 
     if (server != NULL) {
 	if (server->flags.locked_out) {
-	    _kdc_audit_addreason((kdc_request_t)r, "Server locked out");
+	    kdc_audit_addreason((kdc_request_t)r, "Server locked out");
 	    return KRB5KDC_ERR_SERVICE_REVOKED;
 	}
 	if (server->flags.invalid) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Server has invalid flag set");
+	    kdc_audit_addreason((kdc_request_t)r,
+				"Server has invalid flag set");
 	    return KRB5KDC_ERR_POLICY;
 	}
 	if (!server->flags.server) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Principal may not act as server");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Principal may not act as server");
 	    return KRB5KDC_ERR_POLICY;
 	}
 
 	if (!is_as_req && server->flags.initial) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "AS-REQ is required for server");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "AS-REQ is required for server");
 	    return KRB5KDC_ERR_POLICY;
 	}
 
@@ -1716,8 +1716,8 @@ kdc_check_flags(astgs_request_t r,
 	    char starttime_str[100];
 	    krb5_format_time(r->context, *server->valid_start,
 			     starttime_str, sizeof(starttime_str), TRUE);
-	    _kdc_audit_addreason((kdc_request_t)r, "Server not yet valid "
-                                 "until %s", starttime_str);
+	    kdc_audit_addreason((kdc_request_t)r, "Server not yet valid "
+                                "until %s", starttime_str);
 	    return KRB5KDC_ERR_SERVICE_NOTYET;
 	}
 
@@ -1725,8 +1725,8 @@ kdc_check_flags(astgs_request_t r,
 	    char endtime_str[100];
 	    krb5_format_time(r->context, *server->valid_end,
 			     endtime_str, sizeof(endtime_str), TRUE);
-	    _kdc_audit_addreason((kdc_request_t)r, "Server expired at %s",
-                                 endtime_str);
+	    kdc_audit_addreason((kdc_request_t)r, "Server expired at %s",
+                                endtime_str);
 	    return KRB5KDC_ERR_SERVICE_EXP;
 	}
 
@@ -1734,8 +1734,8 @@ kdc_check_flags(astgs_request_t r,
 	    char pwend_str[100];
 	    krb5_format_time(r->context, *server->pw_end,
 			     pwend_str, sizeof(pwend_str), TRUE);
-	    _kdc_audit_addreason((kdc_request_t)r, "Server's key has expired "
-                                 "at %s", pwend_str);
+	    kdc_audit_addreason((kdc_request_t)r, "Server's key has expired "
+                                "at %s", pwend_str);
 	    return KRB5KDC_ERR_KEY_EXPIRED;
 	}
     }
@@ -1801,8 +1801,8 @@ krb5_error_code
 _kdc_check_anon_policy(astgs_request_t r)
 {
     if (!r->config->allow_anonymous) {
-	_kdc_audit_addreason((kdc_request_t)r,
-                             "Anonymous tickets denied by local policy");
+	kdc_audit_addreason((kdc_request_t)r,
+                            "Anonymous tickets denied by local policy");
 	return KRB5KDC_ERR_POLICY;
     }
 
@@ -1854,8 +1854,8 @@ generate_pac(astgs_request_t r, const Key *skey, const Key *tkey,
     krb5_const_principal canon_princ = NULL;
 
     r->pac_attributes = get_pac_attributes(r->context, &r->req);
-    _kdc_audit_setkv_number((kdc_request_t)r, "pac_attributes",
-			    r->pac_attributes);
+    kdc_audit_setkv_number((kdc_request_t)r, "pac_attributes",
+			   r->pac_attributes);
 
     if (!_kdc_include_pac_p(r))
 	return 0;
@@ -1903,8 +1903,8 @@ generate_pac(astgs_request_t r, const Key *skey, const Key *tkey,
 	canon_princ = r->canon_client_princ;
 
 	(void) krb5_unparse_name(r->context, canon_princ, &cpn);
-	_kdc_audit_addkv((kdc_request_t)r, 0, "canon_client_name", "%s",
-			     cpn ? cpn : "<unknown>");
+	kdc_audit_addkv((kdc_request_t)r, 0, "canon_client_name", "%s",
+			cpn ? cpn : "<unknown>");
 	krb5_xfree(cpn);
     }
 
@@ -2193,8 +2193,8 @@ _kdc_as_rep(astgs_request_t r)
 	kdc_log(r->context, config, 4, "UNKNOWN -- %s: %s", r->cname, msg);
 	krb5_free_error_message(r->context, msg);
 	ret = KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN;
-	_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-				KDC_AUTH_EVENT_CLIENT_UNKNOWN);
+	kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			       KDC_AUTH_EVENT_CLIENT_UNKNOWN);
 	goto out;
     }
     }
@@ -2261,8 +2261,8 @@ _kdc_as_rep(astgs_request_t r)
                     ret = KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN;
                     goto out;
                 }
-		_kdc_audit_addkv((kdc_request_t)r, KDC_AUDIT_VIS, "pa", "%s",
-				 pat[n].name);
+		kdc_audit_addkv((kdc_request_t)r, KDC_AUDIT_VIS, "pa", "%s",
+				pat[n].name);
 		ret = pat[n].validate(r, pa);
 		if (ret != 0) {
 		    krb5_error_code  ret2;
@@ -2270,9 +2270,9 @@ _kdc_as_rep(astgs_request_t r)
 		    krb5_boolean default_salt;
 
 		    if (ret != KRB5_KDC_ERR_MORE_PREAUTH_DATA_REQUIRED &&
-			!_kdc_audit_getkv((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT))
-			_kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-						KDC_AUTH_EVENT_PREAUTH_FAILED);
+			!kdc_audit_getkv((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT))
+			kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+					       KDC_AUTH_EVENT_PREAUTH_FAILED);
 
 		    /*
 		     * If there is a client key, send ETYPE_INFO{,2}
@@ -2288,9 +2288,9 @@ _kdc_as_rep(astgs_request_t r)
 		    }
 		    goto out;
 		}
-		if (!_kdc_audit_getkv((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT))
-		    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-					    KDC_AUTH_EVENT_PREAUTH_SUCCEEDED);
+		if (!kdc_audit_getkv((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT))
+		    kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+					   KDC_AUTH_EVENT_PREAUTH_SUCCEEDED);
 		kdc_log(r->context, config, 4,
 			"%s pre-authentication succeeded -- %s",
 			pat[n].name, r->cname);
@@ -2386,8 +2386,8 @@ _kdc_as_rep(astgs_request_t r)
 	r->et.flags.anonymous = 1;
     }
 
-    _kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
-			    KDC_AUTH_EVENT_CLIENT_AUTHORIZED);
+    kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,
+			   KDC_AUTH_EVENT_CLIENT_AUTHORIZED);
 
     /*
      * Select the best encryption type for the KDC with out regard to
@@ -2486,12 +2486,12 @@ _kdc_as_rep(astgs_request_t r)
     }
 
     if (b->addresses)
-        _kdc_audit_addaddrs((kdc_request_t)r, b->addresses, "reqaddrs");
+        kdc_audit_addaddrs((kdc_request_t)r, b->addresses, "reqaddrs");
 
     /* check for valid set of addresses */
     if (!_kdc_check_addresses(r, b->addresses, r->addr)) {
         if (r->config->warn_ticket_addresses) {
-            _kdc_audit_setkv_bool((kdc_request_t)r, "wrongaddr", TRUE);
+            kdc_audit_setkv_bool((kdc_request_t)r, "wrongaddr", TRUE);
         } else {
             _kdc_set_e_text(r, "Request from wrong address");
             ret = KRB5KRB_AP_ERR_BADADDR;

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -211,35 +211,35 @@ check_tgs_flags(astgs_request_t r, KDC_REQ_BODY *b,
 
     if(f.validate){
 	if (!tgt->flags.invalid || tgt->starttime == NULL) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Bad request to validate ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Bad request to validate ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	if(*tgt->starttime > kdc_time){
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Early request to validate ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Early request to validate ticket");
 	    return KRB5KRB_AP_ERR_TKT_NYV;
 	}
 	/* XXX  tkt = tgt */
 	et->flags.invalid = 0;
     } else if (tgt->flags.invalid) {
-	_kdc_audit_addreason((kdc_request_t)r,
-                             "Ticket-granting ticket has INVALID flag set");
+	kdc_audit_addreason((kdc_request_t)r,
+                            "Ticket-granting ticket has INVALID flag set");
 	return KRB5KRB_AP_ERR_TKT_INVALID;
     }
 
     if(f.forwardable){
 	if (!tgt->flags.forwardable) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Bad request for forwardable ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Bad request for forwardable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	et->flags.forwardable = 1;
     }
     if(f.forwarded){
 	if (!tgt->flags.forwardable) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Request to forward non-forwardable ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Request to forward non-forwardable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	et->flags.forwarded = 1;
@@ -250,16 +250,16 @@ check_tgs_flags(astgs_request_t r, KDC_REQ_BODY *b,
 
     if(f.proxiable){
 	if (!tgt->flags.proxiable) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Bad request for proxiable ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Bad request for proxiable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	et->flags.proxiable = 1;
     }
     if(f.proxy){
 	if (!tgt->flags.proxiable) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Request to proxy non-proxiable ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Request to proxy non-proxiable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	et->flags.proxy = 1;
@@ -270,16 +270,16 @@ check_tgs_flags(astgs_request_t r, KDC_REQ_BODY *b,
 
     if(f.allow_postdate){
 	if (!tgt->flags.may_postdate) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Bad request for post-datable ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Bad request for post-datable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	et->flags.may_postdate = 1;
     }
     if(f.postdated){
 	if (!tgt->flags.may_postdate) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Bad request for postdated ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Bad request for postdated ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	if(b->from)
@@ -287,15 +287,15 @@ check_tgs_flags(astgs_request_t r, KDC_REQ_BODY *b,
 	et->flags.postdated = 1;
 	et->flags.invalid = 1;
     } else if (b->from && *b->from > kdc_time + r->context->max_skew) {
-	_kdc_audit_addreason((kdc_request_t)r,
-                             "Ticket cannot be postdated");
+	kdc_audit_addreason((kdc_request_t)r,
+                            "Ticket cannot be postdated");
 	return KRB5KDC_ERR_CANNOT_POSTDATE;
     }
 
     if(f.renewable){
 	if (!tgt->flags.renewable || tgt->renew_till == NULL) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Bad request for renewable ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Bad request for renewable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	et->flags.renewable = 1;
@@ -306,8 +306,8 @@ check_tgs_flags(astgs_request_t r, KDC_REQ_BODY *b,
     if(f.renew){
 	time_t old_life;
 	if (!tgt->flags.renewable || tgt->renew_till == NULL) {
-	    _kdc_audit_addreason((kdc_request_t)r,
-                                 "Request to renew non-renewable ticket");
+	    kdc_audit_addreason((kdc_request_t)r,
+                                "Request to renew non-renewable ticket");
 	    return KRB5KDC_ERR_BADOPTION;
 	}
 	old_life = tgt->endtime;
@@ -326,8 +326,8 @@ check_tgs_flags(astgs_request_t r, KDC_REQ_BODY *b,
      */
     if (tgt->flags.anonymous &&
 	!_kdc_is_anonymous(r->context, tgt_name)) {
-	_kdc_audit_addreason((kdc_request_t)r,
-                             "Anonymous ticket flag set without "
+	kdc_audit_addreason((kdc_request_t)r,
+                            "Anonymous ticket flag set without "
 			 "anonymous principal");
 	return KRB5KDC_ERR_BADOPTION;
     }
@@ -740,8 +740,8 @@ tgs_make_reply(astgs_request_t r,
 	char *cpn;
 
 	(void) krb5_unparse_name(r->context, r->canon_client_princ, &cpn);
-	_kdc_audit_addkv((kdc_request_t)r, 0, "canon_client_name", "%s",
-			 cpn ? cpn : "<unknown>");
+	kdc_audit_addkv((kdc_request_t)r, 0, "canon_client_name", "%s",
+			cpn ? cpn : "<unknown>");
 	krb5_xfree(cpn);
     }
 
@@ -752,8 +752,8 @@ tgs_make_reply(astgs_request_t r,
      * is implementation dependent.
      */
     if (r->pac && !et->flags.anonymous) {
-	_kdc_audit_setkv_number((kdc_request_t)r, "pac_attributes",
-			        r->pac_attributes);
+	kdc_audit_setkv_number((kdc_request_t)r, "pac_attributes",
+			       r->pac_attributes);
 
 	/*
 	 * PACs are included when issuing TGTs, if there is no PAC_ATTRIBUTES
@@ -1059,10 +1059,10 @@ next_kvno:
 			      &r->ticket,
 			      KRB5_KU_TGS_REQ_AUTH);
     if (r->ticket && r->ticket->ticket.caddr)
-        _kdc_audit_addaddrs((kdc_request_t)r, r->ticket->ticket.caddr, "tixaddrs");
+        kdc_audit_addaddrs((kdc_request_t)r, r->ticket->ticket.caddr, "tixaddrs");
     if (r->config->warn_ticket_addresses && ret == KRB5KRB_AP_ERR_BADADDR &&
         r->ticket != NULL) {
-        _kdc_audit_setkv_bool((kdc_request_t)r, "wrongaddr", TRUE);
+        kdc_audit_setkv_bool((kdc_request_t)r, "wrongaddr", TRUE);
         ret = 0;
     }
     if (ret == KRB5KRB_AP_ERR_BAD_INTEGRITY && kvno_search_tries > 0) {
@@ -1454,7 +1454,7 @@ server_lookup:
     priv->serverdb = serverdb;
     if (ret == HDB_ERR_NOT_FOUND_HERE) {
 	kdc_log(context, config, 5, "target %s does not have secrets at this KDC, need to proxy", spn);
-        _kdc_audit_addreason((kdc_request_t)priv, "Target not found here");
+        kdc_audit_addreason((kdc_request_t)priv, "Target not found here");
 	goto out;
     } else if (ret == HDB_ERR_WRONG_REALM) {
         free(ref_realm);
@@ -1505,8 +1505,8 @@ server_lookup:
                                          req_rlm, TRUE, &capath, &num_capath);
                 if (ret2) {
                     ret = ret2;
-                    _kdc_audit_addreason((kdc_request_t)priv,
-                                         "No trusted path from client realm to ours");
+                    kdc_audit_addreason((kdc_request_t)priv,
+                                        "No trusted path from client realm to ours");
                     goto out;
                 }
             }
@@ -1568,8 +1568,8 @@ server_lookup:
 	krb5_free_error_message(context, msg);
 	if (ret == HDB_ERR_NOENTRY)
 	    ret = KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN;
-        _kdc_audit_addreason((kdc_request_t)priv,
-                             "Service principal unknown");
+        kdc_audit_addreason((kdc_request_t)priv,
+                            "Service principal unknown");
 	goto out;
     }
 
@@ -1649,16 +1649,16 @@ server_lookup:
 		ret = KRB5KDC_ERR_BADOPTION; /* ? */
 		kdc_log(context, config, 4,
 			"No second ticket present in user-to-user request");
-		_kdc_audit_addreason((kdc_request_t)priv,
-				     "No second ticket present in user-to-user request");
+		kdc_audit_addreason((kdc_request_t)priv,
+				    "No second ticket present in user-to-user request");
 		goto out;
 	    }
 	    t = &b->additional_tickets->val[0];
 	    if(!get_krbtgt_realm(&t->sname)){
 		kdc_log(context, config, 4,
 			"Additional ticket is not a ticket-granting ticket");
-		_kdc_audit_addreason((kdc_request_t)priv,
-				     "Additional ticket is not a ticket-granting ticket");
+		kdc_audit_addreason((kdc_request_t)priv,
+				    "Additional ticket is not a ticket-granting ticket");
 		ret = KRB5KDC_ERR_POLICY;
 		goto out;
 	    }
@@ -1680,8 +1680,8 @@ server_lookup:
 	    if(ret){
 		if (ret == HDB_ERR_NOENTRY)
 		    ret = KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN;
-		_kdc_audit_addreason((kdc_request_t)priv,
-				     "User-to-user service principal (TGS) unknown");
+		kdc_audit_addreason((kdc_request_t)priv,
+				    "User-to-user service principal (TGS) unknown");
 		krb5_xfree(tpn);
 		goto out;
 	    }
@@ -1689,23 +1689,23 @@ server_lookup:
 				  t->enc_part.etype, &uukey);
 	    if(ret){
 		ret = KRB5KDC_ERR_ETYPE_NOSUPP; /* XXX */
-		_kdc_audit_addreason((kdc_request_t)priv,
-				     "User-to-user enctype not supported");
+		kdc_audit_addreason((kdc_request_t)priv,
+				    "User-to-user enctype not supported");
 		krb5_xfree(tpn);
 		goto out;
 	    }
 	    ret = krb5_decrypt_ticket(context, t, &uukey->key, &adtkt, 0);
 	    if(ret) {
-		_kdc_audit_addreason((kdc_request_t)priv,
-				     "User-to-user TGT decrypt failure");
+		kdc_audit_addreason((kdc_request_t)priv,
+				    "User-to-user TGT decrypt failure");
 		krb5_xfree(tpn);
 		goto out;
 	    }
 
 	    ret = _kdc_verify_flags(context, config, &adtkt, tpn);
 	    if (ret) {
-		_kdc_audit_addreason((kdc_request_t)priv,
-				     "User-to-user TGT expired or invalid");
+		kdc_audit_addreason((kdc_request_t)priv,
+				    "User-to-user TGT expired or invalid");
 		krb5_xfree(tpn);
 		goto out;
 	    }
@@ -1803,8 +1803,8 @@ server_lookup:
 			"Addition ticket have not matching etypes");
 		krb5_clear_error_message(context);
 		ret = KRB5KDC_ERR_ETYPE_NOSUPP;
-                _kdc_audit_addreason((kdc_request_t)priv,
-                                     "No matching enctypes for 2nd ticket");
+                kdc_audit_addreason((kdc_request_t)priv,
+                                    "No matching enctypes for 2nd ticket");
 		goto out;
 	    }
 	    etype = b->etype.val[i];
@@ -1819,8 +1819,8 @@ server_lookup:
 	    if(ret) {
 		kdc_log(context, config, 4,
 			"Server (%s) has no support for etypes", spn);
-                _kdc_audit_addreason((kdc_request_t)priv,
-                                     "Enctype not supported");
+                kdc_audit_addreason((kdc_request_t)priv,
+                                    "Enctype not supported");
 		goto out;
 	    }
 	    ret = _kdc_get_preferred_key(context, config, server, spn,
@@ -1828,8 +1828,8 @@ server_lookup:
 	    if(ret) {
 		kdc_log(context, config, 4,
 			"Server (%s) has no supported etypes", spn);
-                _kdc_audit_addreason((kdc_request_t)priv,
-                                     "Enctype not supported");
+                kdc_audit_addreason((kdc_request_t)priv,
+                                    "Enctype not supported");
 		goto out;
 	    }
 	    ekey = &skey->key;
@@ -1864,7 +1864,7 @@ server_lookup:
 	if(ret == 0)
 	    free(ktpn);
 	ret = KRB5KRB_AP_ERR_NOT_US;
-        _kdc_audit_addreason((kdc_request_t)priv, "Request with wrong TGT");
+        kdc_audit_addreason((kdc_request_t)priv, "Request with wrong TGT");
 	goto out;
     }
 
@@ -1873,8 +1873,8 @@ server_lookup:
     if (ret) {
 	kdc_log(context, config, 4,
 		    "Failed to find key for krbtgt PAC signature");
-        _kdc_audit_addreason((kdc_request_t)priv,
-                             "Failed to find key for krbtgt PAC signature");
+        kdc_audit_addreason((kdc_request_t)priv,
+                            "Failed to find key for krbtgt PAC signature");
 	goto out;
     }
     ret = hdb_enctype2key(context, krbtgt_out, NULL,
@@ -1882,8 +1882,8 @@ server_lookup:
     if(ret) {
 	kdc_log(context, config, 4,
 		    "Failed to find key for krbtgt PAC signature");
-        _kdc_audit_addreason((kdc_request_t)priv,
-                             "Failed to find key for krbtgt PAC signature");
+        kdc_audit_addreason((kdc_request_t)priv,
+                            "Failed to find key for krbtgt PAC signature");
 	goto out;
     }
 
@@ -1906,7 +1906,7 @@ server_lookup:
 			 &priv->pac_attributes);
     if (ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-        _kdc_audit_addreason((kdc_request_t)priv, "PAC check failed");
+        kdc_audit_addreason((kdc_request_t)priv, "PAC check failed");
 	kdc_log(context, config, 4,
 		"Verify PAC failed for %s (%s) from %s with %s",
 		spn, cpn, from, msg);
@@ -1938,7 +1938,7 @@ server_lookup:
        !krb5_principal_compare(context,
 			       priv->krbtgt->principal,
 			       priv->server->principal)){
-        _kdc_audit_addreason((kdc_request_t)priv, "Inconsistent request");
+        kdc_audit_addreason((kdc_request_t)priv, "Inconsistent request");
 	kdc_log(context, config, 4, "Inconsistent request.");
 	ret = KRB5KDC_ERR_SERVER_NOMATCH;
 	goto out;
@@ -1948,12 +1948,12 @@ server_lookup:
     if (!_kdc_check_addresses(priv, tgt->caddr, from_addr)) {
         if (config->check_ticket_addresses) {
             ret = KRB5KRB_AP_ERR_BADADDR;
-            _kdc_audit_setkv_bool((kdc_request_t)priv, "wrongaddr", TRUE);
+            kdc_audit_setkv_bool((kdc_request_t)priv, "wrongaddr", TRUE);
             kdc_log(context, config, 4, "Request from wrong address");
-            _kdc_audit_addreason((kdc_request_t)priv, "Request from wrong address");
+            kdc_audit_addreason((kdc_request_t)priv, "Request from wrong address");
             goto out;
         } else if (config->warn_ticket_addresses) {
-            _kdc_audit_setkv_bool((kdc_request_t)priv, "wrongaddr", TRUE);
+            kdc_audit_setkv_bool((kdc_request_t)priv, "wrongaddr", TRUE);
         }
     }
 
@@ -1983,7 +1983,7 @@ server_lookup:
 				    NULL, s, &pa.padata_value);
 	krb5_crypto_destroy(context, crypto);
 	if (ret) {
-            _kdc_audit_addreason((kdc_request_t)priv, "Referral build failed");
+            kdc_audit_addreason((kdc_request_t)priv, "Referral build failed");
 	    kdc_log(context, config, 4,
 		    "Failed building server referral");
 	    goto out;

--- a/kdc/libkdc-exports.def
+++ b/kdc/libkdc-exports.def
@@ -21,19 +21,19 @@ EXPORTS
 	kdc_request_get_attribute
 	kdc_request_copy_attribute
 	kdc_request_delete_attribute
-	_kdc_audit_addkv
-	_kdc_audit_addkv_number
-	_kdc_audit_addkv_object
-	_kdc_audit_addkv_timediff
-	_kdc_audit_addaddrs
-	_kdc_audit_addreason
-	_kdc_audit_getkv
-	_kdc_audit_setkv_bool
-	_kdc_audit_setkv_number
-	_kdc_audit_setkv_object
+	kdc_audit_addkv
+	kdc_audit_addkv_number
+	kdc_audit_addkv_object
+	kdc_audit_addkv_timediff
+	kdc_audit_addaddrs
+	kdc_audit_addreason
+	kdc_audit_getkv
+	kdc_audit_setkv_bool
+	kdc_audit_setkv_number
+	kdc_audit_setkv_object
+	kdc_audit_vaddkv
+	kdc_audit_vaddreason
 	_kdc_audit_trail
-	_kdc_audit_vaddkv
-	_kdc_audit_vaddreason
 
 	; needed for digest-service
 	_kdc_db_fetch

--- a/kdc/mssfu.c
+++ b/kdc/mssfu.c
@@ -168,15 +168,15 @@ validate_protocol_transition(astgs_request_t r)
 			     sdata->padata_value.length,
 			     &self, NULL);
     if (ret) {
-	_kdc_audit_addreason((kdc_request_t)r,
-			     "Failed to decode PA-S4U2Self");
+	kdc_audit_addreason((kdc_request_t)r,
+			    "Failed to decode PA-S4U2Self");
 	kdc_log(r->context, r->config, 4, "Failed to decode PA-S4U2Self");
 	goto out;
     }
 
     if (!krb5_checksum_is_keyed(r->context, self.cksum.cksumtype)) {
-	_kdc_audit_addreason((kdc_request_t)r,
-			     "PA-S4U2Self with unkeyed checksum");
+	kdc_audit_addreason((kdc_request_t)r,
+			    "PA-S4U2Self with unkeyed checksum");
 	kdc_log(r->context, r->config, 4, "Reject PA-S4U2Self with unkeyed checksum");
 	ret = KRB5KRB_AP_ERR_INAPP_CKSUM;
 	goto out;
@@ -225,8 +225,8 @@ validate_protocol_transition(astgs_request_t r)
     krb5_crypto_destroy(r->context, crypto);
     if (ret) {
 	const char *msg = krb5_get_error_message(r->context, ret);
-	_kdc_audit_addreason((kdc_request_t)r,
-			     "S4U2Self checksum failed");
+	kdc_audit_addreason((kdc_request_t)r,
+			    "S4U2Self checksum failed");
 	kdc_log(r->context, r->config, 4,
 		"krb5_verify_checksum failed for S4U2Self: %s", msg);
 	krb5_free_error_message(r->context, msg);
@@ -262,8 +262,8 @@ validate_protocol_transition(astgs_request_t r)
 	if (ret == HDB_ERR_NOENTRY)
 	    ret = KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN;
 	msg = krb5_get_error_message(r->context, ret);
-	_kdc_audit_addreason((kdc_request_t)r,
-			     "S4U2Self principal to impersonate not found");
+	kdc_audit_addreason((kdc_request_t)r,
+			    "S4U2Self principal to impersonate not found");
 	kdc_log(r->context, r->config, 2,
 		"S4U2Self principal to impersonate %s not found in database: %s",
 		s4ucname, msg);
@@ -281,7 +281,7 @@ validate_protocol_transition(astgs_request_t r)
 
     ret = kdc_check_flags(r, FALSE, s4u_client, r->server);
     if (ret)
-	goto out; /* kdc_check_flags() calls _kdc_audit_addreason() */
+	goto out; /* kdc_check_flags() calls kdc_audit_addreason() */
 
     ret = _kdc_pac_generate(r->context,
 			    r->config,
@@ -397,7 +397,7 @@ validate_constrained_delegation(astgs_request_t r)
      */
     if (r->pac == NULL) {
 	ret = KRB5KDC_ERR_BADOPTION;
-	_kdc_audit_addreason((kdc_request_t)r, "Missing PAC");
+	kdc_audit_addreason((kdc_request_t)r, "Missing PAC");
 	kdc_log(r->context, r->config, 4,
 		"Constrained delegation without PAC, %s/%s",
 		r->cname, r->sname);
@@ -417,8 +417,8 @@ validate_constrained_delegation(astgs_request_t r)
 
     ret = krb5_decrypt_ticket(r->context, t, &clientkey->key, &evidence_tkt, 0);
     if (ret) {
-	_kdc_audit_addreason((kdc_request_t)r,
-			     "Failed to decrypt constrained delegation ticket");
+	kdc_audit_addreason((kdc_request_t)r,
+			    "Failed to decrypt constrained delegation ticket");
 	kdc_log(r->context, r->config, 4,
 		"failed to decrypt ticket for "
 		"constrained delegation from %s to %s ", r->cname, r->sname);
@@ -436,7 +436,7 @@ validate_constrained_delegation(astgs_request_t r)
     if (ret)
 	goto out;
 
-    _kdc_audit_addkv((kdc_request_t)r, 0, "impersonatee", "%s", s4ucname);
+    kdc_audit_addkv((kdc_request_t)r, 0, "impersonatee", "%s", s4ucname);
 
     ret = _krb5_principalname2krb5_principal(r->context,
 					     &s4u_server_name,
@@ -451,8 +451,8 @@ validate_constrained_delegation(astgs_request_t r)
 
 	/* check that ticket is valid */
     if (evidence_tkt.flags.forwardable == 0) {
-	_kdc_audit_addreason((kdc_request_t)r,
-			     "Missing forwardable flag on ticket for constrained delegation");
+	kdc_audit_addreason((kdc_request_t)r,
+			    "Missing forwardable flag on ticket for constrained delegation");
 	kdc_log(r->context, r->config, 4,
 		"Missing forwardable flag on ticket for "
 		"constrained delegation from %s (%s) as %s to %s ",
@@ -464,8 +464,8 @@ validate_constrained_delegation(astgs_request_t r)
     ret = check_constrained_delegation(r->context, r->config, r->clientdb,
 				       r->client, r->server, r->server_princ);
     if (ret) {
-	_kdc_audit_addreason((kdc_request_t)r,
-			     "Constrained delegation not allowed");
+	kdc_audit_addreason((kdc_request_t)r,
+			    "Constrained delegation not allowed");
 	kdc_log(r->context, r->config, 4,
 		"constrained delegation from %s (%s) as %s to %s not allowed",
 		r->cname, s4usname, s4ucname, r->sname);
@@ -474,8 +474,8 @@ validate_constrained_delegation(astgs_request_t r)
 
     ret = _kdc_verify_flags(r->context, r->config, &evidence_tkt, s4ucname);
     if (ret) {
-	_kdc_audit_addreason((kdc_request_t)r,
-			     "Constrained delegation ticket expired or invalid");
+	kdc_audit_addreason((kdc_request_t)r,
+			    "Constrained delegation ticket expired or invalid");
 	goto out;
     }
 
@@ -503,8 +503,8 @@ validate_constrained_delegation(astgs_request_t r)
 			 &s4u_canon_client_name, &s4u_pac_attributes);
     if (ret) {
 	const char *msg = krb5_get_error_message(r->context, ret);
-        _kdc_audit_addreason((kdc_request_t)r,
-                                 "Constrained delegation ticket PAC check failed");
+        kdc_audit_addreason((kdc_request_t)r,
+			    "Constrained delegation ticket PAC check failed");
 	kdc_log(r->context, r->config, 4,
 		"Verify delegated PAC failed to %s for client"
 		"%s (%s) as %s from %s with %s",
@@ -520,8 +520,8 @@ validate_constrained_delegation(astgs_request_t r)
 		"for delegation to %s for client %s (%s) from %s; (%s).",
 		r->sname, s4ucname, s4usname, r->cname, r->from,
 		s4u_pac ? "Ticket unsigned" : "No PAC");
-	_kdc_audit_addreason((kdc_request_t)r,
-			     "Constrained delegation ticket not signed");
+	kdc_audit_addreason((kdc_request_t)r,
+			    "Constrained delegation ticket not signed");
 	goto out;
     }
 

--- a/kdc/process.c
+++ b/kdc/process.c
@@ -43,14 +43,14 @@
 #define __attribute__(x)
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_vaddreason(kdc_request_t r, const char *fmt, va_list ap)
+kdc_audit_vaddreason(kdc_request_t r, const char *fmt, va_list ap)
 	__attribute__ ((__format__ (__printf__, 2, 0)))
 {
     heim_audit_vaddreason((heim_svc_req_desc)r, fmt, ap);
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_addreason(kdc_request_t r, const char *fmt, ...)
+kdc_audit_addreason(kdc_request_t r, const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 2, 3)))
 {
     va_list ap;
@@ -67,7 +67,7 @@ _kdc_audit_addreason(kdc_request_t r, const char *fmt, ...)
  */
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_vaddkv(kdc_request_t r, int flags, const char *k,
+kdc_audit_vaddkv(kdc_request_t r, int flags, const char *k,
 		  const char *fmt, va_list ap)
 	__attribute__ ((__format__ (__printf__, 4, 0)))
 {
@@ -75,7 +75,7 @@ _kdc_audit_vaddkv(kdc_request_t r, int flags, const char *k,
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_addkv(kdc_request_t r, int flags, const char *k,
+kdc_audit_addkv(kdc_request_t r, int flags, const char *k,
 		 const char *fmt, ...)
 	__attribute__ ((__format__ (__printf__, 4, 5)))
 {
@@ -87,7 +87,7 @@ _kdc_audit_addkv(kdc_request_t r, int flags, const char *k,
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_addkv_timediff(kdc_request_t r, const char *k,
+kdc_audit_addkv_timediff(kdc_request_t r, const char *k,
 			  const struct timeval *start,
 			  const struct timeval *end)
 {
@@ -95,37 +95,37 @@ _kdc_audit_addkv_timediff(kdc_request_t r, const char *k,
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_setkv_bool(kdc_request_t r, const char *k, krb5_boolean v)
+kdc_audit_setkv_bool(kdc_request_t r, const char *k, krb5_boolean v)
 {
     heim_audit_setkv_bool((heim_svc_req_desc)r, k, (int)v);
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_addkv_number(kdc_request_t r, const char *k, int64_t v)
+kdc_audit_addkv_number(kdc_request_t r, const char *k, int64_t v)
 {
     heim_audit_addkv_number((heim_svc_req_desc)r, k, v);
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_setkv_number(kdc_request_t r, const char *k, int64_t v)
+kdc_audit_setkv_number(kdc_request_t r, const char *k, int64_t v)
 {
     heim_audit_setkv_number((heim_svc_req_desc)r, k, v);
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_addkv_object(kdc_request_t r, const char *k, heim_object_t obj)
+kdc_audit_addkv_object(kdc_request_t r, const char *k, heim_object_t obj)
 {
     heim_audit_addkv_object((heim_svc_req_desc)r, k, obj);
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_setkv_object(kdc_request_t r, const char *k, heim_object_t obj)
+kdc_audit_setkv_object(kdc_request_t r, const char *k, heim_object_t obj)
 {
     heim_audit_setkv_object((heim_svc_req_desc)r, k, obj);
 }
 
 KDC_LIB_FUNCTION heim_object_t KDC_LIB_CALL
-_kdc_audit_getkv(kdc_request_t r, const char *k)
+kdc_audit_getkv(kdc_request_t r, const char *k)
 {
     return heim_audit_getkv((heim_svc_req_desc)r, k);
 }
@@ -135,7 +135,7 @@ _kdc_audit_getkv(kdc_request_t r, const char *k)
  * PA-TGS ticket or whatever.
  */
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-_kdc_audit_addaddrs(kdc_request_t r, HostAddresses *a, const char *key)
+kdc_audit_addaddrs(kdc_request_t r, HostAddresses *a, const char *key)
 {
     size_t i;
     char buf[128];
@@ -145,12 +145,12 @@ _kdc_audit_addaddrs(kdc_request_t r, HostAddresses *a, const char *key)
 
         if (snprintf(numkey, sizeof(numkey), "num%s", key) >= sizeof(numkey))
             numkey[31] = '\0';
-        _kdc_audit_addkv(r, 0, numkey, "%llu", (unsigned long long)a->len);
+        kdc_audit_addkv(r, 0, numkey, "%llu", (unsigned long long)a->len);
     }
 
     for (i = 0; i < 3 && i < a->len; i++) {
         if (krb5_print_address(&a->val[i], buf, sizeof(buf), NULL) == 0)
-            _kdc_audit_addkv(r, 0, key, "%s", buf);
+            kdc_audit_addkv(r, 0, key, "%s", buf);
     }
 }
 

--- a/kdc/version-script.map
+++ b/kdc/version-script.map
@@ -24,19 +24,19 @@ HEIMDAL_KDC_1.0 {
 		kdc_request_get_attribute;
 		kdc_request_copy_attribute;
 		kdc_request_delete_attribute;
-		_kdc_audit_addkv;
-		_kdc_audit_addkv_number;
-		_kdc_audit_addkv_object;
-		_kdc_audit_addkv_timediff;
-		_kdc_audit_addaddrs;
-		_kdc_audit_addreason;
-		_kdc_audit_getkv;
-		_kdc_audit_setkv_bool;
-		_kdc_audit_setkv_number;
-		_kdc_audit_setkv_object;
+		kdc_audit_addkv;
+		kdc_audit_addkv_number;
+		kdc_audit_addkv_object;
+		kdc_audit_addkv_timediff;
+		kdc_audit_addaddrs;
+		kdc_audit_addreason;
+		kdc_audit_getkv;
+		kdc_audit_setkv_bool;
+		kdc_audit_setkv_number;
+		kdc_audit_setkv_object;
+		kdc_audit_vaddkv;
+		kdc_audit_vaddreason;
 		_kdc_audit_trail;
-		_kdc_audit_vaddkv;
-		_kdc_audit_vaddreason;
 
 		# needed for digest-service
 		_kdc_db_fetch;


### PR DESCRIPTION
Samba plugins will need to use auditing API without including krb5-private.h, so make the auditing APIs public.

Essentially this patch is `s/_kdc_audit/kdc_audit/` except for `_kdc_audit_trail`.