### PR TITLE
gssapi/mech: mech_locl.h roken.h must be included earlier

### DIFF
--- a/lib/gssapi/mech/mech_locl.h
+++ b/lib/gssapi/mech/mech_locl.h
@@ -35,23 +35,16 @@
 
 #include <config.h>
 
+#include <roken.h>
+
 #include <krb5-types.h>
 
-#include <sys/types.h>
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <ctype.h>
-#include <dlfcn.h>
-#include <errno.h>
 
 #include <heimbase.h>
 
 #include <gssapi_asn1.h>
 #include <der.h>
-
-#include <roken.h>
 
 #include <gssapi.h>
 #include <gssapi_mech.h>


### PR DESCRIPTION
If included roken.h should be immediately following config.h.
Doing so ensures that all platform specific headers are
included in the proper order and avoids unnecessary includes
of headers managed by roken.h.
