### PR TITLE
Follow the Linux kernel's lead on "fallthrough"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -509,12 +509,12 @@ dnl Deal with switch FALLTHROUGH
 AH_TOP([
 #if defined(__GNUC__)
 #if __GNUC__ >= 7
-# define fallthrough __attribute__((fallthrough));
+# define fallthrough __attribute__((fallthrough))
 #else
-# define fallthrough
+# define fallthrough do {} while (0) /* fallthrough */
 #endif
 #else
-# define fallthrough
+# define fallthrough  do {} while (0) /* fallthrough */
 #endif
 ])
 

--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -32,7 +32,7 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-#define fallthrough
+#define fallthrough do {} while(0) /* fallthrough */
 
 #ifndef RCSID
 #define RCSID(msg) \

--- a/kadmin/rpc.c
+++ b/kadmin/rpc.c
@@ -972,8 +972,7 @@ process_stream(krb5_context contextp,
 	    INSIST(gctx.ctx == NULL);
 
 	    gctx.inprogress = 1;
-            /* FALLTHROUGH */
-	    fallthrough
+	    fallthrough;
 	case RPG_CONTINUE_INIT: {
 	    gss_name_t src_name = GSS_C_NO_NAME;
 	    krb5_data in;

--- a/lib/asn1/gen_copy.c
+++ b/lib/asn1/gen_copy.c
@@ -62,8 +62,7 @@ copy_type (const char *from, const char *to, const Type *t, int preserve)
 	    copy_primitive ("heim_integer", from, to);
 	    break;
 	}
-        /* FALLTHROUGH */
-        fallthrough
+        fallthrough;
     case TBoolean:
     case TEnumerated :
 	fprintf(codefile, "*(%s) = *(%s);\n", to, from);

--- a/lib/asn1/gen_free.c
+++ b/lib/asn1/gen_free.c
@@ -56,7 +56,7 @@ free_type (const char *name, const Type *t, int preserve)
 	    free_primitive ("heim_integer", name);
 	    break;
 	}
-        /* fallthrough */
+        /* fallthrough; */
     case TBoolean:
     case TEnumerated :
     case TNull:

--- a/lib/gssapi/krb5/init_sec_context.c
+++ b/lib/gssapi/krb5/init_sec_context.c
@@ -932,8 +932,7 @@ OM_uint32 GSSAPI_CALLCONV _gsskrb5_init_sec_context
 			time_rec);
 	if (ret != GSS_S_COMPLETE)
 	    break;
-	/* FALLTHROUGH */
-        fallthrough
+        fallthrough;
     case INITIATOR_RESTART:
 	ret = init_auth_restart(minor_status,
 				cred,

--- a/lib/hcrypto/libtommath/etc/tune.c
+++ b/lib/hcrypto/libtommath/etc/tune.c
@@ -425,7 +425,6 @@ int main(int argc, char **argv)
          case 'h':
             s_exit_code = EXIT_SUCCESS;
             /* FALLTHROUGH */
-            fallthrough
          default:
             s_usage(argv[0]);
          }

--- a/lib/hx509/cert.c
+++ b/lib/hx509/cert.c
@@ -2441,11 +2441,10 @@ hx509_verify_path(hx509_context context,
 		 * EE checking below.
 		 */
 		type = EE_CERT;
-                /* FALLTHROUGH */
+                fallthrough;
 	    }
 	}
