### PR TITLE
kdc: provide kdc_request_get_explicit_armor_{clientdb,client,pac}()

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -465,7 +465,6 @@ fast_unwrap_request(astgs_request_t r,
     krb5_flags ap_req_options;
     krb5_keyblock armorkey;
     krb5_keyblock explicit_armorkey;
-    krb5_boolean explicit_armor;
     krb5_error_code ret;
     krb5_ap_req ap_req;
     KrbFastReq fastreq;
@@ -519,7 +518,7 @@ fast_unwrap_request(astgs_request_t r,
 	goto out;
     }
 
-    explicit_armor = fxreq.u.armored_data.armor != NULL && tgs_ac != NULL;
+    r->explicit_armor_present = fxreq.u.armored_data.armor != NULL && tgs_ac != NULL;
 
     /*
      *
@@ -626,11 +625,11 @@ fast_unwrap_request(astgs_request_t r,
 			       ac->remote_subkey,
 			       &ticket->ticket.key,
 			       &armorkey,
-			       explicit_armor ? NULL : &r->armor_crypto);
+			       r->explicit_armor_present ? NULL : &r->armor_crypto);
     if (ret)
 	goto out;
 
-    if (explicit_armor) {
+    if (r->explicit_armor_present) {
 	ret = _krb5_fast_explicit_armor_key(r->context,
 					    &armorkey,
 					    tgs_ac->remote_subkey,
@@ -886,6 +885,17 @@ _kdc_fast_check_armor_pac(astgs_request_t r)
 	krb5_free_error_message(r->context, msg);
 
 	goto out;
+    }
+
+    if (r->explicit_armor_present) {
+	r->explicit_armor_clientdb = armor_db;
+	armor_db = NULL;
+
+	r->explicit_armor_client = armor_client;
+	armor_client = NULL;
+
+	r->explicit_armor_pac = mspac;
+	mspac = NULL;
     }
 
 out:

--- a/kdc/kdc-accessors.h
+++ b/kdc/kdc-accessors.h
@@ -346,4 +346,24 @@ ASTGS_REQUEST_GET_ACCESSOR(uint64_t, pac_attributes)
 
 ASTGS_REQUEST_SET_ACCESSOR(uint64_t, pac_attributes)
 
+/*
+ * const HDB *
+ * kdc_request_get_explicit_armor_clientdb(astgs_request_t);
+ */
+
+ASTGS_REQUEST_GET_ACCESSOR_PTR(HDB *, explicit_armor_clientdb)
+
+/*
+ * const hdb_entry *
+ * kdc_request_get_explicit_armor_client(astgs_request_t);
+ */
+ASTGS_REQUEST_GET_ACCESSOR_PTR(hdb_entry *, explicit_armor_client);
+
+/*
+ * krb5_const_pac
+ * kdc_request_get_explicit_armor_pac(astgs_request_t);
+ */
+
+ASTGS_REQUEST_GET_ACCESSOR_PTR(struct krb5_pac_data *, explicit_armor_pac);
+
 #endif /* HEIMDAL_KDC_KDC_ACCESSORS_H */

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -182,12 +182,17 @@ struct astgs_request_desc {
     /* only valid for tgs-req */
     unsigned int rk_is_subkey : 1;
     unsigned int fast_asserted : 1;
+    unsigned int explicit_armor_present : 1;
 
     krb5_crypto armor_crypto;
     hdb_entry *armor_server;
     HDB *armor_serverdb;
     krb5_ticket *armor_ticket;
     Key *armor_key;
+
+    hdb_entry *explicit_armor_client;
+    HDB *explicit_armor_clientdb;
+    krb5_pac explicit_armor_pac;
 
     KDCFastState fast;
 };

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -2203,6 +2203,12 @@ out:
 	krb5_free_ticket(r->context, r->armor_ticket);
     if (r->armor_server)
 	_kdc_free_ent(r->context, r->armor_serverdb, r->armor_server);
+    if (r->explicit_armor_client)
+	_kdc_free_ent(r->context,
+		      r->explicit_armor_clientdb,
+		      r->explicit_armor_client);
+    if (r->explicit_armor_pac)
+	krb5_pac_free(r->context, r->explicit_armor_pac);
     krb5_free_keyblock_contents(r->context, &r->reply_key);
     krb5_free_keyblock_contents(r->context, &r->strengthen_key);
 

--- a/kdc/libkdc-exports.def
+++ b/kdc/libkdc-exports.def
@@ -32,6 +32,9 @@ EXPORTS
 	kdc_request_get_config
 	kdc_request_get_cname
 	kdc_request_get_error_code
+	kdc_request_get_explicit_armor_pac
+	kdc_request_get_explicit_armor_clientdb
+	kdc_request_get_explicit_armor_client
 	kdc_request_get_from
 	kdc_request_get_krbtgt
 	kdc_request_get_krbtgtdb

--- a/kdc/version-script.map
+++ b/kdc/version-script.map
@@ -35,6 +35,9 @@ HEIMDAL_KDC_1.0 {
 		kdc_request_get_config;
 		kdc_request_get_cname;
 		kdc_request_get_error_code;
+		kdc_request_get_explicit_armor_pac;
+		kdc_request_get_explicit_armor_clientdb;
+		kdc_request_get_explicit_armor_client;
 		kdc_request_get_from;
 		kdc_request_get_krbtgt;
 		kdc_request_get_krbtgtdb;


### PR DESCRIPTION
_kdc_fast_check_armor_pac() already checks the PAC of the armor,
but it should also remember it if it's an TGS-REQ with explicit armor.

This will allow the kdc pac hooks to generate a compound identity PAC
with PAC_TYPE_DEVICE_INFO.

