### PR TITLE
kdc: remove krb5_ prefix for KDC attribute functions

### DIFF
--- a/kdc/altsecid_gss_preauth_authorizer.c
+++ b/kdc/altsecid_gss_preauth_authorizer.c
@@ -452,8 +452,8 @@ authorize(void *ctx,
     } while (reconnect_p);
 
     if (requestor_sid) {
-	krb5_kdc_request_set_attribute((kdc_request_t)r,
-				       HSTR("org.h5l.gss-pa-requestor-sid"), requestor_sid);
+	kdc_request_set_attribute((kdc_request_t)r,
+				  HSTR("org.h5l.gss-pa-requestor-sid"), requestor_sid);
 	heim_release(requestor_sid);
     }
 
@@ -465,8 +465,8 @@ finalize_pac(void *ctx, astgs_request_t r)
 {
     heim_data_t requestor_sid;
 
-    requestor_sid = krb5_kdc_request_get_attribute((kdc_request_t)r,
-						   HSTR("org.h5l.gss-pa-requestor-sid"));
+    requestor_sid = kdc_request_get_attribute((kdc_request_t)r,
+					      HSTR("org.h5l.gss-pa-requestor-sid"));
     if (requestor_sid == NULL)
 	return 0;
 

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -577,8 +577,8 @@ pa_gss_validate(astgs_request_t r, const PA_DATA *pa)
 	goto out;
     }
 
-    ret = krb5_kdc_request_set_attribute((kdc_request_t)r,
-					 HSTR("org.h5l.pa-gss-client-params"), gcp);
+    ret = kdc_request_set_attribute((kdc_request_t)r,
+				    HSTR("org.h5l.pa-gss-client-params"), gcp);
     if (ret)
 	goto out;
 
@@ -594,7 +594,7 @@ pa_gss_finalize_pac(astgs_request_t r)
 {
     gss_client_params *gcp;
 
-    gcp = krb5_kdc_request_get_attribute((kdc_request_t)r, HSTR("org.h5l.pa-gss-client-params"));
+    gcp = kdc_request_get_attribute((kdc_request_t)r, HSTR("org.h5l.pa-gss-client-params"));
 
     heim_assert(gcp != NULL, "invalid GSS-API client params");
 

--- a/kdc/libkdc-exports.def
+++ b/kdc/libkdc-exports.def
@@ -17,10 +17,10 @@ EXPORTS
 	krb5_kdc_save_request
 	krb5_kdc_update_time
 	krb5_kdc_pk_initialize
-	krb5_kdc_request_set_attribute
-	krb5_kdc_request_get_attribute
-	krb5_kdc_request_copy_attribute
-	krb5_kdc_request_delete_attribute
+	kdc_request_set_attribute
+	kdc_request_get_attribute
+	kdc_request_copy_attribute
+	kdc_request_delete_attribute
 	_kdc_audit_addkv
 	_kdc_audit_addkv_number
 	_kdc_audit_addkv_object

--- a/kdc/process.c
+++ b/kdc/process.c
@@ -524,25 +524,25 @@ out:
 }
 
 KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
-krb5_kdc_request_set_attribute(kdc_request_t r, heim_object_t key, heim_object_t value)
+kdc_request_set_attribute(kdc_request_t r, heim_object_t key, heim_object_t value)
 {
     return heim_dict_set_value(r->attributes, key, value);
 }
 
 KDC_LIB_FUNCTION heim_object_t KDC_LIB_CALL
-krb5_kdc_request_get_attribute(kdc_request_t r, heim_object_t key)
+kdc_request_get_attribute(kdc_request_t r, heim_object_t key)
 {
     return heim_dict_get_value(r->attributes, key);
 }
 
 KDC_LIB_FUNCTION heim_object_t KDC_LIB_CALL
-krb5_kdc_request_copy_attribute(kdc_request_t r, heim_object_t key)
+kdc_request_copy_attribute(kdc_request_t r, heim_object_t key)
 {
     return heim_dict_copy_value(r->attributes, key);
 }
 
 KDC_LIB_FUNCTION void KDC_LIB_CALL
-krb5_kdc_request_delete_attribute(kdc_request_t r, heim_object_t key)
+kdc_request_delete_attribute(kdc_request_t r, heim_object_t key)
 {
     heim_dict_delete_key(r->attributes, key);
 }

--- a/kdc/version-script.map
+++ b/kdc/version-script.map
@@ -20,10 +20,10 @@ HEIMDAL_KDC_1.0 {
 		krb5_kdc_save_request;
 		krb5_kdc_update_time;
 		krb5_kdc_pk_initialize;
-		krb5_kdc_request_set_attribute;
-		krb5_kdc_request_get_attribute;
-		krb5_kdc_request_copy_attribute;
-		krb5_kdc_request_delete_attribute;
+		kdc_request_set_attribute;
+		kdc_request_get_attribute;
+		kdc_request_copy_attribute;
+		kdc_request_delete_attribute;
 		_kdc_audit_addkv;
 		_kdc_audit_addkv_number;
 		_kdc_audit_addkv_object;

--- a/tests/plugin/kdc_test_plugin.c
+++ b/tests/plugin/kdc_test_plugin.c
@@ -126,8 +126,8 @@ finalize_reply(void *ctx, astgs_request_t r)
     if (n == NULL)
 	return ENOMEM;
 
-    ret = krb5_kdc_request_set_attribute((kdc_request_t)r,
-					 HSTR("org.h5l.tests.kdc-plugin"), n);
+    ret = kdc_request_set_attribute((kdc_request_t)r,
+				    HSTR("org.h5l.tests.kdc-plugin"), n);
     heim_release(n);
 
     return ret;
@@ -143,8 +143,8 @@ audit(void *ctx, astgs_request_t r)
     if (r->ret)
 	return 0; /* finalize_reply only called in success */
 
-    n = krb5_kdc_request_get_attribute((kdc_request_t)r,
-				       HSTR("org.h5l.tests.kdc-plugin"));
+    n = kdc_request_get_attribute((kdc_request_t)r,
+				  HSTR("org.h5l.tests.kdc-plugin"));
 
     heim_assert(n && heim_number_get_int(n) == 1234,
 		"attribute not passed from finalize_reply");


### PR DESCRIPTION
We will use the kdc_ rather than `krb5_kdc_` prefix for new public APIs exported from `libkdc`. Amend the recently introduced `request_{get,set,copy,delete}_attribute` APIs to conform.