### PR TITLE
Introduce HDB_F_FOR_S4U2SELF

### DIFF
--- a/kdc/mssfu.c
+++ b/kdc/mssfu.c
@@ -110,7 +110,7 @@ validate_protocol_transition(astgs_request_t r)
     EncTicketPart *ticket = &r->ticket->ticket;
     hdb_entry *s4u_client = NULL;
     HDB *s4u_clientdb;
-    int flags = HDB_F_FOR_TGS_REQ;
+    int flags = HDB_F_FOR_TGS_REQ | HDB_F_FOR_S4U2SELF;
     krb5_principal s4u_client_name = NULL, s4u_canon_client_name = NULL;
     krb5_pac s4u_pac = NULL;
     const PA_DATA *sdata;

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -68,6 +68,7 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
 #define HDB_F_CANON		0x00020	/* want canonicalition */
 #define HDB_F_ADMIN_DATA	0x00040	/* want data that kdc don't use  */
 #define HDB_F_KVNO_SPECIFIED	0x00080	/* we want a particular KVNO */
+#define HDB_F_FOR_S4U2SELF	0x00100	/* lookup a for S4U2Self */
 #define HDB_F_LIVE_CLNT_KVNOS	0x00200	/* we want all live keys for pre-auth */
 #define HDB_F_LIVE_SVC_KVNOS	0x00400	/* we want all live keys for tix */
 #define HDB_F_ALL_KVNOS		0x00800	/* we want all the keys, live or not */


### PR DESCRIPTION
The will be used to allow the addition of special SIDS into the
    PAC:
    
    - SID_AUTHENTICATION_AUTHORITY_ASSERTED_IDENTITY (S-1-18-1):
    
      This is added during the AS-REQ/AS-REP exchange after
      pre-authentication was successful.
    
    - SID_SERVICE_ASSERTED_IDENTITY (S-1-18-2):
      This is added during S4U2Self PAC creation.
      It won't replace a possible
      SID_AUTHENTICATION_AUTHORITY_ASSERTED_IDENTITY
      during S4U2Proxy.
