### PR TITLE
Hard and soft HDB entry aliases

### DIFF
--- a/doc/setup.texi
+++ b/doc/setup.texi
@@ -17,6 +17,8 @@ doing so.  It will make life easier for you and everyone else.
 * Creating the database::
 * Modifying the database::
 * Using namespaces and synthetic principals to keep the database small::
+* Using hard aliases for realm migration::
+* Using soft aliases for configuring referrals::
 * Checking the setup::
 * keytabs::
 * Remote administration::
@@ -344,6 +346,60 @@ details.
 Using these features one can end up with a database that contains just
 @code{krbtgt} principals, principals for locked users, and principals
 that are neither @code{krbtgt}, user, nor host-based services.
+
+@node Using hard aliases for realm migration, Using soft aliases for configuring referrals, Using namespaces and synthetic principals to keep the database small, Setting up a realm
+@section Using hard aliases for realm migration
+
+The Heimdal @command{kadmin} command can be used to add aliases to
+principal entries in the Heimdal database.  Aliases of principals of
+the form @samp{WELLKNOWN/REFERRALS/TARGET} or
+@samp{WELLKNOWN/REFERRALS/TARGET/anything} are "soft" aliases.
+Aliases of principals of other forms are "hard" aliases.
+
+When a client makes a request for a principal's alias, and it does not
+use the KDC request "canonicalize" option flag, the Heimdal KDC will
+treat the alias as a distinct principal that happens to share
+attributes and long-term symmetric keys and salts with the principal
+it is an alias of.
+
+This is useful for, for example, ensuring that host-based principals
+can be referred to by any aliases.
+
+This can also be very useful for renaming realms: add new
+@code{krbtgt} principals for the new realms, then add aliases to
+existing principals in their new realms. For example, a user with a
+principal @code{joe@@A} can be given an alias of
+@code{joes@@B}, and
+then they can @code{kinit joes@@B} and get Kerberos tickets for
+@code{joes@@B}. Similarly, a service principal such as
+@code{HTTP/foo.bar.baz.example@@BAZ.EXAMPLE} can be given an alias such as
+@code{HTTP/foo.bar.baz.example@@BAR.BAZ.EXAMPLE}, or even
+@code{HTTP/foobar.new-domain.example@@NEW-DOMAIN.EXAMPLE}, and
+requesting tickets with those aliases as the service names will work.
+
+@node Using soft aliases for configuring referrals, Checking the setup, Using hard aliases for realm migration, Setting up a realm
+@section Using soft aliases for configuring referrals
+
+Soft aliases, which are aliases of principals of the form
+@code{WELLKNOWN/REFERRALS/TARGET} or
+@code{WELLKNOWN/REFERRALS/TARGET/anything}, are used to generate
+referrals to other realms. Specifically, the realm of a soft alias'
+canonical name is the realm to issue referrals to.
+
+Soft aliases can be used to configure individual referrals, but also
+of entire namespaces of hostnames. To configure the issuance of
+referrals for entire namespaces, make a soft alias of the form
+@code{WELLKNOWN/HOSTBASED-NAMESPACE/service/namespace-fqdn@@REALM} to
+have the TGS for that @samp{REALM} issue referrals for all principals
+of the form @code{service/hostname@@REALM} where the hostname component
+is a sub-domain of the namespace component of the alias name.
+
+For example, a soft alias name
+@code{WELLKNOWN/HOSTBASED-NAMESPACE/host/cloud.bar.example@@BAR.EXAMPLE}
+to a realm @samp{B} will cause the KDC to issue referrals to @samp{B}
+for any principals such as
+@samp{host/foo.cloud.bar.example@@BAR.EXAMPLE}, and
+@samp{host/baz.cloud.bar.example@@BAR.EXAMPLE}, and so on.
 
 @node Checking the setup, keytabs, Using namespaces and synthetic principals to keep the database small, Setting up a realm
 @section Checking the setup

--- a/kadmin/kadmin.1
+++ b/kadmin/kadmin.1
@@ -150,14 +150,34 @@ This command has the following aliases:
 .Bd -ragged -offset indent
 Adds one or more aliases to the given principal.
 .Pp
