### PR TITLE
lib/hdb: Add a flag to force canonicalization

### DIFF
--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -76,6 +76,7 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
 #define HDB_F_DELAY_NEW_KEYS	32768	/* apply [hdb] new_service_key_delay */
 #define HDB_F_SYNTHETIC_OK	65536	/* synthetic principal for PKINIT or GSS preauth OK */
 #define HDB_F_GET_FAST_COOKIE  131072	/* fetch the FX-COOKIE key (not a normal principal) */
+#define HDB_F_FORCE_CANON	262144	/* force canonicalization */
 
 /* hdb_capability_flags */
 #define HDB_CAP_F_HANDLE_ENTERPRISE_PRINCIPAL 1


### PR DESCRIPTION
We need a force canonicalization flag for the Samba database module.