### PR TITLE
allow _kdc_audit_request() to return an error, e.g. HDB_ERR_NOT_FOUND_HERE

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2739,7 +2739,8 @@ out:
     /*
      * In case of a non proxy error, build an error message.
      */
-    if (ret != 0 && ret != HDB_ERR_NOT_FOUND_HERE && r->reply->length == 0)
+    if (ret != 0 && ret != HDB_ERR_NOT_FOUND_HERE && r->reply->length == 0) {
+	kdc_log(r->context, config, 5, "as-req: sending error: %d to client", ret);
 	ret = _kdc_fast_mk_error(r,
 				 r->rep.padata,
 			         r->armor_crypto,
@@ -2749,6 +2750,7 @@ out:
 			         r->server_princ,
 			         NULL, NULL,
 			         r->reply);
+    }
 
     if (r->pa_used && r->pa_used->cleanup)
 	r->pa_used->cleanup(r);

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -2081,7 +2081,7 @@ _kdc_tgs_rep(astgs_request_t r)
     int i = 0;
     const PA_DATA *tgs_req, *pa;
     krb5_enctype krbtgt_etype = ETYPE_NULL;
-
+    krb5_error_code audit_ret;
     time_t *csec = NULL;
     int *cusec = NULL;
 
@@ -2156,7 +2156,14 @@ _kdc_tgs_rep(astgs_request_t r)
 
 out:
     r->error_code = ret;
-    _kdc_audit_request(r);
+    audit_ret = _kdc_audit_request(r);
+    if (audit_ret != 0) {
+	krb5_data_free(r->reply);
+	kdc_audit_addreason((kdc_request_t)r,
+		"tgs-req: _kdc_audit_request(error_code=%d) => %d",
+		r->error_code, audit_ret);
+	ret = audit_ret;
+    }
 
     if(ret && ret != HDB_ERR_NOT_FOUND_HERE && data->data == NULL){
 	METHOD_DATA error_method = { 0, NULL };


### PR DESCRIPTION
This is (at least) required to trigger HDB_ERR_NOT_FOUND_HERE on
    pre-authentication failures on an RODC.
    
    Read-Only DC's need to pass failing pre-authentications to a Read-Write DC
    
    BUG: https://bugzilla.samba.org/show_bug.cgi?id=14865
