### PR TITLE
kdc-plugin: also pass astgs_request_t to the pac related functions

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -870,7 +870,7 @@ _kdc_fast_check_armor_pac(astgs_request_t r)
     if (ret)
 	goto out;
 
-    ret = _kdc_check_pac(r->context, r->config, armor_client_principal, NULL,
+    ret = _kdc_check_pac(r, armor_client_principal, NULL,
 			 armor_client, r->armor_server,
 			 r->armor_server, r->armor_server,
 			 &r->armor_key->key, &r->armor_key->key,

--- a/kdc/kdc-plugin.h
+++ b/kdc/kdc-plugin.h
@@ -48,8 +48,7 @@
 
 typedef krb5_error_code
 (KRB5_CALLCONV *krb5plugin_kdc_pac_generate)(void *,
-					     krb5_context, /* context */
-					     krb5_kdc_configuration *, /* configuration */
+					     astgs_request_t,
 					     hdb_entry *, /* client */
 					     hdb_entry *, /* server */
 					     const krb5_keyblock *, /* pk_replykey */
@@ -64,8 +63,7 @@ typedef krb5_error_code
 
 typedef krb5_error_code
 (KRB5_CALLCONV *krb5plugin_kdc_pac_verify)(void *,
-					   krb5_context, /* context */
-					   krb5_kdc_configuration *, /* configuration */
+					   astgs_request_t,
 					   const krb5_principal, /* new ticket client */
 					   const krb5_principal, /* delegation proxy */
 					   hdb_entry *,/* client */

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1849,8 +1849,7 @@ generate_pac(astgs_request_t r, const Key *skey, const Key *tkey,
      * Validate a PA mech was actually used before doing this.
      */
 
-    ret = _kdc_pac_generate(r->context,
-			    r->config,
+    ret = _kdc_pac_generate(r,
 			    r->client,
 			    r->server,
 			    r->pa_used && !pa_used_flag_isset(r, PA_USES_LONG_TERM_KEY)

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -76,8 +76,7 @@ _kdc_synthetic_princ_used_p(krb5_context context, krb5_ticket *ticket)
  */
 
 krb5_error_code
-_kdc_check_pac(krb5_context context,
-	       krb5_kdc_configuration *config,
+_kdc_check_pac(astgs_request_t r,
 	       const krb5_principal client_principal,
 	       const krb5_principal delegated_proxy_principal,
 	       hdb_entry *client,
@@ -92,6 +91,8 @@ _kdc_check_pac(krb5_context context,
 	       krb5_principal *pac_canon_name,
 	       uint64_t *pac_attributes)
 {
+    krb5_context context = r->context;
+    krb5_kdc_configuration *config = r->config;
     krb5_pac pac = NULL;
     krb5_error_code ret;
     krb5_boolean signedticket;
@@ -122,7 +123,7 @@ _kdc_check_pac(krb5_context context,
     }
 
     /* Verify the KDC signatures. */
-    ret = _kdc_pac_verify(context, config,
+    ret = _kdc_pac_verify(r,
 			  client_principal, delegated_proxy_principal,
 			  client, server, krbtgt, &pac);
     if (ret == 0) {
@@ -1770,7 +1771,7 @@ server_lookup:
 	    }
 
 	    /* Verify the PAC of the TGT. */
-	    ret = _kdc_check_pac(context, config, user2user_princ, NULL,
+	    ret = _kdc_check_pac(priv, user2user_princ, NULL,
 				 user2user_client, user2user_krbtgt, user2user_krbtgt, user2user_krbtgt,
 				 &uukey->key, &priv->ticket_key->key, &adtkt,
 				 &user2user_kdc_issued, &user2user_pac, NULL, NULL);
@@ -1897,7 +1898,7 @@ server_lookup:
     flags &= ~HDB_F_SYNTHETIC_OK;
     priv->clientdb = clientdb;
 
-    ret = _kdc_check_pac(context, config, priv->client_princ, NULL,
+    ret = _kdc_check_pac(priv, priv->client_princ, NULL,
 			 priv->client, priv->server,
 			 priv->krbtgt, priv->krbtgt,
 			 &priv->ticket_key->key, &priv->ticket_key->key, tgt,

--- a/kdc/mssfu.c
+++ b/kdc/mssfu.c
@@ -252,8 +252,7 @@ validate_protocol_transition(astgs_request_t r)
     if (ret)
 	goto out; /* kdc_check_flags() calls kdc_audit_addreason() */
 
-    ret = _kdc_pac_generate(r->context,
-			    r->config,
+    ret = _kdc_pac_generate(r,
 			    s4u_client,
 			    r->server,
 			    NULL,
@@ -473,7 +472,7 @@ validate_constrained_delegation(astgs_request_t r)
      * TODO: pass in t->sname and t->realm and build
      * a S4U_DELEGATION_INFO blob to the PAC.
      */
-    ret = _kdc_check_pac(r->context, r->config, s4u_client_name, s4u_server_name,
+    ret = _kdc_check_pac(r, s4u_client_name, s4u_server_name,
 			 s4u_client, r->server, r->krbtgt, r->client,
 			 &clientkey->key, &r->ticket_key->key, &evidence_tkt,
 			 &ad_kdc_issued, &s4u_pac,


### PR DESCRIPTION
This is more consistent and allows the pac hooks to be more flexible.
