### PR TITLE
kadmin online listing

### DIFF
--- a/kadmin/kadmin-commands.in
+++ b/kadmin/kadmin-commands.in
@@ -500,6 +500,12 @@ command = {
 		type = "string"
 		help = "filename to save the principal's krb5.confg in"
 	}
+	option = {
+		long = "upto"
+		type = "integer"
+                default = "-1"
+		help = "maximum number of principals to get/list"
+	}
 	argument = "principal..."
 	min_args = "1"
 	help = "Shows information about principals matching the expressions."
@@ -674,6 +680,13 @@ command = {
 	option = {
 		long = "krb5-config-file"
 		type = "string"
+                help = "only use this option with the get command"
+	}
+	option = {
+		long = "upto"
+		type = "integer"
+                default = "-1"
+		help = "maximum number of principals to get/list"
 	}
 	argument = "principal..."
 	min_args = "1"

--- a/kadmin/kadmin_locl.h
+++ b/kadmin/kadmin_locl.h
@@ -98,6 +98,7 @@
 
 extern krb5_context context;
 extern void * kadm_handle;
+extern int list_chunk_size;
 
 #undef ALLOC
 #define ALLOC(X) ((X) = malloc(sizeof(*(X))))

--- a/kadmin/kadmind.c
+++ b/kadmin/kadmind.c
@@ -45,6 +45,7 @@ static int debug_flag;
 static int readonly_flag;
 static char *port_str;
 char *realm;
+int list_chunk_size = -1;
 
 static int detach_from_console = -1;
 int daemon_child = -1;
@@ -71,6 +72,9 @@ static struct getargs args[] = {
 #endif
     {	"debug",	'd',	arg_flag,   &debug_flag,
 	"enable debugging", NULL
+    },
+    {   "list-chunk-size", 0,   arg_integer,&list_chunk_size,
+        "set the LIST streaming count of names per chunk", "NUMBER"
     },
     {
         "detach",       0 ,      arg_flag, &detach_from_console,

--- a/kadmin/util.c
+++ b/kadmin/util.c
@@ -605,6 +605,34 @@ is_expression(const char *string)
     return 0;
 }
 
+struct foreach_principal_data {
+    krb5_error_code ret;
+    const char *funcname;
+    int (*func)(krb5_principal, void *);
+    void *data;
+};
+
+static int
+foreach_principal_cb(void *data, const char *p)
+{
+    struct foreach_principal_data *d = data;
+    krb5_principal princ;
+    krb5_error_code ret;
+
+    ret = krb5_parse_name(context, p, &princ);
+    if (ret)
+        return ret;
+
+    d->ret = d->func(princ, d->data);
+    krb5_free_principal(context, princ);
+    if (d->ret) {
+        krb5_warn(context, d->ret, "%s %s", d->funcname, p);
+        krb5_clear_error_message(context);
+        ret = d->ret ? d->ret : ret;
+    }
+    return ret;
+}
+
 /*
  * Loop over all principals matching exp.  If any of calls to `func'
  * failes, the first error is returned when all principals are
@@ -616,52 +644,67 @@ foreach_principal(const char *exp_str,
 		  const char *funcname,
 		  void *data)
 {
-    char **princs = NULL;
-    int num_princs = 0;
-    int i;
-    krb5_error_code saved_ret = 0, ret = 0;
-    krb5_principal princ_ent;
+    struct foreach_principal_data d;
+    krb5_error_code ret;
+    krb5_principal p;
     int is_expr;
+    int go_slow =
+        secure_getenv("KADMIN_USE_GET_PRINCIPALS") != NULL &&
+        *secure_getenv("KADMIN_USE_GET_PRINCIPALS") != '\0';
 
     /* if this isn't an expression, there is no point in wading
        through the whole database looking for matches */
     is_expr = is_expression(exp_str);
-    if(is_expr)
-	ret = kadm5_get_principals(kadm_handle, exp_str, &princs, &num_princs);
-    if(!is_expr || ret == KADM5_AUTH_LIST) {
-	/* we might be able to perform the requested opreration even
-           if we're not allowed to list principals */
-	num_princs = 1;
-	princs = malloc(sizeof(*princs));
-	if(princs == NULL)
-	    return ENOMEM;
-	princs[0] = strdup(exp_str);
-	if(princs[0] == NULL){
-	    free(princs);
-	    return ENOMEM;
-	}
-    } else if(ret) {
-	krb5_warn(context, ret, "kadm5_get_principals");
-	return ret;
+
+    d.funcname = funcname;
+    d.func = func;
+    d.data = data;
+    d.ret = 0;
+
+    if (is_expr && !go_slow) {
+	ret = kadm5_iter_principals(kadm_handle, exp_str,
+                                    foreach_principal_cb, &d);
+        if (ret == 0)
+            return 0;
+        if (ret != KADM5_AUTH_LIST) {
+            krb5_warn(context, ret, "kadm5_iter_principals");
+            return d.ret;
+        }
+    } else if (is_expr) {
+        char **princs = NULL;
+        int count = 0;
+
+        /*
+         * This is just for testing, and maybe in case there are HDB backends
+         * that are not re-entrant (LDAP?).
+         */
+        ret = kadm5_get_principals(kadm_handle, exp_str, &princs, &count);
+        if (ret == 0 && count > 0) {
+            int i;
+
+            for (i = 0; ret == 0 && i < count; i++)
+                ret = foreach_principal_cb(&d, princs[i]);
+            kadm5_free_name_list(kadm_handle, princs, &count);
+            return ret;
+        }
+        if (ret != KADM5_AUTH_LIST) {
+            krb5_warn(context, ret, "kadm5_iter_principals");
+            return d.ret;
+        }
     }
-    for(i = 0; i < num_princs; i++) {
-	ret = krb5_parse_name(context, princs[i], &princ_ent);
-	if(ret){
-	    krb5_warn(context, ret, "krb5_parse_name(%s)", princs[i]);
-	    continue;
-	}
-	ret = (*func)(princ_ent, data);
-	if(ret) {
-	    krb5_warn(context, ret, "%s %s", funcname, princs[i]);
-	    krb5_clear_error_message(context);
-	    if (saved_ret == 0)
-		saved_ret = ret;
-	}
-	krb5_free_principal(context, princ_ent);
+    /* we might be able to perform the requested opreration even
+       if we're not allowed to list principals */
+    ret = krb5_parse_name(context, exp_str, &p);
+    if (ret) {
+        krb5_warn(context, ret, "krb5_parse_name(%s)", exp_str);
+        return ret;
     }
-    if (ret == 0 && saved_ret != 0)
-	ret = saved_ret;
-    kadm5_free_name_list(kadm_handle, princs, &num_princs);
+    ret = (*func)(p, data);
+    if (ret) {
+        krb5_warn(context, ret, "%s %s", funcname, exp_str);
+        krb5_clear_error_message(context);
+    }
+    krb5_free_principal(context, p);
     return ret;
 }
 

--- a/lib/kadm5/ad.c
+++ b/lib/kadm5/ad.c
@@ -1066,6 +1066,33 @@ kadm5_ad_get_principals(void *server_handle,
 }
 
 static kadm5_ret_t
+kadm5_ad_iter_principals(void *server_handle,
+			 const char *expression,
+			 int (*cb)(void *, const char *),
+			 void *cbdata)
+{
+    kadm5_ad_context *context = server_handle;
+
+#ifdef OPENLDAP
+    kadm5_ret_t ret;
+
+    ret = ad_get_cred(context, NULL);
+    if (ret)
+	return ret;
+
+    ret = _kadm5_ad_connect(server_handle);
+    if (ret)
+	return ret;
+
+    krb5_set_error_message(context->context, KADM5_RPC_ERROR, "Function not implemented");
+    return KADM5_RPC_ERROR;
+#else
+    krb5_set_error_message(context->context, KADM5_RPC_ERROR, "Function not implemented");
+    return KADM5_RPC_ERROR;
+#endif
+}
+
+static kadm5_ret_t
 kadm5_ad_get_privs(void *server_handle, uint32_t*privs)
 {
     kadm5_ad_context *context = server_handle;
@@ -1388,6 +1415,9 @@ set_funcs(kadm5_ad_context *c)
     SET(c, lock);
     SET(c, unlock);
     SETNOTIMP(c, setkey_principal_3);
+    SETNOTIMP(c, prune_principal);
+    SET(c, iter_principals);
+    SET(c, dup_context);
 }
 
 kadm5_ret_t
@@ -1453,6 +1483,12 @@ kadm5_ad_init_with_password_ctx(krb5_context context,
 
     *server_handle = ctx;
     return 0;
+}
+
+kadm5_ret_t
+kadm5_ad_dup_context(void *in, void **out)
+{
+    return ENOTSUP;
 }
 
 kadm5_ret_t

--- a/lib/kadm5/common_glue.c
+++ b/lib/kadm5/common_glue.c
@@ -39,6 +39,12 @@ RCSID("$Id$");
 #define __CALLABLE(F) (((kadm5_common_context*)server_handle)->funcs.F != 0)
 
 kadm5_ret_t
+kadm5_dup_context(void *server_handle, void **dup_server_handle)
+{
+    return __CALL(dup_context, (server_handle, dup_server_handle));
+}
+
+kadm5_ret_t
 kadm5_chpass_principal(void *server_handle,
 		       krb5_principal princ,
 		       const char *password)
@@ -220,6 +226,15 @@ kadm5_get_principals(void *server_handle,
 		     int *count)
 {
     return __CALL(get_principals, (server_handle, expression, princs, count));
+}
+
+kadm5_ret_t
+kadm5_iter_principals(void *server_handle,
+		      const char *expression,
+                      int (*cb)(void *, const char *),
+                      void *cbdata)
+{
+    return __CALL(iter_principals, (server_handle, expression, cb, cbdata));
 }
 
 kadm5_ret_t

--- a/lib/kadm5/context_s.c
+++ b/lib/kadm5/context_s.c
@@ -112,6 +112,8 @@ set_funcs(kadm5_server_context *c)
     SET(c, lock);
     SET(c, unlock);
     SET(c, setkey_principal_3);
+    SET(c, iter_principals);
+    SET(c, dup_context);
 }
 
 #ifndef NO_UNIX_SOCKETS
@@ -250,6 +252,8 @@ _kadm5_s_init_context(kadm5_server_context **ctx,
     krb5_add_et_list (context, initialize_kadm5_error_table_r);
 
 #define is_set(M) (params && params->mask & KADM5_CONFIG_ ## M)
+    if (params)
+        (*ctx)->config.mask = params->mask;
     if (is_set(REALM)) {
 	(*ctx)->config.realm = strdup(params->realm);
         if ((*ctx)->config.realm == NULL)
@@ -275,9 +279,9 @@ _kadm5_s_init_context(kadm5_server_context **ctx,
 	    return krb5_enomem(context);
     }
 
-    find_db_spec(*ctx);
-
-    ret = _kadm5_s_init_hooks(*ctx);
+    ret = find_db_spec(*ctx);
+    if (ret == 0)
+        ret = _kadm5_s_init_hooks(*ctx);
     if (ret != 0) {
 	kadm5_s_destroy(*ctx);
 	*ctx = NULL;

--- a/lib/kadm5/destroy_s.c
+++ b/lib/kadm5/destroy_s.c
@@ -42,10 +42,12 @@ RCSID("$Id$");
 static void
 destroy_config (kadm5_config_params *c)
 {
-    free (c->realm);
-    free (c->dbname);
-    free (c->acl_file);
-    free (c->stash_file);
+    if (!c)
+        return;
+    free(c->realm);
+    free(c->dbname);
+    free(c->acl_file);
+    free(c->stash_file);
 }
 
 /*
@@ -55,6 +57,8 @@ destroy_config (kadm5_config_params *c)
 static void
 destroy_kadm5_log_context (kadm5_log_context *c)
 {
+    if (!c)
+        return;
     free(c->log_file);
     if (c->socket_fd != rk_INVALID_SOCKET)
         rk_closesocket(c->socket_fd);

--- a/lib/kadm5/get_princs_c.c
+++ b/lib/kadm5/get_princs_c.c
@@ -66,7 +66,7 @@ kadm5_c_get_principals(void *server_handle,
     ret = krb5_store_int32(sp, kadm_get_princs);
     if (ret)
 	goto out;
-    ret = krb5_store_int32(sp, expression != NULL);
+    ret = krb5_store_int32(sp, expression != NULL ? 1 : 0);
     if (ret)
 	goto out;
     if (expression) {
@@ -108,6 +108,182 @@ kadm5_c_get_principals(void *server_handle,
 	    goto out;
     }
     *count = tmp;
+
+  out:
+    krb5_clear_error_message(context->context);
+
+  out_keep_error:
+    krb5_storage_free(sp);
+    krb5_data_free(&reply);
+    return ret;
+}
+
+kadm5_ret_t
+kadm5_c_iter_principals(void *server_handle,
+			const char *expression,
+			int (*cb)(void *, const char *),
+			void *cbdata)
+{
+    kadm5_client_context *context = server_handle;
+    kadm5_ret_t ret;
+    krb5_storage *sp;
+    unsigned char buf[1024];
+    int32_t tmp;
+    krb5_data reply;
+    size_t i;
+
+    ret = _kadm5_connect(server_handle, 0 /* want_write */);
+    if (ret)
+	return ret;
+
+    krb5_data_zero(&reply);
+
+    sp = krb5_storage_from_mem(buf, sizeof(buf));
+    if (sp == NULL) {
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
+    }
+    ret = krb5_store_int32(sp, kadm_get_princs);
+    if (ret)
+	goto out;
+
+    /*
+     * Our protocol has an int boolean for this operation to indicate whether
+     * there's an expression.  What we'll do here is that instead of sending
+     * just false or trueish, for online iteration we'll send a number other
+     * than 0 or 1 -- a magic value > 0 and < INT_MAX.
+     *
+     * In response we'll expect multiple replies, each with up to some small
+     * number of principal names.  See kadmin/server.c.
+     */
+    ret = krb5_store_int32(sp, 0x55555555);
+    if (ret)
+	goto out;
+    ret = krb5_store_string(sp, expression ? expression : "");
+    if (ret)
+        goto out;
+    ret = _kadm5_client_send(context, sp);
+    if (ret)
+	goto out_keep_error;
+    ret = _kadm5_client_recv(context, &reply);
+    if (ret)
+	goto out_keep_error;
+    krb5_storage_free(sp);
+    sp = krb5_storage_from_data (&reply);
+    if (sp == NULL) {
+	ret = krb5_enomem(context->context);
+	goto out_keep_error;
+    }
+    ret = krb5_ret_int32(sp, &tmp);
+    if (ret == 0)
+	ret = tmp;
+
+    if (ret)
+	goto out;
+
+    ret = krb5_ret_int32(sp, &tmp);
+    if (ret)
+	goto out;
+
+    if (tmp < 0) {
+        size_t n = -tmp;
+        int more = 1;
+        int stop = 0;
+
+        /* The server supports online iteration, hooray! */
+
+        while (more) {
+            /*
+             * We expect any number of chunks, each having `n' names, except
+             * the last one would have fewer than `n' (possibly zero, even).
+             *
+             * After that we expect one more reply with just a final return
+             * code.
+             */
+            krb5_data_free(&reply);
+            krb5_storage_free(sp);
+            sp = NULL;
+            ret = _kadm5_client_recv(context, &reply);
+            if (ret == 0 && (sp = krb5_storage_from_data(&reply)) == NULL)
+                ret = krb5_enomem(context->context);
+            if (ret)
+                goto out;
+
+            /* Every chunk begins with a status code */
+            ret = krb5_ret_int32(sp, &tmp);
+            if (ret == 0)
+                ret = tmp;
+            if (ret)
+                goto out;
+
+            /* We expect up to -tmp principals per reply */
+            for (i = 0; i < n; i++) {
+                char *princ = NULL;
+
+                ret = krb5_ret_string(sp, &princ);
+                if (ret == HEIM_ERR_EOF) {
+                    /* This was the last reply */
+                    more = 0;
+                    ret = 0;
+                    break;
+                }
+                if (ret)
+                    goto out;
+                if (!stop) {
+                    stop = cb(cbdata, princ);
+                    if (stop) {
+                        /* Tell the server to stop */
+                        krb5_storage_free(sp);
+                        if ((sp = krb5_storage_emem()) &&
+                            krb5_store_int32(sp, kadm_nop) == 0)
+                            (void) _kadm5_client_send(context, sp);
+                    }
+                }
+                free(princ);
+            }
+
+            if (!more) {
+                if (ret == 0)
+                    ret = stop;
+                break;
+            }
+        }
+        /* Get the final result code */
+        krb5_data_free(&reply);
+        krb5_storage_free(sp);
+        sp = NULL;
+        ret = _kadm5_client_recv(context, &reply);
+        if (ret == 0 && (sp = krb5_storage_from_data(&reply)) == NULL)
+            ret = krb5_enomem(context->context);
+        if (ret)
+            goto out;
+        ret = krb5_ret_int32(sp, &tmp);
+        if (ret == 0)
+            ret = tmp;
+        if (!stop) {
+            /*
+             * Send our "interrupt" after the last chunk if we hand't
+             * interrupted already.
+             */
+            krb5_storage_free(sp);
+            if ((sp = krb5_storage_emem()) &&
+                krb5_store_int32(sp, kadm_nop) == 0)
+                (void) _kadm5_client_send(context, sp);
+        }
+    } else {
+        size_t n = tmp;
+
+        /* Old server -- listing not online */
+        for (i = 0; i < n; i++) {
+            char *princ = NULL;
+
+            ret = krb5_ret_string(sp, &princ);
+            if (ret)
+                goto out;
+            cb(cbdata, princ);
+            free(princ);
+        }
+    }
 
   out:
     krb5_clear_error_message(context->context);

--- a/lib/kadm5/get_princs_s.c
+++ b/lib/kadm5/get_princs_s.c
@@ -94,7 +94,7 @@ kadm5_s_get_principals(void *server_handle,
 {
     struct foreach_data d;
     kadm5_server_context *context = server_handle;
-    kadm5_ret_t ret;
+    kadm5_ret_t ret = 0;
 
     if (!context->keep_open) {
 	ret = context->db->hdb_open(context->context, context->db, O_RDONLY, 0);
@@ -104,24 +104,25 @@ kadm5_s_get_principals(void *server_handle,
 	}
     }
     d.exp = expression;
-    {
+    d.exp2 = NULL;
+    if (expression) {
 	krb5_realm r;
 	int aret;
 
 	ret = krb5_get_default_realm(context->context, &r);
-        if (ret)
-            goto out;
-	aret = asprintf(&d.exp2, "%s@%s", expression, r);
-	free(r);
-	if (aret == -1 || d.exp2 == NULL) {
-	    ret = krb5_enomem(context->context);
-            goto out;
-	}
+        if (ret == 0) {
+            aret = asprintf(&d.exp2, "%s@%s", expression, r);
+            free(r);
+            if (aret == -1 || d.exp2 == NULL)
+                ret = krb5_enomem(context->context);
+        }
     }
     d.princs = NULL;
     d.nalloced = 0;
     d.count = 0;
-    ret = hdb_foreach(context->context, context->db, HDB_F_ADMIN_DATA, foreach, &d);
+    if (ret == 0)
+        ret = hdb_foreach(context->context, context->db, HDB_F_ADMIN_DATA,
+                          foreach, &d);
 
     if (ret == 0)
 	ret = add_princ(context->context, &d, NULL);
@@ -134,7 +135,72 @@ kadm5_s_get_principals(void *server_handle,
     else
 	kadm5_free_name_list(context, d.princs, count);
     free(d.exp2);
- out:
+    if (!context->keep_open)
+	context->db->hdb_close(context->context, context->db);
+    return _kadm5_error_code(ret);
+}
+
+struct foreach_online_data {
+    const char *exp;
+    char *exp2;
+    int (*cb)(void *, const char *);
+    void *cbdata;
+};
+
+static krb5_error_code
+foreach_online(krb5_context context, HDB *db, hdb_entry *ent, void *data)
+{
+    struct foreach_online_data *d = data;
+    krb5_error_code ret;
+    char *princ = NULL;
+
+    ret = krb5_unparse_name(context, ent->principal, &princ);
+    if (ret == 0) {
+        if (!d->exp ||
+            fnmatch(d->exp, princ, 0) == 0 || fnmatch(d->exp2, princ, 0) == 0)
+            ret = d->cb(d->cbdata, princ);
+        free(princ);
+    }
+    return ret;
+}
+
+kadm5_ret_t
+kadm5_s_iter_principals(void *server_handle,
+			const char *expression,
+			int (*cb)(void *, const char *),
+			void *cbdata)
+{
+    struct foreach_online_data d;
+    kadm5_server_context *context = server_handle;
+    kadm5_ret_t ret = 0;
+
+    if (!context->keep_open) {
+	ret = context->db->hdb_open(context->context, context->db, O_RDONLY, 0);
+	if (ret) {
+	    krb5_warn(context->context, ret, "opening database");
+	    return ret;
+	}
+    }
+    d.exp = expression;
+    d.exp2 = NULL;
+    d.cb = cb;
+    d.cbdata = cbdata;
+    if (expression) {
+	krb5_realm r;
+	int aret;
+
+	ret = krb5_get_default_realm(context->context, &r);
+        if (ret == 0) {
+            aret = asprintf(&d.exp2, "%s@%s", expression, r);
+            free(r);
+            if (aret == -1 || d.exp2 == NULL)
+                ret = krb5_enomem(context->context);
+        }
+    }
+    if (ret == 0)
+        ret = hdb_foreach(context->context, context->db, HDB_F_ADMIN_DATA,
+                          foreach_online, &d);
+    free(d.exp2);
     if (!context->keep_open)
 	context->db->hdb_close(context->context, context->db);
     return _kadm5_error_code(ret);

--- a/lib/kadm5/init_c.c
+++ b/lib/kadm5/init_c.c
@@ -78,6 +78,8 @@ set_funcs(kadm5_client_context *c)
     SET(c, lock);
     SET(c, unlock);
     SETNOTIMP(c, setkey_principal_3);
+    SET(c, iter_principals);
+    SET(c, dup_context);
 }
 
 kadm5_ret_t
@@ -190,6 +192,53 @@ _kadm5_c_init_context(kadm5_client_context **ctx,
     if ((*ctx)->readonly_kadmind_port == 0)
 	(*ctx)->readonly_kadmind_port = (*ctx)->kadmind_port;
     return 0;
+}
+
+kadm5_ret_t
+kadm5_c_dup_context(void *vin, void **out)
+{
+    krb5_error_code ret;
+    kadm5_client_context *in = vin;
+    krb5_context context = in->context;
+    kadm5_client_context *ctx;
+
+    *out = NULL;
+    ctx = malloc(sizeof(*ctx));
+    if (ctx == NULL)
+	return krb5_enomem(in->context);
+
+
+    memset(ctx, 0, sizeof(*ctx));
+    set_funcs(ctx);
+    ctx->readonly_kadmind_port = in->readonly_kadmind_port;
+    ctx->kadmind_port = in->kadmind_port;
+
+    ret = krb5_copy_context(context, &(ctx->context));
+    if (ret == 0)
+        ret = krb5_add_et_list(ctx->context, initialize_kadm5_error_table_r);
+    if (ret == 0 && (ctx->realm = strdup(in->realm)) == NULL)
+        ret = krb5_enomem(context);
+    if (ret == 0 &&
+        (ctx->admin_server = strdup(in->admin_server)) == NULL)
+        ret = krb5_enomem(context);
+    if (in->readonly_admin_server &&
+	(ctx->readonly_admin_server = strdup(in->readonly_admin_server)) == NULL)
+        ret = krb5_enomem(context);
+    if (in->keytab && (ctx->keytab = strdup(in->keytab)) == NULL)
+        ret = krb5_enomem(context);
+    if (in->ccache) {
+        char *fullname = NULL;
+
+        ret = krb5_cc_get_full_name(context, in->ccache, &fullname);
+        if (ret == 0)
+            ret = krb5_cc_resolve(context, fullname, &ctx->ccache);
+        free(fullname);
+    }
+    if (ret == 0)
+        *out = ctx;
+    else
+        kadm5_c_destroy(ctx);
+    return ret;
 }
 
 static krb5_error_code

--- a/lib/kadm5/init_s.c
+++ b/lib/kadm5/init_s.c
@@ -109,6 +109,21 @@ kadm5_s_init_with_context(krb5_context context,
 }
 
 kadm5_ret_t
+kadm5_s_dup_context(void *vin, void **out)
+{
+    kadm5_server_context *in = vin;
+    kadm5_ret_t ret;
+    char *p = NULL;
+
+    ret = krb5_unparse_name(in->context, in->caller, &p);
+    if (ret == 0)
+        ret = kadm5_s_init_with_context(in->context, p, NULL,
+                                        &in->config, 0, 0, out);
+    free(p);
+    return ret;
+}
+
+kadm5_ret_t
 kadm5_s_init_with_password_ctx(krb5_context context,
 			       const char *client_name,
 			       const char *password,

--- a/lib/kadm5/libkadm5srv-exports.def
+++ b/lib/kadm5/libkadm5srv-exports.def
@@ -15,6 +15,7 @@ EXPORTS
         kadm5_delete_policy
 	kadm5_delete_principal
 	kadm5_destroy
+	kadm5_dup_context
 	kadm5_flush
 	kadm5_free_key_data
 	kadm5_free_name_list
@@ -32,6 +33,7 @@ EXPORTS
 	kadm5_init_with_password_ctx
 	kadm5_init_with_skey
 	kadm5_init_with_skey_ctx
+	kadm5_iter_principals
         kadm5_lock
         kadm5_modify_policy
 	kadm5_modify_principal

--- a/lib/kadm5/private.h
+++ b/lib/kadm5/private.h
@@ -68,6 +68,8 @@ struct kadm_func {
 				       int, krb5_key_salt_tuple *,
 				       krb5_keyblock *, int);
     kadm5_ret_t (*prune_principal) (void *, krb5_principal, int);
+    kadm5_ret_t (*iter_principals) (void*, const char*, int (*)(void *, const char *), void *);
+    kadm5_ret_t (*dup_context) (void*, void **);
 };
 
 typedef struct kadm5_hook_context {

--- a/lib/kadm5/version-script-client.map
+++ b/lib/kadm5/version-script-client.map
@@ -11,6 +11,7 @@ HEIMDAL_KADM5_CLIENT_1.0 {
 		kadm5_c_create_principal;
 		kadm5_c_delete_principal;
 		kadm5_c_destroy;
+		kadm5_c_dup_context;
 		kadm5_c_flush;
 		kadm5_c_get_principal;
 		kadm5_c_get_principals;
@@ -21,6 +22,8 @@ HEIMDAL_KADM5_CLIENT_1.0 {
 		kadm5_c_init_with_password_ctx;
 		kadm5_c_init_with_skey;
 		kadm5_c_init_with_skey_ctx;
+		kadm5_c_iter_principals;
+		kadm5_c_get_privs;
 		kadm5_c_modify_principal;
 		kadm5_c_prune_principal;
 		kadm5_c_randkey_principal;
@@ -30,6 +33,7 @@ HEIMDAL_KADM5_CLIENT_1.0 {
 		kadm5_create_principal;
 		kadm5_delete_principal;
 		kadm5_destroy;
+		kadm5_dup_context;
 		kadm5_flush;
 		kadm5_free_key_data;
 		kadm5_free_name_list;
@@ -43,6 +47,7 @@ HEIMDAL_KADM5_CLIENT_1.0 {
 		kadm5_init_with_password_ctx;
 		kadm5_init_with_skey;
 		kadm5_init_with_skey_ctx;
+		kadm5_iter_principals;
 		kadm5_modify_principal;
 		kadm5_randkey_principal;
 		kadm5_randkey_principal_3;

--- a/lib/kadm5/version-script.map
+++ b/lib/kadm5/version-script.map
@@ -16,6 +16,7 @@ HEIMDAL_KAMD5_SERVER_1.0 {
 		kadm5_create_principal_3;
 		kadm5_delete_principal;
 		kadm5_destroy;
+		kadm5_dup_context;
 		kadm5_decrypt_key;
 		kadm5_delete_policy;
 		kadm5_flush;
@@ -35,6 +36,7 @@ HEIMDAL_KAMD5_SERVER_1.0 {
 		kadm5_init_with_password_ctx;
 		kadm5_init_with_skey;
 		kadm5_init_with_skey_ctx;
+		kadm5_iter_principals;
 		kadm5_lock;
 		kadm5_modify_principal;
 		kadm5_modify_policy;

--- a/tests/kdc/check-kadmin.in
+++ b/tests/kdc/check-kadmin.in
@@ -221,10 +221,6 @@ ${kadmin} -p foo/admin@${R} add -p abc --use-defaults kaka@${R} &&
 	{ echo "kadmin succeeded $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kadmin get doesnotexists"
 env KRB5CCNAME=${cache} \
 ${kadmin} -p foo/admin@${R} get -s doesnotexists@${R} \
@@ -316,6 +312,103 @@ cat kadmin.tmp | ${EGREP} Keytypes: | cut -d: -f2 | tr ' ' '
 ' | sed 's/^.*[[]\(.*\)[]].*$/\1/' | grep '[0-9]' | sort -nu | tr -d '
 ' | ${EGREP} '^3$' > /dev/null || \
         { echo "kadmin pruneall failed $?"; cat messages.log ; exit 1; }
+
+env KRB5CCNAME=${cache} \
+    ${kadmin} -p foo/admin@${R} list --upto=3 '*' > kadmin.tmp
+[ `wc -l < kadmin.tmp` -eq 3 ] ||
+        { echo "kadmin list --upto 3 produced `wc -l < kadmin.tmp` results!"; exit 1; }
+
+#----------------------------------
+# We have 20 principals in the DB.  Test two chunks of 1 (since that's how we
+# started kadmind above.
+> messages.log
+echo "kadmin list all (chunk size 1)"
+# Check that list produces the same output locally and remote.
+env KRB5CCNAME=${cache} \
+    ${kadmin} -p foo/admin@${R} list '*' | sort > kadmin.tmp ||
+        { echo "failed to list principals"; cat messages.log ; exit 1; }
+${kadmin} -l list '*' | sort > kadmin.tmp2
+diff kadmin.tmp kadmin.tmp2 ||
+        { echo "failed to list all principals"; cat messages.log ; exit 1; }
+# kadmin dump does not use kadm5_iter_principals, so this is a good way to
+# double check the above results.  This time we drop the realm part because
+# kadmin doesn't show us the realm for principals in the default realm.
+${kadmin} -l list '*' | cut -d'@' -f1 | sort > kadmin.tmp
+${kadmin} -l dump | cut -d'@' -f1 | sort > kadmin.tmp2
+diff kadmin.tmp kadmin.tmp2 ||
+        { echo "failed to list all principals (dump)"; cat messages.log ; exit 1; }
+
+#----------------------------------
+# We have 20 principals in the DB.  Test two chunks of 10.
+sh ${leaks_kill} kadmind $kadmpid || exit 1
+${kadmind} --list-chunk-size=10 -d &
+kadmpid=$!
+sleep 1
+
+> messages.log
+echo "kadmin list all (chunk size 10)"
+# Check that list produces the same output locally and remote.
+env KRB5CCNAME=${cache} \
+    ${kadmin} -p foo/admin@${R} list '*' | sort > kadmin.tmp ||
+        { echo "failed to list principals"; cat messages.log ; exit 1; }
+${kadmin} -l list '*' | sort > kadmin.tmp2
+diff kadmin.tmp kadmin.tmp2 ||
+        { echo "failed to list all principals"; cat messages.log ; exit 1; }
+# kadmin dump does not use kadm5_iter_principals, so this is a good way to
+# double check the above results.  This time we drop the realm part because
+# kadmin doesn't show us the realm for principals in the default realm.
+${kadmin} -l list '*' | cut -d'@' -f1 | sort > kadmin.tmp
+${kadmin} -l dump | cut -d'@' -f1 | sort > kadmin.tmp2
+diff kadmin.tmp kadmin.tmp2 ||
+        { echo "failed to list all principals (dump)"; cat messages.log ; exit 1; }
+
+#----------------------------------
+# We have 20 principals in the DB.  Test one chunk of 50.
+wait $kadmipid
+${kadmind} --list-chunk-size=50 -d &
+kadmpid=$!
+sleep 1
+
+> messages.log
+echo "kadmin list all (chunk size 50)"
+# Check that list produces the same output locally and remote.
+env KRB5CCNAME=${cache} \
+    ${kadmin} -p foo/admin@${R} list '*' | sort > kadmin.tmp ||
+        { echo "failed to list principals"; cat messages.log ; exit 1; }
+${kadmin} -l list '*' | sort > kadmin.tmp2
+diff kadmin.tmp kadmin.tmp2 ||
+        { echo "failed to list all principals"; cat messages.log ; exit 1; }
+# kadmin dump does not use kadm5_iter_principals, so this is a good way to
+# double check the above results.  This time we drop the realm part because
+# kadmin doesn't show us the realm for principals in the default realm.
+${kadmin} -l list '*' | cut -d'@' -f1 | sort > kadmin.tmp
+${kadmin} -l dump | cut -d'@' -f1 | sort > kadmin.tmp2
+diff kadmin.tmp kadmin.tmp2 ||
+        { echo "failed to list all principals (dump)"; cat messages.log ; exit 1; }
+
+#----------------------------------
+# We have 20 principals in the DB.  Test 3 chunks of up to 7.
+wait $kadmipid
+${kadmind} --list-chunk-size=7 -d &
+kadmpid=$!
+sleep 1
+
+> messages.log
+echo "kadmin list all (chunk size 7)"
+# Check that list produces the same output locally and remote.
+env KRB5CCNAME=${cache} \
+    ${kadmin} -p foo/admin@${R} list '*' | sort > kadmin.tmp ||
+        { echo "failed to list principals"; cat messages.log ; exit 1; }
+${kadmin} -l list '*' | sort > kadmin.tmp2
+diff kadmin.tmp kadmin.tmp2 ||
+        { echo "failed to list all principals"; cat messages.log ; exit 1; }
+# kadmin dump does not use kadm5_iter_principals, so this is a good way to
+# double check the above results.  This time we drop the realm part because
+# kadmin doesn't show us the realm for principals in the default realm.
+${kadmin} -l list '*' | cut -d'@' -f1 | sort > kadmin.tmp
+${kadmin} -l dump | cut -d'@' -f1 | sort > kadmin.tmp2
+diff kadmin.tmp kadmin.tmp2 ||
+        { echo "failed to list all principals (dump)"; cat messages.log ; exit 1; }
 
 #----------------------------------
 

--- a/tests/kdc/check-kadmin.in
+++ b/tests/kdc/check-kadmin.in
@@ -100,6 +100,11 @@ echo Starting kdc ; > messages.log
 ${kdc} --detach --testing || { echo "kdc failed to start"; cat messages.log; exit 1; }
 kdcpid=`getpid kdc`
 
+echo Starting kadmind
+${kadmind} --detach --list-chunk-size=1 \
+    || { echo "kadmind failed to start"; cat messages.log; exit 1; }
+kadmpid=`getpid kadmind`
+
 trap "kill -9 ${kdcpid} ${kadmpid}" EXIT
 
 #----------------------------------
@@ -107,58 +112,34 @@ echo "kinit (no admin); test mod --alias authorization"
 ${kinit} --password-file=${objdir}/foopassword \
     -S kadmin/admin@${R} hasalias@${R} || exit 1
 
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 # Check that one non-permitted alias -> failure
 env KRB5CCNAME=${cache} \
 ${kadmin} -p hasalias@${R} modify --alias=goodalias1@${R} --alias=badalias@${R} hasalias@${R} &&
 	{ echo "kadmin failed $?"; cat messages.log ; exit 1; }
-wait $kadmpid || { echo "kadmind failed $?"; cat messages.log ; exit 1; }
-
-${kadmind} -d &
-kadmpid=$!
-sleep 1
 
 # Check that all permitted aliases -> success
 env KRB5CCNAME=${cache} \
 ${kadmin} -p hasalias@${R} modify --alias=goodalias1@${R} --alias=goodalias2@${R} hasalias@${R} ||
 	{ echo "kadmin failed $?"; cat messages.log ; exit 1; }
-wait $kadmpid || { echo "kadmind failed $?"; cat messages.log ; exit 1; }
-
-${kadmind} -d &
-kadmpid=$!
-sleep 1
 
 # Check that we can drop aliases
 env KRB5CCNAME=${cache} \
 ${kadmin} -p hasalias@${R} modify --alias=goodalias3@${R} hasalias@${R} ||
 	{ echo "kadmin failed $?"; cat messages.log ; exit 1; }
-wait $kadmpid || { echo "kadmind failed $?"; cat messages.log ; exit 1; }
 ${kadmin} -l get hasalias@${R} | grep Aliases: > kadmin.tmp
 read junk aliases < kadmin.tmp
 rm kadmin.tmp
 [ "$aliases" != "goodalias3@${R}" ] && { echo "kadmind failed $?"; cat messages.log ; exit 1; }
 
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 env KRB5CCNAME=${cache} \
 ${kadmin} -p hasalias@${R} modify --alias=goodalias1@${R} --alias=goodalias2@${R} --alias=goodalias3@${R} hasalias@${R} ||
 	{ echo "kadmin failed $?"; cat messages.log ; exit 1; }
-wait $kadmpid || { echo "kadmind failed $?"; cat messages.log ; exit 1; }
 ${kadmin} -l get hasalias@${R} | grep Aliases: > kadmin.tmp
 read junk aliases < kadmin.tmp
 rm kadmin.tmp
 [ "$aliases" != "goodalias1@${R} goodalias2@${R} goodalias3@${R}" ] && { echo "FOO failed $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kinit (no admin)"
 ${kinit} --password-file=${objdir}/foopassword \
     -S kadmin/admin@${R} bar@${R} || exit 1
@@ -171,10 +152,6 @@ ${kadmin} -l get kaka2@${R} > /dev/null ||
 	{ echo "kadmin failed $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kinit (no admin)"
 ${kinit} --password-file=${objdir}/foopassword \
     -S kadmin/admin@${R} baz@${R} || exit 1
@@ -184,10 +161,6 @@ ${kadmin} -p baz@${R} get bar@${R} > /dev/null ||
 	{ echo "kadmin failed $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kinit (no admin)"
 ${kinit} --password-file=${objdir}/foopassword \
     -S kadmin/admin@${R} baz@${R} || exit 1
@@ -197,10 +170,6 @@ ${kadmin} -p baz@${R} passwd -p "$foopassword" bar@${R} > /dev/null 2>/dev/null 
 	{ echo "kadmin succesded $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kinit (no admin)"
 ${kinit} --password-file=${objdir}/foopassword \
     -S kadmin/admin@${R} baz@${R} || exit 1
@@ -210,10 +179,6 @@ ${kadmin} -p baz@${R} get bar@${R} > /dev/null ||
 	{ echo "kadmin failed $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kinit (no admin)"
 ${kinit} --password-file=${objdir}/foopassword \
     -S kadmin/admin@${R} bez@${R} || exit 1
@@ -223,10 +188,6 @@ ${kadmin} -p bez@${R} passwd -p "$foopassword" bar@${R} > /dev/null 2>/dev/null 
 	{ echo "kadmin succesded $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kinit (no admin)"
 ${kinit} --password-file=${objdir}/foopassword \
     -S kadmin/admin@${R} fez@${R} || exit 1
@@ -236,10 +197,6 @@ ${kadmin} -p fez@${R} get bar@${R} > /dev/null ||
 	{ echo "kadmin failed $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kinit (no admin)"
 ${kinit} --password-file=${objdir}/foopassword \
     -S kadmin/admin@${R} fez@${R} || exit 1
@@ -249,10 +206,6 @@ ${kadmin} -p fez@${R} passwd -p "$foopassword" bar@${R} > /dev/null 2>/dev/null 
 	{ echo "kadmin succesded $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kinit (admin)"
 ${kinit} --password-file=${objdir}/foopassword \
     -S kadmin/admin@${R} foo/admin@${R} || exit 1
@@ -290,10 +243,6 @@ cmp kadmin.tmp ${srcdir}/donotexists.txt || \
     { echo "wrong response"; exit 1;}
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kadmin get pkinit-acl"
 env KRB5CCNAME=${cache} \
 ${kadmin} -p foo/admin@${R} get -o pkinit-acl pkinit@${R} \
@@ -301,10 +250,6 @@ ${kadmin} -p foo/admin@${R} get -o pkinit-acl pkinit@${R} \
 	{ echo "kadmin failed $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kadmin get -o principal"
 env KRB5CCNAME=${cache} \
 ${kadmin} -p foo/admin@${R} get -o principal bar@${R} \
@@ -316,10 +261,6 @@ fi
 
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kadmin get -o kvno"
 env KRB5CCNAME=${cache} \
 ${kadmin} -p foo/admin@${R} get -o kvno bar@${R} \
@@ -331,10 +272,6 @@ fi
 
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kadmin get -o princ_expire_time"
 env KRB5CCNAME=${cache} \
 ${kadmin} -p foo/admin@${R} get -o princ_expire_time bar@${R} \
@@ -345,10 +282,6 @@ if test "`cat kadmin.tmp`" != "Principal expires: never" ; then
 fi
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kadmin get -s -o attributes"
 env KRB5CCNAME=${cache} \
 ${kadmin} -p foo/admin@${R} get -s -o attributes bar@${R} \
@@ -359,44 +292,26 @@ if test "`cat kadmin.tmp`" != "Attributes" ; then
 fi
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kadmin prune"
 env KRB5CCNAME=${cache} \
 ${kadmin} prune --kvno=2 prune@${R} \
         > kadmin.tmp 2>&1 || \
         { echo "kadmin failed $?"; cat messages.log ; exit 1; }
-wait $kadmpid || { echo "kadmind failed $?"; cat messages.log ; exit 1; }
-
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 env KRB5CCNAME=${cache} \
 ${kadmin} get prune@${R} \
         > kadmin.tmp 2>&1 || \
         { echo "kadmin failed $?"; cat messages.log ; exit 1; }
-wait $kadmpid || { echo "kadmind failed $?"; cat messages.log ; exit 1; }
-
 cat kadmin.tmp | ${EGREP} Keytypes: | cut -d: -f2 | tr ' ' '
 ' | sed 's/^.*[[]\(.*\)[]].*$/\1/' | grep '[0-9]' | sort -nu | tr -d '
 ' | ${EGREP} '^13$' > /dev/null || \
         { echo "kadmin prune failed $?"; cat messages.log ; exit 1; }
 
 #----------------------------------
-${kadmind} -d &
-kadmpid=$!
-sleep 1
-
 echo "kadmin pruneall"
 env KRB5CCNAME=${cache} \
 ${kadmin} get pruneall@${R} \
         > kadmin.tmp 2>&1 || \
         { echo "kadmin failed $?"; cat messages.log ; exit 1; }
-wait $kadmpid || { echo "kadmind failed $?"; cat messages.log ; exit 1; }
-
 cat kadmin.tmp | ${EGREP} Keytypes: | cut -d: -f2 | tr ' ' '
 ' | sed 's/^.*[[]\(.*\)[]].*$/\1/' | grep '[0-9]' | sort -nu | tr -d '
 ' | ${EGREP} '^3$' > /dev/null || \


### PR DESCRIPTION
I've had it with `kadmin list` being slow when there are _many_ principals in a database.

This PR adds a `kadm5_iter_principals()` function that uses a callback rather than gathering all [matching] principals into an array in memory.

This PR also adds a variation on the Heimdal kadmin protocol's `LIST` operation that is correspondingly online, implements it in `kadmind`, and makes the `kadmin` client use it.

Lastly, there is a test, which tests listing an HDB w/ 20 principal in chunk sizes of 7 (three chunks), 10 (two chunks), and 50 (one chunk).  Testing listing of an HDB w/ zero principals is... hard and pointless, so no need.