-When a client requests a service ticket for a service principal
-name that is an alias of a principal in a different realm, the
-TGS will return a referral to that realm.
-This compares favorably to using
+There are two types of aliases: hard, and soft.
+A soft alias is an alias of a principal of the form
+.Ar WELLKNOWN/REFERRALS/TARGET@target_realm
+or
+.Ar WELLKNOWN/REFERRALS/TARGET/arbitrary-component@target_realm .
+A hard alias is an alias of any normal principal, even if in a
+different realm.
+.Pp
+Hard aliases are treated as distinct principals sharing
+attributes and keys with their canonical principals.
+If a client requests canonicalization of a hard alias name, the
+KDC will use the canonical name in the ticket issued as long as
+the alias and canonical names are in the same realm.
+Conversely, if a client does not request canonicalization, or if
+the hard alias and the canonical name have different realms, then
+the KDC will issue a ticket for the alias name.
+.Pp
+Soft aliases can only be used to configure the production of
+referrals by the KDC.
+When a client requests a ticket for a principal that turns out to
+be a soft alias, the KDC will respond with a referral to the
+alias' canonical name's realm.
+.Pp
+Soft aliasing compares favorably to using
 .Ar [domain_realm]
 entries in the KDC's
-.Ar krb5.conf ,
-but may be managed via the
+.Ar krb5.conf :
+soft aliases may be managed via the
 .Nm kadmin
 command and its
 .Nm add_alias
@@ -166,9 +186,9 @@ and
 sub-commands rather than having to edit the KDC's configuration
 file and having to restart the KDC.
 .Pp
