### PR TITLE
kdc: Add function to add encrypted padata

### DIFF
--- a/kdc/kdc-plugin.c
+++ b/kdc/kdc-plugin.c
@@ -432,6 +432,19 @@ kdc_request_add_reply_padata(astgs_request_t r, PA_DATA *md)
 }
 
 KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
+kdc_request_add_encrypted_padata(astgs_request_t r, PA_DATA *md)
+{
+    if (r->ek.encrypted_pa_data == NULL) {
+	r->ek.encrypted_pa_data = calloc(1, sizeof *(r->ek.encrypted_pa_data));
+	if (r->ek.encrypted_pa_data == NULL) {
+	    return ENOMEM;
+	}
+    }
+
+    return add_METHOD_DATA(r->ek.encrypted_pa_data, md);
+}
+
+KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 kdc_request_add_pac_buffer(astgs_request_t r,
 			   uint32_t pactype,
 			   const krb5_data *d)

--- a/kdc/libkdc-exports.def
+++ b/kdc/libkdc-exports.def
@@ -21,6 +21,7 @@ EXPORTS
 	kdc_request_get_attribute
 	kdc_request_copy_attribute
 	kdc_request_delete_attribute
+	kdc_request_add_encrypted_padata
 	kdc_request_add_pac_buffer
 	kdc_request_add_reply_padata
 	kdc_request_get_addr

--- a/kdc/version-script.map
+++ b/kdc/version-script.map
@@ -24,6 +24,7 @@ HEIMDAL_KDC_1.0 {
 		kdc_request_get_attribute;
 		kdc_request_copy_attribute;
 		kdc_request_delete_attribute;
+		kdc_request_add_encrypted_padata;
 		kdc_request_add_pac_buffer;
 		kdc_request_add_reply_padata;
 		kdc_request_get_addr;


### PR DESCRIPTION
Since plugins no longer have a way of accessing the 'ek' member of the request structure, this function provides a way for a plugin to add encrypted padata to the response.