### PR TITLE
kcm: Allow disabling automatic TGT renewal

### DIFF
--- a/kcm/config.c
+++ b/kcm/config.c
@@ -45,6 +45,7 @@ static char *max_request_str;	/* `max_request' as a string */
 
 int detach_from_console = -1;
 int daemon_child = -1;
+int automatic_renewal = -1;
 
 static const char *system_cache_name = NULL;
 static const char *system_keytab = NULL;
@@ -92,6 +93,10 @@ static struct getargs args[] = {
     {
         "daemon-child",       0 ,      arg_integer, &daemon_child,
         "private argument, do not use", NULL
+    },
+    {
+	"automatic-renewal",	0 , arg_negative_flag, &automatic_renewal,
+	"disable automatic TGT renewal", NULL
     },
     {	"help",		'h',	arg_flag,   &help_flag, NULL, NULL },
     {
@@ -389,6 +394,13 @@ kcm_configure(int argc, char **argv)
 	if (ret)
 	    krb5_err(kcm_context, 1, ret, "initializing system ccache");
     }
+
+    if(automatic_renewal == -1)
+	automatic_renewal = krb5_config_get_bool_default(kcm_context, NULL,
+							 TRUE,
+							 "kcm",
+							 "automatic_renewal",
+							 NULL);
 
     if(detach_from_console == -1)
 	detach_from_console = krb5_config_get_bool_default(kcm_context, NULL,

--- a/kcm/events.c
+++ b/kcm/events.c
@@ -220,7 +220,7 @@ kcm_ccache_make_default_event(krb5_context context,
 	event->fire_time = time(NULL); /* right away */
 	event->action = KCM_EVENT_ACQUIRE_CREDS;
     } else if (is_primary_credential_p(context, ccache, newcred)) {
-	if (newcred->flags.b.renewable) {
+	if (automatic_renewal && newcred->flags.b.renewable) {
 	    event->action = KCM_EVENT_RENEW_CREDS;
 	    ccache->flags |= KCM_FLAGS_RENEWABLE;
 	} else {

--- a/kcm/kcm_locl.h
+++ b/kcm/kcm_locl.h
@@ -169,6 +169,7 @@ extern sig_atomic_t exit_flag;
 extern int name_constraints;
 extern int detach_from_console;
 extern int daemon_child;
+extern int automatic_renewal;
 extern int launchd_flag;
 extern int disallow_getting_krbtgt;
 


### PR DESCRIPTION
Add --no-automatic-renewal option to disable automatic TGT renewal.
Renewal can also be disabled by setting automatic_renewal to false
in the [kcm] section of krb5.conf.