### PR TITLE
lib/krb5: before we create a new FAST armor we should clear the old s…

### DIFF
--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -413,8 +413,14 @@ _krb5_fast_create_armor(krb5_context context,
     }
 
     if (state->type == choice_PA_FX_FAST_REQUEST_armored_data) {
-	if (state->armor_crypto)
+	if (state->armor_crypto) {
 	    krb5_crypto_destroy(context, state->armor_crypto);
+	    state->armor_crypto = NULL;
+	}
+	if (state->strengthen_key) {
+	    krb5_free_keyblock(context, state->strengthen_key);
+	    state->strengthen_key = NULL;
+	}
 	krb5_free_keyblock_contents(context, &state->armor_key);
 
 	/*


### PR DESCRIPTION
…trengthen_key

In a cross-realm situation the client KDC exchange may use on orphaned
strengthen_key (from the previous exchange) if the current KDC
doesn't not support FAST and the previous KDC supported it.

Otherwise init_creds_step() or fast_tgs_strengthen_key()
generate the reply key.

BUG: https://bugzilla.samba.org/show_bug.cgi?id=15005

Signed-off-by: Stefan Metzmacher <metze@samba.org>