### PR TITLE
KCM: Memory leak in `handle_read`

### DIFF
--- a/lib/ipc/server.c
+++ b/lib/ipc/server.c
@@ -700,6 +700,7 @@ maybe_close(struct client *c)
     dispatch_release(c->out);
 #endif
     close(c->fd); /* ref count fd close */
+    free(c->inmsg);
     free(c);
     return 1;
 }


### PR DESCRIPTION
The `inmsg` field of the client structure is malloc/realloc'ed in `handle_read` but never free'ed in `maybe_close`.
Seems like Apple already fixed that with this.