### PR TITLE
krb5: don't export krb5_init_creds_step()

### DIFF
--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -826,7 +826,7 @@ _krb5_fast_anon_pkinit_step(krb5_context context,
 
     anon_pk_ctx = state->anon_pkinit_ctx;
 
-    ret = krb5_init_creds_step(context, anon_pk_ctx, in, out, hostinfo, flags);
+    ret = _krb5_init_creds_step(context, anon_pk_ctx, in, out, hostinfo, flags);
     if (ret ||
 	(*flags & KRB5_INIT_CREDS_STEP_FLAG_CONTINUE))
 	goto out;

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -3447,13 +3447,17 @@ init_creds_step(krb5_context context,
  * @ingroup krb5_credential
  */
 
-KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
-krb5_init_creds_step(krb5_context context,
-		     krb5_init_creds_context ctx,
-		     krb5_data *in,
-		     krb5_data *out,
-		     krb5_krbhst_info *hostinfo,
-		     unsigned int *flags)
+/*
+ * This has a broken prototype, so don't export it, see:
+ * https://github.com/heimdal/heimdal/pull/972
+ */
+krb5_error_code
+_krb5_init_creds_step(krb5_context context,
+		      krb5_init_creds_context ctx,
+		      krb5_data *in,
+		      krb5_data *out,
+		      krb5_krbhst_info *hostinfo,
+		      unsigned int *flags)
 {
     krb5_error_code ret;
     krb5_data empty;
@@ -3693,7 +3697,7 @@ krb5_init_creds_get(krb5_context context, krb5_init_creds_context ctx)
 	struct timeval nstart, nend;
 
 	flags = 0;
-	ret = krb5_init_creds_step(context, ctx, &in, &out, hostinfo, &flags);
+	ret = _krb5_init_creds_step(context, ctx, &in, &out, hostinfo, &flags);
 	krb5_data_free(&in);
 	if (ret)
 	    goto out;

--- a/lib/krb5/libkrb5-exports.def.in
+++ b/lib/krb5/libkrb5-exports.def.in
@@ -870,7 +870,6 @@ EXPORTS
 	krb5_init_creds_set_password
 	krb5_init_creds_set_service
 	krb5_init_creds_set_sitename
-	krb5_init_creds_step
 	krb5_init_creds_store
 	krb5_init_creds_store_config
 	krb5_init_creds_warn_user

--- a/lib/krb5/version-script.map
+++ b/lib/krb5/version-script.map
@@ -858,7 +858,6 @@ HEIMDAL_KRB5_2.0 {
 		krb5_init_creds_get_error;
 		krb5_init_creds_set_password;
 		krb5_init_creds_set_sitename;
-		krb5_init_creds_step;
 		krb5_init_creds_store;
 		krb5_init_creds_store_config;
 		krb5_init_creds_free;


### PR DESCRIPTION
The current prototype is unusable for external callers
and no released version exported it yet.

https://github.com/heimdal/heimdal/pull/972 will hopefully
fix it, but for now we should keep it internal.
