### PR TITLE
lib/hcrypto: ENGINE_by_dso do not leak handle

### DIFF
--- a/lib/hcrypto/engine.c
+++ b/lib/hcrypto/engine.c
@@ -349,12 +349,12 @@ ENGINE_by_dso(const char *path, const char *id)
 	    return NULL;
 	}
     }
+    dlclose(handle);
 
     ENGINE_up_ref(engine);
 
     ret = add_engine(engine);
     if (ret != 1) {
-	dlclose(handle);
 	ENGINE_finish(engine);
 	return NULL;
     }


### PR DESCRIPTION
Must dlclose(handle) before returning even if 'engine' is
returned to caller.

