### PR TITLE
assert non-NULL ptrs before calling mem funcs

### DIFF
--- a/lib/asn1/der_copy.c
+++ b/lib/asn1/der_copy.c
@@ -99,11 +99,15 @@ int ASN1CALL
 der_copy_printable_string (const heim_printable_string *from,
 		       heim_printable_string *to)
 {
-    to->length = from->length;
-    to->data   = malloc(to->length + 1);
-    if(to->data == NULL)
+    assert(from->length == 0 || (from->length > 0 && from->data != NULL));
+    to->data = malloc(from->length + 1);
+    if (to->data == NULL) {
+	to->length = 0;
 	return ENOMEM;
-    memcpy(to->data, from->data, to->length);
+    }
+    to->length = from->length;
+    if (to->length > 0)
+	memcpy(to->data, from->data, to->length);
     ((char *)to->data)[to->length] = '\0';
     return 0;
 }
@@ -118,11 +122,18 @@ der_copy_ia5_string (const heim_ia5_string *from,
 int ASN1CALL
 der_copy_bmp_string (const heim_bmp_string *from, heim_bmp_string *to)
 {
-    to->length = from->length;
-    to->data   = malloc(to->length * sizeof(to->data[0]));
-    if(to->length != 0 && to->data == NULL)
+    assert(from->length == 0 || (from->length > 0 && from->data != NULL));
+    if (from->length == 0)
+	to->data = calloc(1, 1);
+    else
+	to->data = malloc(from->length * sizeof(from->data[0]));
+    if (to->data == NULL) {
+	to->length = 0;
 	return ENOMEM;
-    memcpy(to->data, from->data, to->length * sizeof(to->data[0]));
+    }
+    to->length = from->length;
+    if (to->length > 0)
+	memcpy(to->data, from->data, to->length * sizeof(to->data[0]));
     return 0;
 }
 
@@ -130,11 +141,18 @@ int ASN1CALL
 der_copy_universal_string (const heim_universal_string *from,
 			   heim_universal_string *to)
 {
-    to->length = from->length;
-    to->data   = malloc(to->length * sizeof(to->data[0]));
-    if(to->length != 0 && to->data == NULL)
+    assert(from->length == 0 || (from->length > 0 && from->data != NULL));
+    if (from->length == 0)
+	to->data = calloc(1, 1);
+    else
+	to->data = malloc(from->length * sizeof(from->data[0]));
+    if (to->data == NULL) {
+	to->length = 0;
 	return ENOMEM;
-    memcpy(to->data, from->data, to->length * sizeof(to->data[0]));
+    }
+    to->length = from->length;
+    if (to->length > 0)
+	memcpy(to->data, from->data, to->length * sizeof(to->data[0]));
     return 0;
 }
 
@@ -148,26 +166,36 @@ der_copy_visible_string (const heim_visible_string *from,
 int ASN1CALL
 der_copy_octet_string (const heim_octet_string *from, heim_octet_string *to)
 {
-    to->length = from->length;
-    if (from->data == NULL) {
-        to->data = NULL;
-        return 0;
-    }
-    to->data = malloc(to->length);
-    if (to->length != 0 && to->data == NULL)
+    assert(from->length == 0 || (from->length > 0 && from->data != NULL));
+    if (from->length == 0)
+	to->data = calloc(1, 1);
+    else
+	to->data = malloc(from->length);
+    if (to->data == NULL) {
+	to->length = 0;
 	return ENOMEM;
-    memcpy(to->data, from->data, to->length);
+    }
+    to->length = from->length;
+    if (to->length > 0)
+	memcpy(to->data, from->data, to->length);
     return 0;
 }
 
 int ASN1CALL
 der_copy_heim_integer (const heim_integer *from, heim_integer *to)
 {
-    to->length = from->length;
-    to->data   = malloc(to->length);
-    if(to->length != 0 && to->data == NULL)
+    assert(from->length == 0 || (from->length > 0 && from->data != NULL));
+    if (from->length == 0)
+	to->data = calloc(1, 1);
+    else
+	to->data = malloc(from->length);
+    if (to->data == NULL) {
+	to->length = 0;
 	return ENOMEM;
-    memcpy(to->data, from->data, to->length);
+    }
+    to->length = from->length;
+    if (to->length > 0)
+	memcpy(to->data, from->data, to->length);
     to->negative = from->negative;
     return 0;
 }
@@ -175,10 +203,20 @@ der_copy_heim_integer (const heim_integer *from, heim_integer *to)
 int ASN1CALL
 der_copy_oid (const heim_oid *from, heim_oid *to)
 {
-    to->length     = from->length;
-    to->components = malloc(to->length * sizeof(*to->components));
-    if (to->length != 0 && to->components == NULL)
+    if (from->length == 0) {
+	to->length = 0;
+	to->components = calloc(1, sizeof(*from->components));
+	if (to->components == NULL)
+	    return ENOMEM;
+	return 0;
+    }
+    assert(from->components != NULL);
+    to->components = malloc(from->length * sizeof(*from->components));
+    if (to->components == NULL) {
+	to->length = 0;
 	return ENOMEM;
+    }
+    to->length = from->length;
     memcpy(to->components, from->components,
 	   to->length * sizeof(*to->components));
     return 0;
@@ -189,11 +227,19 @@ der_copy_bit_string (const heim_bit_string *from, heim_bit_string *to)
 {
     size_t len;
 
+    assert(from->length == 0 || (from->length > 0 && from->data != NULL));
+
     len = (from->length + 7) / 8;
-    to->length = from->length;
-    to->data   = malloc(len);
-    if(len != 0 && to->data == NULL)
+    if (len == 0)
+	to->data = calloc(1, 1);
+    else
+	to->data = malloc(len);
+    if (to->data == NULL) {
+	to->length = 0;
 	return ENOMEM;
-    memcpy(to->data, from->data, len);
+    }
+    to->length = from->length;
+    if (len > 0)
+	memcpy(to->data, from->data, len);
     return 0;
 }

--- a/lib/asn1/der_get.c
+++ b/lib/asn1/der_get.c
@@ -174,6 +174,8 @@ der_get_general_string (const unsigned char *p, size_t len,
     const unsigned char *p1;
     char *s;
 
+    assert(p != NULL);
+
     if (size)
 	*size = 0;
 
@@ -220,6 +222,8 @@ int ASN1CALL
 der_get_printable_string(const unsigned char *p, size_t len,
 			 heim_printable_string *str, size_t *size)
 {
+    assert(p != NULL);
+
     if (size)
 	*size = 0;
 
@@ -233,6 +237,7 @@ der_get_printable_string(const unsigned char *p, size_t len,
 	gen_data_zero(str);
 	return ENOMEM;
     }
+
     memcpy(str->data, p, len);
     ((char *)str->data)[len] = '\0';
     if(size) *size = len;
@@ -251,6 +256,8 @@ der_get_bmp_string (const unsigned char *p, size_t len,
 		    heim_bmp_string *data, size_t *size)
 {
     size_t i;
+
+    assert(p != NULL);
 
     if (size)
 	*size = 0;
@@ -290,6 +297,8 @@ der_get_universal_string (const unsigned char *p, size_t len,
 			  heim_universal_string *data, size_t *size)
 {
     size_t i;
+
+    assert(p != NULL);
 
     if (size)
 	*size = 0;
@@ -334,14 +343,23 @@ int ASN1CALL
 der_get_octet_string (const unsigned char *p, size_t len,
 		      heim_octet_string *data, size_t *size)
 {
+    assert(p != NULL);
+
     if (size)
 	*size = 0;
-    data->length = len;
-    data->data = malloc(len);
-    if (data->data == NULL && data->length != 0)
+
+    if (len == 0)
+	data->data = malloc(1);
+    else
+	data->data = malloc(len);
+    if (data->data == NULL) {
+	data->length = 0;
 	return ENOMEM;
+    }
+    data->length = len;
     memcpy (data->data, p, len);
-    if(size) *size = len;
+    if (size)
+	*size = len;
     return 0;
 }
 
@@ -354,6 +372,8 @@ der_get_octet_string_ber (const unsigned char *p, size_t len,
     Der_class cls;
     unsigned int tag, depth = 0;
     size_t l, datalen, oldlen = len;
+
+    assert(p != NULL);
 
     if (size)
 	*size = 0;
@@ -430,6 +450,8 @@ der_get_heim_integer (const unsigned char *p, size_t len,
 
     if (len == 0)
 	return 0;
+
+    assert(p != NULL);
 
     if (p[0] & 0x80) {
 	unsigned char *q;
@@ -511,6 +533,8 @@ der_get_time (const unsigned char *p, size_t len,
     char *times;
     int e;
 
+    assert(p != NULL);
+
     if (size)
 	*size = 0;
 
@@ -549,6 +573,8 @@ der_get_oid (const unsigned char *p, size_t len,
     size_t n;
     size_t oldlen = len;
 
+    assert(p != NULL);
+
     if (size)
 	*size = 0;
 
@@ -562,8 +588,10 @@ der_get_oid (const unsigned char *p, size_t len,
 	return ERANGE;
 
     data->components = malloc((len + 1) * sizeof(data->components[0]));
-    if (data->components == NULL)
+    if (data->components == NULL) {
+	data->length = 0;
 	return ENOMEM;
+    }
     data->components[0] = (*p) / 40;
     data->components[1] = (*p) % 40;
     --len;
@@ -605,6 +633,9 @@ der_get_tag (const unsigned char *p, size_t len,
 
     if (len < 1)
 	return ASN1_MISSING_FIELD;
+
+    assert(p != NULL);
+
     *cls = (Der_class)(((*p) >> 6) & 0x03);
     *type = (Der_type)(((*p) >> 5) & 0x01);
     *tag = (*p) & 0x1f;
@@ -731,6 +762,8 @@ int ASN1CALL
 der_get_bit_string (const unsigned char *p, size_t len,
 		    heim_bit_string *data, size_t *size)
 {
+    assert(p != NULL);
+
     if (size)
 	*size = 0;
 
@@ -750,8 +783,10 @@ der_get_bit_string (const unsigned char *p, size_t len,
     if (len - 1 > 0) {
 	data->length = (len - 1) * 8;
 	data->data = malloc(len - 1);
-	if (data->data == NULL)
+	if (data->data == NULL) {
+	    data->length = 0;
 	    return ENOMEM;
+	}
 	memcpy (data->data, p + 1, len - 1);
 	data->length -= p[0];
     } else {

--- a/lib/asn1/der_put.c
+++ b/lib/asn1/der_put.c
@@ -244,9 +244,11 @@ int ASN1CALL
 der_put_general_string (unsigned char *p, size_t len,
 			const heim_general_string *str, size_t *size)
 {
-    size_t slen = strlen(*str);
+    size_t slen;
 
+    assert(p != NULL && str != NULL && *str != NULL && size != NULL);
     *size = 0;
+    slen = strlen(*str);
     if (len < slen)
 	return ASN1_OVERFLOW;
     p -= slen;
@@ -281,6 +283,8 @@ der_put_bmp_string (unsigned char *p, size_t len,
 		    const heim_bmp_string *data, size_t *size)
 {
     size_t i;
+
+    assert(p != NULL && data != NULL);
 
     if (size)
 	*size = 0;
@@ -331,6 +335,8 @@ int ASN1CALL
 der_put_octet_string (unsigned char *p, size_t len,
 		      const heim_octet_string *data, size_t *size)
 {
+    assert(p != NULL && data != NULL && size != NULL);
+
     *size = 0;
     if (len < data->length)
 	return ASN1_OVERFLOW;
@@ -344,8 +350,10 @@ int ASN1CALL
 der_put_heim_integer (unsigned char *p, size_t len,
 		     const heim_integer *data, size_t *size)
 {
-    unsigned char *buf = data->data;
+    unsigned char *buf;
     int hibitset = 0;
+
+    assert(p != NULL);
 
     if (size)
 	*size = 0;
@@ -361,6 +369,8 @@ der_put_heim_integer (unsigned char *p, size_t len,
     if (len < data->length)
 	return ASN1_OVERFLOW;
 
+    assert(data->data != NULL);
+    buf = data->data;
     len -= data->length;
 
     if (data->negative) {
@@ -484,6 +494,8 @@ der_replace_tag(const unsigned char *p, size_t len,
     size_t payload_len, l, tag_len, len_len;
     int e;
 
+    assert(p != NULL && out != NULL && outlen != NULL);
+
     e = der_get_tag(p, len, &found_class, &found_type, &found_tag, &l);
     if (e)
         return e;
@@ -528,6 +540,8 @@ der_encode_implicit(unsigned char *p, size_t len,
     size_t l;
     unsigned char *p2;
     int e;
+
+    assert(p != NULL && size != NULL);
 
     /* Attempt to encode in place */
     e = encoder(p, len, obj, size);
@@ -653,9 +667,12 @@ int ASN1CALL
 der_put_bit_string (unsigned char *p, size_t len,
 		    const heim_bit_string *data, size_t *size)
 {
-    size_t data_size = (data->length + 7) / 8;
+    size_t data_size;
+
+    assert(p != NULL && data != NULL && size != NULL);
 
     *size = 0;
+    data_size = (data->length + 7) / 8;
     if (len < data_size + 1)
 	return ASN1_OVERFLOW;
     p -= data_size + 1;
@@ -672,9 +689,12 @@ der_put_bit_string (unsigned char *p, size_t len,
 int
 _heim_der_set_sort(const void *a1, const void *a2)
 {
-    const heim_octet_string *s1 = a1, *s2 = a2;
+    const heim_octet_string *s1, *s2;
     int ret;
 
+    assert(a1 != NULL && a2 != NULL);
+    s1 = a1;
+    s2 = a2;
     ret = memcmp(s1->data, s2->data,
 		 s1->length < s2->length ? s1->length : s2->length);
     if (ret != 0)

--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -167,10 +167,13 @@ arcfour_mic_cksum_iov(krb5_context context,
 	    continue;
 	}
 
-	memcpy(ptr + ofs,
-	       iov[i].buffer.value,
-	       iov[i].buffer.length);
-	ofs += iov[i].buffer.length;
+	if (iov[i].buffer.length > 0) {
+	    assert(iov[i].buffer.value != NULL);
+	    memcpy(ptr + ofs,
+		   iov[i].buffer.value,
+		   iov[i].buffer.length);
+	    ofs += iov[i].buffer.length;
+	}
     }
 
     if (padding) {

--- a/lib/krb5/pac.c
+++ b/lib/krb5/pac.c
@@ -35,6 +35,7 @@
 
 #include <heimbasepriv.h>
 #include <wind.h>
+#include <assert.h>
 
 struct PAC_INFO_BUFFER {
     uint32_t type;
@@ -381,6 +382,8 @@ krb5_pac_add_buffer(krb5_context context, krb5_pac p,
     void *ptr;
     size_t len, offset, header_end, old_end;
     uint32_t i;
+
+    assert(data->length > 0 && data->data != NULL);
 
     len = p->pac->numbuffers;
 
@@ -1101,7 +1104,7 @@ build_logon_name(krb5_context context,
 	    krb5_set_error_message(context, ret, "Principal %s is not valid UTF-8", s);
 	    free(s);
 	    return ret;
-	} else 
+	} else
 	    free(s);
 
 	s2_len = (ucs2_len + 1) * 2;

--- a/lib/krb5/store_emem.c
+++ b/lib/krb5/store_emem.c
@@ -33,6 +33,7 @@
 
 #include "krb5_locl.h"
 #include "store-int.h"
+#include <assert.h>
 
 typedef struct emem_storage{
     unsigned char *base;
@@ -45,6 +46,9 @@ static ssize_t
 emem_fetch(krb5_storage *sp, void *data, size_t size)
 {
     emem_storage *s = (emem_storage*)sp->data;
+
+    assert(data != NULL && s->ptr != NULL);
+
     if((size_t)(s->base + s->len - s->ptr) < size)
 	size = s->base + s->len - s->ptr;
     memmove(data, s->ptr, size);
@@ -55,7 +59,17 @@ emem_fetch(krb5_storage *sp, void *data, size_t size)
 static ssize_t
 emem_store(krb5_storage *sp, const void *data, size_t size)
 {
-    emem_storage *s = (emem_storage*)sp->data;
+    emem_storage *s;
+
+    if (size == 0) {
+	sp->seek(sp, 0, SEEK_CUR);
+	return 0;
+    }
+
+    s = (emem_storage*)sp->data;
+
+    assert(data != NULL);
+
     if(size > (size_t)(s->base + s->size - s->ptr)){
 	void *base;
 	size_t sz, off;
@@ -139,6 +153,9 @@ static void
 emem_free(krb5_storage *sp)
 {
     emem_storage *s = sp->data;
+
+    assert(s->base != NULL);
+
     memset_s(s->base, s->len, 0, s->len);
     free(s->base);
 }


### PR DESCRIPTION
The definitions of memcpy(), memmove(), and memset() state that
the behaviour is undefined if any of the pointer arguments are
NULL, and some compilers are known to make use of this to
optimise away existing NULL checks in the source.

Change-Id: I489bc256e3eac7ff41d91becb0b43aba73dbb3f9
Link: https://www.imperialviolet.org/2016/06/26/nonnull.html