### PR TITLE
prevent unintended sign extension errors

### DIFF
--- a/kadmin/rpc.c
+++ b/kadmin/rpc.c
@@ -142,7 +142,7 @@ parse_name(const unsigned char *p, size_t len,
     /* MECHNAME_LEN */
     if (len < 4)
 	return 1;
-    l = p[0] << 24 | p[1] << 16 | p[2] << 8 | p[3];
+    l = (unsigned long)p[0] << 24 | p[1] << 16 | p[2] << 8 | p[3];
     len -= 4;
     p += 4;
 

--- a/lib/base/data.c
+++ b/lib/base/data.c
@@ -69,8 +69,9 @@ data_hash(void *ptr)
 
     if (os->length < 4)
 	return os->length;
-    return s[0] | (s[1] << 8) |
-	(s[os->length - 2] << 16) | (s[os->length - 1] << 24);
+
+    return ((unsigned long)s[os->length - 1] << 24)
+	| (s[os->length - 2] << 16) | (s[1] << 8) | s[0];
 }
 
 struct heim_type_data _heim_data_object = {

--- a/lib/gssapi/mech/gss_import_name.c
+++ b/lib/gssapi/mech/gss_import_name.c
@@ -132,7 +132,7 @@ _gss_import_export_name(OM_uint32 *minor_status,
                 p += t;
                 len -= t;
 
-                t = (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
+                t = ((unsigned long)p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
                 /* p += 4; // we're done using `p' now */
                 len -= 4;
 

--- a/lib/gssapi/mech/gss_krb5.c
+++ b/lib/gssapi/mech/gss_krb5.c
@@ -572,7 +572,7 @@ gsskrb5_extract_authtime_from_sec_context(OM_uint32 *minor_status,
 
     {
 	unsigned char *buf = data_set->elements[0].value;
-	*authtime = (buf[3] <<24) | (buf[2] << 16) |
+	*authtime = ((unsigned long)buf[3] <<24) | (buf[2] << 16) |
 	    (buf[1] << 8) | (buf[0] << 0);
     }
 

--- a/lib/hdb/print.c
+++ b/lib/hdb/print.c
@@ -453,7 +453,8 @@ entry2mit_string_int(krb5_context context, krb5_storage *sp, hdb_entry *ent)
         unsigned char *ptr;
         
         ptr = (unsigned char *)&last_pw_chg;
-        val = ptr[0] | (ptr[1] << 8) | (ptr[2] << 16) | (ptr[3] << 24);
+        val = ((unsigned long)ptr[3] << 24) | (ptr[2] << 16)
+	    | (ptr[1] << 8) | ptr[0];
         d.data = &val;
         d.length = sizeof (last_pw_chg);
         sz = append_string(context, sp, "\t%u\t%u\t",

--- a/lib/kadm5/ipropd_master.c
+++ b/lib/kadm5/ipropd_master.c
@@ -1253,7 +1253,8 @@ fill_input(krb5_context context, slave *s)
             return EWOULDBLOCK;
 
         buf = s->input.header_buf;
-        len = (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
+        len = ((unsigned long)buf[0] << 24) | (buf[1] << 16)
+	    | (buf[2] << 8) | buf[3];
         if (len > SLAVE_MSG_MAX)
             return EINVAL;
         ret = krb5_data_alloc(&s->input.packet, len);


### PR DESCRIPTION
When an unsigned char is shifted << 24 bits its type will be
promoted to signed 32-bits.   If the value is then assigned to
an unsigned 64-bit value sign extension will occur.

Prevent the unwanted sign extension by explicitly casting the
value to unsigned long before shifting.

