### PR TITLE
roken: do not define 'timezone' and 'tzname'

### DIFF
--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -356,10 +356,6 @@ ROKEN_CPP_START
 
 #define fsync   _commit
 
-#define timezone    _timezone
-
-#define tzname  _tzname
-
 #define _PIPE_BUFFER_SZ 8192
 #define pipe(fds) _pipe((fds), _PIPE_BUFFER_SZ, O_BINARY);
 

--- a/lib/roken/strftime.c
+++ b/lib/roken/strftime.c
@@ -36,6 +36,11 @@
 #include "strpftime-test.h"
 #endif
 
+#if defined(_WIN32)
+# define timezone _timezone
+# define tzname   _tzname
+#endif
+
 static const char *abb_weekdays[] = {
     "Sun",
     "Mon",


### PR DESCRIPTION
ec866e635e3c80d6de6bca4f49865a1b2b1213c2
("Windows 10 SDK build fixes") introduced CPP macros

  timezone -> _timezone
  tzname   -> _tzname

but these names are common and the macros rewrite too much.

Change-Id: Ic813bff842124595fd3d86761cee6dcea4ae44e4