### PR TITLE
Make krb5_init_creds_step() usable at all and match the MIT version of it

### DIFF
--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -780,7 +780,7 @@ _krb5_fast_anon_pkinit_step(krb5_context context,
 			    struct krb5_fast_state *state,
 			    krb5_data *in,
 			    krb5_data *out,
-			    const void *_unused,
+			    krb5_realm *out_realm,
 			    unsigned int *flags)
 {
     krb5_error_code ret;
@@ -790,6 +790,9 @@ _krb5_fast_anon_pkinit_step(krb5_context context,
     krb5_ccache ccache = NULL;
     krb5_creds cred;
     krb5_data data = { 3, rk_UNCONST("yes") };
+
+    krb5_data_zero(out);
+    *out_realm = NULL;
 
     memset(&cred, 0, sizeof(cred));
 
@@ -826,7 +829,7 @@ _krb5_fast_anon_pkinit_step(krb5_context context,
 
     anon_pk_ctx = state->anon_pkinit_ctx;
 
-    ret = krb5_init_creds_step(context, anon_pk_ctx, in, out, NULL, flags);
+    ret = krb5_init_creds_step(context, anon_pk_ctx, in, out, out_realm, flags);
     if (ret ||
 	(*flags & KRB5_INIT_CREDS_STEP_FLAG_CONTINUE))
 	goto out;

--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -778,7 +778,7 @@ krb5_error_code
 _krb5_fast_anon_pkinit_step(krb5_context context,
 			    krb5_init_creds_context ctx,
 			    struct krb5_fast_state *state,
-			    krb5_data *in,
+			    const krb5_data *in,
 			    krb5_data *out,
 			    krb5_realm *out_realm,
 			    unsigned int *flags)

--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -877,8 +877,6 @@ _krb5_fast_anon_pkinit_step(krb5_context context,
     krb5_get_init_creds_opt_free(context, state->anon_pkinit_opt);
     state->anon_pkinit_opt = NULL;
 
-    *flags |= KRB5_INIT_CREDS_STEP_FLAG_CONTINUE;
-
 out:
     krb5_free_principal(context, principal);
     krb5_free_cred_contents(context, &cred);

--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -780,7 +780,7 @@ _krb5_fast_anon_pkinit_step(krb5_context context,
 			    struct krb5_fast_state *state,
 			    krb5_data *in,
 			    krb5_data *out,
-			    krb5_krbhst_info *hostinfo,
+			    const void *_unused,
 			    unsigned int *flags)
 {
     krb5_error_code ret;
@@ -826,7 +826,7 @@ _krb5_fast_anon_pkinit_step(krb5_context context,
 
     anon_pk_ctx = state->anon_pkinit_ctx;
 
-    ret = krb5_init_creds_step(context, anon_pk_ctx, in, out, hostinfo, flags);
+    ret = krb5_init_creds_step(context, anon_pk_ctx, in, out, NULL, flags);
     if (ret ||
 	(*flags & KRB5_INIT_CREDS_STEP_FLAG_CONTINUE))
 	goto out;

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -3412,8 +3412,11 @@ init_creds_step(krb5_context context,
     if(len != ctx->req_buffer.length)
 	krb5_abortx(context, "internal error in ASN.1 encoder");
 
-    out->data = ctx->req_buffer.data;
-    out->length = ctx->req_buffer.length;
+    ret = krb5_data_copy(out,
+			 ctx->req_buffer.data,
+			 ctx->req_buffer.length);
+    if (ret)
+	goto out;
 
     *flags = KRB5_INIT_CREDS_STEP_FLAG_CONTINUE;
 
@@ -3435,8 +3438,8 @@ init_creds_step(krb5_context context,
  *
  * @param context a Kerberos 5 context.
  * @param ctx ctx krb5_init_creds_context context.
- * @param in input data from KDC, first round it should be reset by krb5_data_zer().
- * @param out reply to KDC.
+ * @param in input data from KDC, first round it should be reset by krb5_data_zero().
+ * @param out reply to KDC. The caller needs to call krb5_data_free()
  * @param flags status of the round, if
  *        KRB5_INIT_CREDS_STEP_FLAG_CONTINUE is set, continue one more round.
  *
@@ -3702,6 +3705,7 @@ krb5_init_creds_get(krb5_context context, krb5_init_creds_context ctx)
 
 	ret = krb5_sendto_context (context, stctx, &out,
 				   ctx->cred.client->realm, &in);
+	krb5_data_free(&out);
     	if (ret)
 	    goto out;
 

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -2964,7 +2964,7 @@ available_padata_count(METHOD_DATA *md)
 static krb5_error_code
 init_creds_step(krb5_context context,
 		krb5_init_creds_context ctx,
-		krb5_data *in,
+		const krb5_data *in,
 		krb5_data *out,
 		krb5_realm *out_realm,
 		unsigned int *flags)
@@ -3461,7 +3461,7 @@ init_creds_step(krb5_context context,
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_init_creds_step(krb5_context context,
 		     krb5_init_creds_context ctx,
-		     krb5_data *in,
+		     const krb5_data *in,
 		     krb5_data *out,
 		     krb5_realm *out_realm,
 		     unsigned int *flags)

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -2966,7 +2966,7 @@ init_creds_step(krb5_context context,
 		krb5_init_creds_context ctx,
 		krb5_data *in,
 		krb5_data *out,
-		const void *_unused,
+		krb5_realm *out_realm,
 		unsigned int *flags)
 {
     struct timeval start_time, end_time;
@@ -2979,6 +2979,7 @@ init_creds_step(krb5_context context,
     gettimeofday(&start_time, NULL);
 
     krb5_data_zero(out);
+    *out_realm = NULL;
     krb5_data_zero(&checksum_data);
 
     if (ctx->as_req.req_body.cname == NULL) {
@@ -3418,6 +3419,13 @@ init_creds_step(krb5_context context,
     if (ret)
 	goto out;
 
+    *out_realm = strdup(ctx->cred.client->realm);
+    if (*out_realm == NULL) {
+	krb5_data_free(out);
+	ret = ENOMEM;
+	goto out;
+    }
+
     *flags = KRB5_INIT_CREDS_STEP_FLAG_CONTINUE;
 
     gettimeofday(&end_time, NULL);
@@ -3440,6 +3448,7 @@ init_creds_step(krb5_context context,
  * @param ctx ctx krb5_init_creds_context context.
  * @param in input data from KDC, first round it should be reset by krb5_data_zero().
  * @param out reply to KDC. The caller needs to call krb5_data_free()
+ * @param out_realm the destination realm for 'out', free with krb5_xfree()
  * @param flags status of the round, if
  *        KRB5_INIT_CREDS_STEP_FLAG_CONTINUE is set, continue one more round.
  *
@@ -3454,18 +3463,20 @@ krb5_init_creds_step(krb5_context context,
 		     krb5_init_creds_context ctx,
 		     krb5_data *in,
 		     krb5_data *out,
-		     const void *_unused,
+		     krb5_realm *out_realm,
 		     unsigned int *flags)
 {
     krb5_error_code ret;
     krb5_data empty;
 
     krb5_data_zero(&empty);
+    krb5_data_zero(out);
+    *out_realm = NULL;
 
     if ((ctx->fast_state.flags & KRB5_FAST_ANON_PKINIT_ARMOR) &&
 	ctx->fast_state.armor_ccache == NULL) {
 	ret = _krb5_fast_anon_pkinit_step(context, ctx, &ctx->fast_state,
-					  in, out, NULL, flags);
+					  in, out, out_realm, flags);
         if (ret && (ctx->fast_state.flags & KRB5_FAST_OPTIMISTIC)) {
             _krb5_debug(context, 5, "Preauth failed with optimistic "
                         "FAST, trying w/o FAST");
@@ -3479,7 +3490,7 @@ krb5_init_creds_step(krb5_context context,
 	in = &empty;
     }
 
-    return init_creds_step(context, ctx, in, out, NULL, flags);
+    return init_creds_step(context, ctx, in, out, out_realm, flags);
 }
 
 /**
@@ -3691,9 +3702,10 @@ krb5_init_creds_get(krb5_context context, krb5_init_creds_context ctx)
 
     while (1) {
 	struct timeval nstart, nend;
+	krb5_realm realm = NULL;
 
 	flags = 0;
-	ret = krb5_init_creds_step(context, ctx, &in, &out, NULL, &flags);
+	ret = krb5_init_creds_step(context, ctx, &in, &out, &realm, &flags);
 	krb5_data_free(&in);
 	if (ret)
 	    goto out;
@@ -3703,9 +3715,9 @@ krb5_init_creds_get(krb5_context context, krb5_init_creds_context ctx)
 
 	gettimeofday(&nstart, NULL);
 
-	ret = krb5_sendto_context (context, stctx, &out,
-				   ctx->cred.client->realm, &in);
+	ret = krb5_sendto_context (context, stctx, &out, realm, &in);
 	krb5_data_free(&out);
+	free(realm);
     	if (ret)
 	    goto out;
 

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -1243,7 +1243,6 @@ pkinit_step(krb5_context context, krb5_init_creds_context ctx, void *pa_ctx, PA_
 				   a->req_body.realm,
 				   ctx->pk_init_ctx,
 				   rep->enc_part.etype,
-				   NULL,
 				   ctx->pk_nonce,
 				   &ctx->req_buffer,
 				   pa,

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -2256,7 +2256,6 @@ pa_step(krb5_context context,
 	krb5_init_creds_context ctx,
 	const AS_REQ *a,
 	const AS_REP *rep,
-	const krb5_krbhst_info *hi,
 	METHOD_DATA *in_md,
 	METHOD_DATA *out_md)
 {
@@ -2308,7 +2307,7 @@ pa_step(krb5_context context,
 
     _krb5_debug(context, 5, "Stepping pa-mech: %s", ctx->pa_mech->patype->name);
 
-    ret = ctx->pa_mech->patype->step(context, ctx, (void *)&ctx->pa_mech->pactx[0], pa, a, rep, hi, in_md, out_md);
+    ret = ctx->pa_mech->patype->step(context, ctx, (void *)&ctx->pa_mech->pactx[0], pa, a, rep, NULL, in_md, out_md);
     _krb5_debug(context, 10, "PA type %s returned %d", ctx->pa_mech->patype->name, ret);
     if (ret == 0) {
 	struct pa_auth_mech *next_pa = ctx->pa_mech->next;
@@ -2384,7 +2383,7 @@ process_pa_data_to_md(krb5_context context,
 
     log_kdc_pa_types(context, in_md);
 
-    ret = pa_step(context, ctx, a, NULL, NULL, in_md, *out_md);
+    ret = pa_step(context, ctx, a, NULL, in_md, *out_md);
     if (ret == HEIM_ERR_PA_CONTINUE_NEEDED) {
 	_krb5_debug(context, 0, "pamech need more stepping");
     } else if (ret == 0) {
@@ -2443,7 +2442,7 @@ process_pa_data_to_key(krb5_context context,
 	}
     }
 
-    ret = pa_step(context, ctx, a, rep, NULL, rep->padata, NULL);
+    ret = pa_step(context, ctx, a, rep, rep->padata, NULL);
     if (ret == HEIM_ERR_PA_CONTINUE_NEEDED) {
 	_krb5_debug(context, 0, "In final stretch and pa require more stepping ?");
 	return ret;

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -3470,8 +3470,7 @@ krb5_init_creds_step(krb5_context context,
             ctx->fast_state.flags &= ~KRB5_FAST_REQUIRED;
             ctx->fast_state.flags &= ~KRB5_FAST_ANON_PKINIT_ARMOR;
         } else if (ret ||
-                   ((*flags & KRB5_INIT_CREDS_STEP_FLAG_CONTINUE) == 0) ||
-                   out->length)
+                   (*flags & KRB5_INIT_CREDS_STEP_FLAG_CONTINUE))
 	    return ret;
 
 	in = &empty;

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -2966,7 +2966,7 @@ init_creds_step(krb5_context context,
 		krb5_init_creds_context ctx,
 		krb5_data *in,
 		krb5_data *out,
-		krb5_krbhst_info *hostinfo,
+		const void *_unused,
 		unsigned int *flags)
 {
     struct timeval start_time, end_time;
@@ -3053,7 +3053,7 @@ init_creds_step(krb5_context context,
 
 	    ret = process_pa_data_to_key(context, ctx, &ctx->cred,
 					 &ctx->as_req, &rep.kdc_rep,
-					 hostinfo, &ctx->fast_state.reply_key);
+					 NULL, &ctx->fast_state.reply_key);
 	    if (ret) {
 		free_AS_REP(&rep.kdc_rep);
 		goto out;
@@ -3437,7 +3437,6 @@ init_creds_step(krb5_context context,
  * @param ctx ctx krb5_init_creds_context context.
  * @param in input data from KDC, first round it should be reset by krb5_data_zer().
  * @param out reply to KDC.
- * @param hostinfo KDC address info, first round it can be NULL.
  * @param flags status of the round, if
  *        KRB5_INIT_CREDS_STEP_FLAG_CONTINUE is set, continue one more round.
  *
@@ -3452,7 +3451,7 @@ krb5_init_creds_step(krb5_context context,
 		     krb5_init_creds_context ctx,
 		     krb5_data *in,
 		     krb5_data *out,
-		     krb5_krbhst_info *hostinfo,
+		     const void *_unused,
 		     unsigned int *flags)
 {
     krb5_error_code ret;
@@ -3463,7 +3462,7 @@ krb5_init_creds_step(krb5_context context,
     if ((ctx->fast_state.flags & KRB5_FAST_ANON_PKINIT_ARMOR) &&
 	ctx->fast_state.armor_ccache == NULL) {
 	ret = _krb5_fast_anon_pkinit_step(context, ctx, &ctx->fast_state,
-					  in, out, hostinfo, flags);
+					  in, out, NULL, flags);
         if (ret && (ctx->fast_state.flags & KRB5_FAST_OPTIMISTIC)) {
             _krb5_debug(context, 5, "Preauth failed with optimistic "
                         "FAST, trying w/o FAST");
@@ -3478,7 +3477,7 @@ krb5_init_creds_step(krb5_context context,
 	in = &empty;
     }
 
-    return init_creds_step(context, ctx, in, out, hostinfo, flags);
+    return init_creds_step(context, ctx, in, out, NULL, flags);
 }
 
 /**
@@ -3671,7 +3670,6 @@ KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_init_creds_get(krb5_context context, krb5_init_creds_context ctx)
 {
     krb5_sendto_ctx stctx = NULL;
-    krb5_krbhst_info *hostinfo = NULL;
     krb5_error_code ret;
     krb5_data in, out;
     unsigned int flags = 0;
@@ -3693,7 +3691,7 @@ krb5_init_creds_get(krb5_context context, krb5_init_creds_context ctx)
 	struct timeval nstart, nend;
 
 	flags = 0;
-	ret = krb5_init_creds_step(context, ctx, &in, &out, hostinfo, &flags);
+	ret = krb5_init_creds_step(context, ctx, &in, &out, NULL, &flags);
 	krb5_data_free(&in);
 	if (ret)
 	    goto out;

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -2417,7 +2417,6 @@ process_pa_data_to_key(krb5_context context,
 		       krb5_creds *creds,
 		       AS_REQ *a,
 		       AS_REP *rep,
-		       const krb5_krbhst_info *hi,
 		       krb5_keyblock **key)
 {
     struct pa_info_data paid, *ppaid = NULL;
@@ -2444,7 +2443,7 @@ process_pa_data_to_key(krb5_context context,
 	}
     }
 
-    ret = pa_step(context, ctx, a, rep, hi, rep->padata, NULL);
+    ret = pa_step(context, ctx, a, rep, NULL, rep->padata, NULL);
     if (ret == HEIM_ERR_PA_CONTINUE_NEEDED) {
 	_krb5_debug(context, 0, "In final stretch and pa require more stepping ?");
 	return ret;
@@ -3054,7 +3053,7 @@ init_creds_step(krb5_context context,
 
 	    ret = process_pa_data_to_key(context, ctx, &ctx->cred,
 					 &ctx->as_req, &rep.kdc_rep,
-					 NULL, &ctx->fast_state.reply_key);
+					 &ctx->fast_state.reply_key);
 	    if (ret) {
 		free_AS_REP(&rep.kdc_rep);
 		goto out;

--- a/lib/krb5/pkinit.c
+++ b/lib/krb5/pkinit.c
@@ -1365,7 +1365,6 @@ pk_rd_pa_reply_dh(krb5_context context,
 		  const char *realm,
 		  krb5_pk_init_ctx ctx,
 		  krb5_enctype etype,
-		  const krb5_krbhst_info *hi,
 		  const DHNonce *c_n,
 		  const DHNonce *k_n,
                   unsigned nonce,
@@ -1407,7 +1406,7 @@ pk_rd_pa_reply_dh(krb5_context context,
 
     if (host) {
 	/* make sure that it is the kdc's certificate */
-	ret = pk_verify_host(context, realm, hi, ctx, host);
+	ret = pk_verify_host(context, realm, NULL, ctx, host);
 	if (ret)
 	    goto out;
 
@@ -1657,7 +1656,7 @@ _krb5_pk_rd_pa_reply(krb5_context context,
 
 	switch (rep.element) {
 	case choice_PA_PK_AS_REP_dhInfo:
-	    ret = pk_rd_pa_reply_dh(context, &data, &oid, realm, ctx, etype, NULL,
+	    ret = pk_rd_pa_reply_dh(context, &data, &oid, realm, ctx, etype,
 				    ctx->clientDHNonce,
 				    rep.u.dhInfo.serverDHNonce,
 				    nonce, pa, key);

--- a/lib/krb5/pkinit.c
+++ b/lib/krb5/pkinit.c
@@ -1115,7 +1115,6 @@ pk_rd_pa_reply_enckey(krb5_context context,
 		      const char *realm,
 		      krb5_pk_init_ctx ctx,
 		      krb5_enctype etype,
-		      const krb5_krbhst_info *hi,
 	       	      unsigned nonce,
 		      const krb5_data *req_buffer,
 	       	      PA_DATA *pa,
@@ -1219,7 +1218,7 @@ pk_rd_pa_reply_enckey(krb5_context context,
 
     if (host) {
 	/* make sure that it is the kdc's certificate */
-	ret = pk_verify_host(context, realm, hi, ctx, host);
+	ret = pk_verify_host(context, realm, NULL, ctx, host);
 	if (ret)
 	    goto out;
 
@@ -1663,7 +1662,7 @@ _krb5_pk_rd_pa_reply(krb5_context context,
 	    break;
 	case choice_PA_PK_AS_REP_encKeyPack:
 	    ret = pk_rd_pa_reply_enckey(context, PKINIT_27, &data, &oid, realm,
-					ctx, etype, NULL, nonce, req_buffer, pa, key);
+					ctx, etype, nonce, req_buffer, pa, key);
 	    break;
 	default:
 	    krb5_abortx(context, "pk-init as-rep case not possible to happen");
@@ -1715,7 +1714,7 @@ _krb5_pk_rd_pa_reply(krb5_context context,
 	    }
 
 	    ret = pk_rd_pa_reply_enckey(context, PKINIT_WIN2K, &data, &oid, realm,
-					ctx, etype, NULL, nonce, req_buffer, pa, key);
+					ctx, etype, nonce, req_buffer, pa, key);
 	    der_free_octet_string(&data);
 	    der_free_oid(&oid);
 

--- a/lib/krb5/pkinit.c
+++ b/lib/krb5/pkinit.c
@@ -1567,7 +1567,6 @@ _krb5_pk_rd_pa_reply(krb5_context context,
 		     const char *realm,
 		     void *c,
 		     krb5_enctype etype,
-		     const krb5_krbhst_info *hi,
 		     unsigned nonce,
 		     const krb5_data *req_buffer,
 		     PA_DATA *pa,
@@ -1658,14 +1657,14 @@ _krb5_pk_rd_pa_reply(krb5_context context,
 
 	switch (rep.element) {
 	case choice_PA_PK_AS_REP_dhInfo:
-	    ret = pk_rd_pa_reply_dh(context, &data, &oid, realm, ctx, etype, hi,
+	    ret = pk_rd_pa_reply_dh(context, &data, &oid, realm, ctx, etype, NULL,
 				    ctx->clientDHNonce,
 				    rep.u.dhInfo.serverDHNonce,
 				    nonce, pa, key);
 	    break;
 	case choice_PA_PK_AS_REP_encKeyPack:
 	    ret = pk_rd_pa_reply_enckey(context, PKINIT_27, &data, &oid, realm,
-					ctx, etype, hi, nonce, req_buffer, pa, key);
+					ctx, etype, NULL, nonce, req_buffer, pa, key);
 	    break;
 	default:
 	    krb5_abortx(context, "pk-init as-rep case not possible to happen");
@@ -1717,7 +1716,7 @@ _krb5_pk_rd_pa_reply(krb5_context context,
 	    }
 
 	    ret = pk_rd_pa_reply_enckey(context, PKINIT_WIN2K, &data, &oid, realm,
-					ctx, etype, hi, nonce, req_buffer, pa, key);
+					ctx, etype, NULL, nonce, req_buffer, pa, key);
 	    der_free_octet_string(&data);
 	    der_free_oid(&oid);
 

--- a/lib/krb5/pkinit.c
+++ b/lib/krb5/pkinit.c
@@ -1017,7 +1017,6 @@ pk_verify_host(krb5_context context,
 	       struct krb5_pk_init_ctx_data *ctx,
 	       struct krb5_pk_cert *host)
 {
-    const krb5_krbhst_info *hi = NULL;
     krb5_error_code ret = 0;
 
     if (ctx->require_eku) {
@@ -1092,18 +1091,6 @@ pk_verify_host(krb5_context context,
     if (ret)
 	return ret;
 
-    if (hi) {
-	ret = hx509_verify_hostname(context->hx509ctx, host->cert,
-				    ctx->require_hostname_match,
-				    HX509_HN_HOSTNAME,
-				    hi->hostname,
-				    hi->ai->ai_addr, hi->ai->ai_addrlen);
-
-	if (ret)
-	    krb5_set_error_message(context, ret,
-				   N_("Address mismatch in "
-				      "the KDC certificate", ""));
-    }
     return ret;
 }
 

--- a/lib/krb5/pkinit.c
+++ b/lib/krb5/pkinit.c
@@ -1014,10 +1014,10 @@ get_reply_key(krb5_context context,
 static krb5_error_code
 pk_verify_host(krb5_context context,
 	       const char *realm,
-	       const krb5_krbhst_info *hi,
 	       struct krb5_pk_init_ctx_data *ctx,
 	       struct krb5_pk_cert *host)
 {
+    const krb5_krbhst_info *hi = NULL;
     krb5_error_code ret = 0;
 
     if (ctx->require_eku) {
@@ -1218,7 +1218,7 @@ pk_rd_pa_reply_enckey(krb5_context context,
 
     if (host) {
 	/* make sure that it is the kdc's certificate */
-	ret = pk_verify_host(context, realm, NULL, ctx, host);
+	ret = pk_verify_host(context, realm, ctx, host);
 	if (ret)
 	    goto out;
 
@@ -1405,7 +1405,7 @@ pk_rd_pa_reply_dh(krb5_context context,
 
     if (host) {
 	/* make sure that it is the kdc's certificate */
-	ret = pk_verify_host(context, realm, NULL, ctx, host);
+	ret = pk_verify_host(context, realm, ctx, host);
 	if (ret)
 	    goto out;
 


### PR DESCRIPTION
    NOTE: commit 1cdc9d5f3cff0288846c29c35ee91b6056a2e2bb
    "krb5: export krb5_init_creds_step()" exported
    krb5_init_creds_step() the first time, but that's
    not in any released version, so it should be fine
    to fix up the prototype in order to make the
    function actually useful for external callers.

All the "lib/krb5: remove unused krb5_krbhst_info argument of" commits are
not strictly required, but they show that the last commit
"lib/krb5: remove dead code from pk_verify_host()"
actually removed dead code. If the logic
in pk_verify_host() should be kept,
a krb5_krbhst_info should be passed in though any useful
way, but passing it to krb5_init_creds_step() is clearly not
the correct way. Maybe a new krb5_init_creds_set_*() function.