-There are two methods for issuing referrals for entire namespaces
-of hostnames.
-An alias of the form
+There are two methods for configuring the issuance of referrals
+for entire namespaces of hostnames.
+A soft alias of the form
 .Ar  WELLKNOWN/HOSTBASED-NAMESPACE/service/namespace-fqdn@REALM
 (see
 .Nm add_namespace
@@ -402,11 +422,15 @@ only change the ones specified.
 .Pp
 The
 .Fl Fl alias= Ns Ar alias-name
-option may be given multiple times, which will set the complete
-list of aliases for the principal.
+option may be given multiple times.
+If this option is used at all, the complete list of aliases must
+be given, with one option per-alias.
+If the list given has fewer aliases than the principal had prior
+to the modification, then the missing aliases will be deleted.
+.Pp
 Use the
 .Nm add_alias
-command instead to add an alias without having to list all
+command instead to add an alias to avoid having to list all
 existing aliases to keep.
 .Pp
 The

--- a/lib/hdb/hdb.asn1
+++ b/lib/hdb/hdb.asn1
@@ -59,6 +59,8 @@ HDBFlags ::= BIT STRING {
 	force-canonicalize(30),		-- force the KDC to return the canonical
 					-- principal irrespective of the setting
 					-- of the canonicalize KDC option
+                                        -- (principals cannot have this flag
+                                        -- set when stored into the HDB)
 	do-not-store(31)		-- Not to be modified and stored in HDB
 }
 

--- a/lib/hdb/hdb.opt
+++ b/lib/hdb/hdb.opt
@@ -3,3 +3,7 @@
 --sequence=HDB-Ext-KeySet
 --sequence=Keys
 --decorate=HDB_entry:void:context?:::
+# The `aliased` field is for indicating whether a name used in an HDB
+# lookup was an alias.  This could be useful to applications when hard
+# aliasing is implemented in an HDB backend, as it should be.
+--decorate=HDB_entry:int:aliased:::

--- a/lib/hdb/keytab.c
+++ b/lib/hdb/keytab.c
@@ -223,10 +223,9 @@ hdb_get_entry(krb5_context context,
                          HDB_F_GET_CLIENT|HDB_F_GET_SERVER|HDB_F_GET_KRBTGT,
                          0, 0, kvno, &ent);
 
-    if(ret == HDB_ERR_NOENTRY) {
+    if (ret == HDB_ERR_WRONG_REALM || ret == HDB_ERR_NOENTRY)
 	ret = KRB5_KT_NOTFOUND;
-	goto out;
-    }else if(ret)
+    if (ret)
 	goto out;
 
     if(kvno && (krb5_kvno)ent.kvno != kvno) {

--- a/tests/gss/krb5.conf.in
+++ b/tests/gss/krb5.conf.in
@@ -45,6 +45,7 @@ include @srcdirabs@/include-krb5.conf
         enable_virtual_hostbased_princs = true
         virtual_hostbased_princ_mindots = 1
         virtual_hostbased_princ_maxdots = 3
+        same_realm_aliases_are_soft = true
 
 [logging]
 	kdc = 0-/FILE:@objdir@/messages.log

--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -238,11 +238,11 @@ ${kadmin} ext -k ${keytab} ${rps} || exit 1
 
 ${kadmin} add -p kaka --use-defaults ${server2}@${R2} || exit 1
 ${kadmin} ext -k ${keytab} ${server2}@${R2} || exit 1
-${kadmin} add -p foo  --use-defaults referral-placeholder@${R5} || exit 1
-${kadmin} add_alias referral-placeholder@${R5} ${server3}@${R} || exit 1
+${kadmin} add -p foo  --use-defaults WELLKNOWN/REFERRALS/TARGET@${R5} || exit 1
+${kadmin} add_alias WELLKNOWN/REFERRALS/TARGET@${R5} ${server3}@${R} || exit 1
 ${kadmin5} add -p kaka --use-defaults ${server3}@${R5} || exit 1
 ${kadmin5} ext -k ${keytab} ${server3}@${R5} || exit 1
-${kadmin} add_alias referral-placeholder@${R5} ${namespace}@${R} || exit 1
+${kadmin} add_alias WELLKNOWN/REFERRALS/TARGET@${R5} ${namespace}@${R} || exit 1
 ${kadmin5} add -p kaka --use-defaults ${server5}@${R5} || exit 1
 ${kadmin5} ext -k ${keytab} ${server5}@${R5} || exit 1
 ${kadmin} add -p kaka --use-defaults ${serverip}@${R} || exit 1

--- a/tests/kdc/check-referral.in
+++ b/tests/kdc/check-referral.in
@@ -45,7 +45,8 @@ ${have_db} || exit 77
 R=TEST.H5L.SE
 R2=SUB.TEST.H5L.SE
 
-service=ldap/host.sub.test.h5l.se:389
+service1=ldap/host.test.h5l.se:389
+service2=ldap/host.sub.test.h5l.se:389
 
 port=@port@
 
@@ -63,6 +64,9 @@ keytab="FILE:${keytabfile}"
 
 KRB5_CONFIG="${objdir}/krb5.conf"
 export KRB5_CONFIG
+
+KRB5CCNAME=$cache
+export KRB5CCNAME
 
 rm -f ${keytabfile}
 rm -f current-db*
@@ -84,11 +88,25 @@ ${kadmin} \
     --realm-max-renewable-life=1month \
     ${R2} || exit 1
 
+${kadmin} add -r --use-defaults WELLKNOWN/REFERRALS/TARGET@${R} || exit 1
+${kadmin} add -r --use-defaults WELLKNOWN/REFERRALS/TARGET@${R2} || exit 1
+
 ${kadmin} add -p foo --use-defaults foo@${R} || exit 1
 ${kadmin} modify --alias=alias1 --alias=alias2 foo@${R} || exit 1
+${kadmin} add_alias foo@${R} foo@${R2} || exit 1
 ${kadmin} get foo@${R} | grep alias1@${R} >/dev/null || exit 1
 
-${kadmin} add -p foo --use-defaults  ${service}@${R2} || exit 1
+${kadmin} add -p foo --use-defaults  ${service2}@${R2} || exit 1
+${kadmin} add_alias ${service2}@${R2}  ${service1}@${R} || exit 1
+${kadmin} get ${service2}@${R2} | grep ${service1}@${R} >/dev/null || exit 1
+
+# Create two host principals in their respective realms
+${kadmin} add -p foo --use-defaults  host/foohost.test.h5l.se@${R} || exit 1
+${kadmin} add -p foo --use-defaults  host/barhost.sub.test.h5l.se@${R2} || exit 1
+
+# Create soft aliases (referrals) for them in the other realm
+${kadmin} add_alias WELLKNOWN/REFERRALS/TARGET@${R2} host/barhost.sub.test.h5l.se@${R} || exit 1
+${kadmin} add_alias WELLKNOWN/REFERRALS/TARGET@${R} host/foohost.test.h5l.se@${R2} || exit 1
 
 ${kadmin} add -p foo --use-defaults bar@${R} || exit 1
 ${kadmin} add -p foo --use-defaults 'baz\@realm.foo@'${R} || exit 1
@@ -187,6 +205,20 @@ ${klist} | grep "Principal: alias1@${R}" > /dev/null || \
 echo "checking that we got back right principal inside the PAC"
 ${test_ap_req} krbtgt/${R}@${R} ${keytab} ${cache} || \
 	{ ec=1 ; eval "${testfailed}"; }
+${kgetcred} ${service2}@${R2} || { ec=1 ; eval "${testfailed}"; }
+${kgetcred} ${service1}@${R} || { ec=1 ; eval "${testfailed}"; }
+
+echo "Getting client foo@${R2} tickets (non canon case)"; > messages.log
+${kinit} --password-file=${objdir}/foopassword foo@${R2} || \
+	{ ec=1 ; eval "${testfailed}"; }
+echo "checking that we got back right principal"
+${klist} | grep "Principal: foo@${R2}" > /dev/null || \
+	{ ec=1 ; eval "${testfailed}"; }
+echo "checking that we got back right principal inside the PAC"
+${test_ap_req} krbtgt/${R}@${R} ${keytab} ${cache} || \
+	{ ec=1 ; eval "${testfailed}"; }
+${kgetcred} ${service2}@${R2} || { ec=1 ; eval "${testfailed}"; }
+${kgetcred} ${service1}@${R} || { ec=1 ; eval "${testfailed}"; }
 
 echo "Getting client alias2 tickets (removed)"; > messages.log
 ${kadmin} modify --alias=alias1 foo@${R} || { ec=1 ; eval "${testfailed}"; }
@@ -200,25 +232,30 @@ ${kadmin} modify --alias= foo@${R} || { ec=1 ; eval "${testfailed}"; }
 
 echo "Test server referrals"
 
-echo "Getting client for ${service}@${R} (tgs kdc referral)"
+echo "Getting client for ${service2}@${R} (tgs kdc referral)"
 > messages.log
 ${kinit} --password-file=${objdir}/foopassword foo@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
-${kgetcred} --canonicalize ${service}@${R} ||
-	{ ec=1 ; eval "${testfailed}"; }
+${kgetcred} --canonicalize ${service2}@${R} || { ec=1 ; eval "${testfailed}"; }
+${kgetcred} host/foohost.test.h5l.se@${R} || { ec=1 ; eval "${testfailed}"; }
+${kgetcred} host/barhost.sub.test.h5l.se@ || { ec=1 ; eval "${testfailed}"; }
 echo "checking that we got back right principal"
-${klist} | grep "${service}@${R2}" > /dev/null || \
+${klist} | grep "${service2}@${R2}" > /dev/null || \
+	{ ec=1 ; eval "${testfailed}"; }
+${klist} | grep "host/barhost.sub.test.h5l.se@TEST.H5L.SE" > /dev/null && \
+	{ ec=1 ; eval "${testfailed}"; }
+${klist} | grep "host/barhost.sub.test.h5l.se@SUB.TEST.H5L.SE" > /dev/null || \
 	{ ec=1 ; eval "${testfailed}"; }
 ${kdestroy}
 
-echo "Getting client for ${service}@${R2} (tgs client side guessing)"
+echo "Getting client for ${service2}@${R2} (tgs client side guessing)"
 > messages.log
 ${kinit} --password-file=${objdir}/foopassword foo@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
-${kgetcred} ${service}@${R2} ||
+${kgetcred} ${service2}@${R2} ||
 	{ ec=1 ; eval "${testfailed}"; }
 echo "checking that we got back right principal"
-${klist} | grep "${service}@${R2}" > /dev/null || \
+${klist} | grep "${service2}@${R2}" > /dev/null || \
 	{ ec=1 ; eval "${testfailed}"; }
 ${kdestroy}
 


### PR DESCRIPTION
At some point we had "hard HDB entry aliases" working, and I broke it when I needed to add something like soft aliases -- I made all aliases soft.  This PR has a fix.

The fix is to distinguish soft and hard aliases by convention.

- Soft aliases are aliases of `WELLKNOWN/REFERRALS/TARGET@${some_realm}` or , `WELLKNOWN/REFERRALS/TARGET/...@${some_realm}`  where the realm is the realm to issue referrals to when a client asks for a ticket for an alias of such a principal.
  The second form is needed because there is a limit to how many aliases an HDB entry can have due to the signed 16-bit "TL-data" length limit imposed by the `kadm5` APIs and MIT kadmin protocol.

- Hard aliases are all others.

`kadmin`/`kadmind`/`httpkadmind`/`kadm5` will not care about the alias type distinction -- we push it onto users.

The `HDB` keytab can't do referrals, so soft aliases are "not found".

The AS will treat client principal soft aliases as referrals.

The TGS will treat service principal soft aliases as referrals.

Hard aliases get used as though they are proper principal entries.

- If the client does not request canonicalization, or if the alias and canonical name are in different realms, then we act as though the requested name were the canonical name of the entry found.
- Conversely, if the client does request canonicalization and the alias and canonical name are in the same realm, then the canonical name will be used in the ticket issued.