### PR TITLE
hdb: Fix crashes with WRONG_REALM

### DIFF
--- a/lib/hdb/common.c
+++ b/lib/hdb/common.c
@@ -1575,7 +1575,7 @@ fetch_it(krb5_context context,
     }
 
 out:
-    if (ret)
+    if (ret != 0 && ret != HDB_ERR_WRONG_REALM)
         hdb_free_entry(context, db, ent);
     krb5_free_principal(context, nsprinc);
     free(host);


### PR DESCRIPTION
With HDB_ERR_WRONG_REALM the backend needs to expose the
principal, so we should not free the entry otherwise
the main kdc code will crash.
