### PR TITLE
kdc: add enable_fast option (enabled by default)

### DIFF
--- a/kdc/default_config.c
+++ b/kdc/default_config.c
@@ -101,6 +101,7 @@ krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
     c->strict_nametypes = FALSE;
     c->trpolicy = TRPOLICY_ALWAYS_CHECK;
     c->require_pac = FALSE;
+    c->enable_fast = TRUE;
     c->enable_armored_pa_enc_timestamp = TRUE;
     c->enable_unarmored_pa_enc_timestamp = TRUE;
     c->enable_pkinit = FALSE;
@@ -260,6 +261,14 @@ krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
 				     c->require_pac,
 				     "kdc",
 				     "require_pac",
+				     NULL);
+
+    c->enable_fast =
+	krb5_config_get_bool_default(context,
+				     NULL,
+				     c->enable_fast,
+				     "kdc",
+				     "enable_fast",
 				     NULL);
 
     c->enable_armored_pa_enc_timestamp =

--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -756,6 +756,9 @@ _kdc_fast_unwrap_request(astgs_request_t r,
     const PA_DATA *pa;
     int i = 0;
 
+    if (!r->config->enable_fast)
+	return 0;
+
     ret = fast_unwrap_request(r, tgs_ticket, tgs_ac);
     if (ret)
 	return ret;

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -100,6 +100,7 @@ struct krb5_kdc_configuration {
     enum krb5_kdc_trpolicy trpolicy;
 
     unsigned int require_pac : 1;
+    unsigned int enable_fast : 1;
     unsigned int enable_armored_pa_enc_timestamp : 1;
     unsigned int enable_unarmored_pa_enc_timestamp : 1;
 

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -902,6 +902,9 @@ validate_fast_ad(astgs_request_t r, krb5_authdata *auth_data)
 
     krb5_data_zero(&data);
 
+    if (!r->config->enable_fast)
+	return 0;
+
     ret = _krb5_get_ad(r->context, auth_data, NULL,
 		       KRB5_AUTHDATA_FX_FAST_USED, &data);
     if (ret == 0) {

--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -816,6 +816,8 @@ addresses in the tickets.
 .It Li allow-null-ticket-addresses = Va BOOL
 Allow address-less tickets.
 .\" XXX
+.It Li enable_fast = Va BOOL
+Enable RFC 6113 FAST support, this is enabled by default.
 .It Li enable_armored_pa_enc_timestamp = Va BOOL
 Enable armored encrypted timestamp pre-authentication with key
 strengthening.


### PR DESCRIPTION
This makes it possible to disable fast if needed,
which is very good for regression tests.
Samba disables this in a few test environments with this
option.

BUG: https://bugzilla.samba.org/show_bug.cgi?id=15002
BUG: https://bugzilla.samba.org/show_bug.cgi?id=15005

Signed-off-by: Stefan Metzmacher <metze@samba.org>