-        /* FALLTHROUGH */
-        fallthrough
+        fallthrough;
 	case EE_CERT:
 	    /*
 	     * If there where any proxy certificates in the chain

--- a/lib/hx509/cms.c
+++ b/lib/hx509/cms.c
@@ -182,8 +182,7 @@ fill_CMSIdentifier(const hx509_cert cert,
 						   &id->u.subjectKeyIdentifier);
 	if (ret == 0)
 	    break;
-	/* FALLTHROUGH */
-        fallthrough
+        fallthrough;
     case CMS_ID_NAME: {
 	hx509_name name;
 

--- a/lib/hx509/file.c
+++ b/lib/hx509/file.c
@@ -230,8 +230,7 @@ hx509_pem_read(hx509_context context,
 		where = INDATA;
 		goto indata;
 	    }
-	    /* FALLTHROUGH */
-            fallthrough
+            fallthrough;
 	case INHEADER:
 	    if (buf[0] == '\0') {
 		where = INDATA;

--- a/lib/hx509/req.c
+++ b/lib/hx509/req.c
@@ -1046,7 +1046,7 @@ authorize_feat(hx509_request req, abitstring a, size_t n, int idx)
     switch (ret) {
     case 0:
         req->nauthorized++;
-        /*fallthrough*/
+        fallthrough;
     case -1:
         return 0;
     default:
@@ -1063,7 +1063,7 @@ reject_feat(hx509_request req, abitstring a, size_t n, int idx)
     switch (ret) {
     case 0:
         req->nauthorized--;
-        /*fallthrough*/
+        fallthrough;
     case -1:
         return 0;
     default:
@@ -1245,7 +1245,7 @@ san_map_type(GeneralName *san)
             if (der_heim_oid_cmp(&san->u.otherName.type_id, map[i].oid) == 0)
                 return map[i].type;
     }
-        /*fallthrough*/
+        fallthrough;
     default:                               return HX509_SAN_TYPE_UNSUPPORTED;
     }
 }
@@ -1360,7 +1360,7 @@ hx509_request_get_san(hx509_request req,
     case HX509_SAN_TYPE_REGISTERED_ID:
         return der_print_heim_oid(&san->u.registeredID, '.', out);
     case HX509_SAN_TYPE_XMPP:
-        /*fallthrough*/
+        fallthrough;
     case HX509_SAN_TYPE_MS_UPN: {
         int ret;
 

--- a/lib/kafs/rxkad_kdf.c
+++ b/lib/kafs/rxkad_kdf.c
@@ -209,8 +209,7 @@ _kafs_derive_des_key(krb5_enctype enctype, void *keydata, size_t keylen,
 	ret = compress_parity_bits(keydata, &keylen);
 	if (ret)
 	    return ret;
-	/* FALLTHROUGH */
-        fallthrough
+        fallthrough;
     default:
 	if (enctype < 0)
 	    return KRB5_PROG_ETYPE_NOSUPP;

--- a/lib/krb5/send_to_kdc.c
+++ b/lib/krb5/send_to_kdc.c
@@ -1192,8 +1192,7 @@ krb5_sendto_context(krb5_context context,
 		break;
 	    }
 	    action = KRB5_SENDTO_KRBHST;
-	    /* FALLTHROUGH */
-            fallthrough
+            fallthrough;
 	case KRB5_SENDTO_KRBHST:
 	    if (ctx->krbhst == NULL) {
 		ret = krb5_krbhst_init_flags(context, realm, type,
@@ -1215,8 +1214,7 @@ krb5_sendto_context(krb5_context context,
 		handle = heim_retain(ctx->krbhst);
 	    }
 	    action = KRB5_SENDTO_TIMEOUT;
-	    /* FALLTHROUGH */
-            fallthrough
+            fallthrough;
 	case KRB5_SENDTO_TIMEOUT:
 
 	    /*

--- a/lib/ntlm/digest.c
+++ b/lib/ntlm/digest.c
@@ -471,8 +471,7 @@ heim_digest_generate_challenge(heim_digest_t context)
 	    break;
 	case HEIM_DIGEST_TYPE_AUTO:
 	    context->type = HEIM_DIGEST_TYPE_RFC2831;
-	    /* FALLTHROUGH */
-            fallthrough
+            fallthrough;
 	case HEIM_DIGEST_TYPE_RFC2831:
 	    asprintf(&challenge, "realm=\"%s\",nonce=\"%s\",qop=\"%s\",algorithm=md5-sess,charset=utf-8,maxbuf=%s",
 		     context->serverRealm, context->serverNonce, context->serverQOP, context->serverMaxbuf);

--- a/lib/roken/base32.c
+++ b/lib/roken/base32.c
@@ -100,10 +100,10 @@ rk_base32_encode(const void *data, int size, char **str, enum rk_base32_flags fl
 	p[6] = chars[(c & 0x0000000000000003e0ULL) >> 5];
 	p[7] = chars[(c & 0x00000000000000001fULL) >> 0];
         switch (i - size) {
-        case 4: p[2] = p[3] = '=';  /*fallthrough*/
-        case 3: p[4] = '=';         /*fallthrough*/
-        case 2: p[5] = p[6] = '=';  /*fallthrough*/
-        case 1: p[7] = '=';         /*fallthrough*/
+        case 4: p[2] = p[3] = '=';  fallthrough;
+        case 3: p[4] = '=';         fallthrough;
+        case 2: p[5] = p[6] = '=';  fallthrough;
+        case 1: p[7] = '=';         fallthrough;
         default:                    break;
         }
 	p += 8;

--- a/lib/roken/dirent-test.c
+++ b/lib/roken/dirent-test.c
@@ -28,7 +28,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  **********************************************************************/
-
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -148,7 +148,7 @@ int teardown_test(void)
 
         strcmp(dirname + len + 1 - sizeof(TESTDIR)/sizeof(char), TESTDIR) == 0) {
 
-        /* fallthrough */
+        fallthrough;
 
     } else {
         /* did we create the directory? */
@@ -162,7 +162,7 @@ int teardown_test(void)
                     fprintf(stderr, "Can't change to test directory. Aborting cleanup.\n");
                     return -1;
                 } else {
-                    /* fallthrough */
+                    fallthrough;
                 }
             } else {
                 return -1;

--- a/lib/roken/fnmatch.c
+++ b/lib/roken/fnmatch.c
@@ -129,8 +129,7 @@ rk_fnmatch(const char *pattern, const char *string, int flags)
 					--pattern;
 				}
 			}
-			/* FALLTHROUGH */
-                        fallthrough
+                        fallthrough;
 		default:
 			if (c != *string++)
 				return (FNM_NOMATCH);

--- a/lib/roken/getuserinfo.c
+++ b/lib/roken/getuserinfo.c
@@ -136,8 +136,7 @@ roken_get_homedir(char *home, size_t homesz)
         }
         return home;
     }
-    /* FALLTHROUGH */
-    fallthrough
+    fallthrough;
 #else
 #ifdef HAVE_GETPWNAM_R
     size_t buflen = 2048;

--- a/lib/roken/snprintf.c
+++ b/lib/roken/snprintf.c
@@ -515,8 +515,7 @@ xyzprintf (struct snprintf_state *state, const char *char_format, va_list ap)
 	    }
 	    case '\0' :
 		--format;
-		/* FALLTHROUGH */
-                fallthrough
+                fallthrough;
 	    case '%' :
 		(*state->append_char)(state, c);
 		++len;

--- a/lib/roken/strftime.c
+++ b/lib/roken/strftime.c
@@ -377,8 +377,7 @@ strftime (char *buf, size_t maxsize, const char *format,
 		break;
 	    case '\0' :
 		--format;
-		/* FALLTHROUGH */
-                fallthrough
+                fallthrough;
 	    case '%' :
 		ret = snprintf (buf, maxsize - n,
 				"%%");

--- a/lib/roken/strptime.c
+++ b/lib/roken/strptime.c
@@ -424,8 +424,7 @@ strptime (const char *buf, const char *format, struct tm *timeptr)
 		abort ();
 	    case '\0' :
 		--format;
-		/* FALLTHROUGH */
-                fallthrough
+                fallthrough;
 	    case '%' :
 		if (*buf == '%')
 		    ++buf;

--- a/lib/wind/utf8.c
+++ b/lib/wind/utf8.c
@@ -205,22 +205,18 @@ wind_ucs4utf8(const uint32_t *in, size_t in_len, char *out, size_t *out_len)
 	    case 4:
 		out[3] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                /* FALLTHROUGH */
-                fallthrough
+                fallthrough;
 	    case 3:
 		out[2] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                /* FALLTHROUGH */
-                fallthrough
+                fallthrough;
 	    case 2:
 		out[1] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                /* FALLTHROUGH */
-                fallthrough
+                fallthrough;
 	    case 1:
 		out[0] = ch | first_char[len - 1];
-                /* FALLTHROUGH */
-                fallthrough
+                fallthrough;
             default:
                 break;
 	    }
@@ -490,17 +486,14 @@ wind_ucs2utf8(const uint16_t *in, size_t in_len, char *out, size_t *out_len)
 	    case 3:
 		out[2] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                /* FALLTHROUGH */
-                fallthrough
+                fallthrough;
 	    case 2:
 		out[1] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                /* FALLTHROUGH */
-                fallthrough
+                fallthrough;
 	    case 1:
 		out[0] = ch | first_char[len - 1];
-                /* FALLTHROUGH */
-                fallthrough
+                fallthrough;
             default:
                 break;
 	    }


### PR DESCRIPTION
The pseudo keyword 'fallthrough' is defined such that case statement
blocks must end with any of these keywords:
 * break;
 * fallthrough;
 * continue;
 * goto <label>;
 * return [expression];
 *
 *  gcc: https://gcc.gnu.org/onlinedocs/gcc/Statement-Attributes.html#Statement-Attributes

The macro is defined either as

  __attribute__((__fallthrough__))

or as

  do {} while (0)  /* fallthrough */

not including the semicolon.

This change implements the Linux kernel style and updates several locations
where "/*fallthrough*/ and /* FALLTHROUGH */ were not previously replaced.

Externally imported code such as libedit, libtommath and sqlite are
restored to their unaltered state.

Change-Id: I69db8167b0d5884f55d96d72de3059a0235a1ba3