### PR TITLE
Use memset_s() and constant-time memory comparisons

### DIFF
--- a/kdc/digest-service.c
+++ b/kdc/digest-service.c
@@ -179,7 +179,7 @@ ntlm_service(void *ctx, const heim_idata *req,
 	    goto failed;
 
 	if (ntq.ntChallengeResponce.length != answer.length ||
-	    memcmp(ntq.ntChallengeResponce.data, answer.data, answer.length) != 0) {
+	    ct_memcmp(ntq.ntChallengeResponce.data, answer.data, answer.length) != 0) {
 	    free(answer.data);
 	    ret = EINVAL;
 	    goto failed;

--- a/kdc/digest.c
+++ b/kdc/digest.c
@@ -1314,7 +1314,7 @@ _kdc_do_digest(krb5_context context,
 	    }
 
 	    if (ireq.u.ntlmRequest.ntlm.length != answer.length ||
-		memcmp(ireq.u.ntlmRequest.ntlm.data, answer.data, answer.length) != 0)
+		ct_memcmp(ireq.u.ntlmRequest.ntlm.data, answer.data, answer.length) != 0)
 		{
 		    free(answer.data);
 		    ret = EINVAL;

--- a/lib/gssapi/krb5/8003.c
+++ b/lib/gssapi/krb5/8003.c
@@ -259,7 +259,7 @@ _gsskrb5_verify_8003_checksum(
     }
 
     if (input_chan_bindings != GSS_C_NO_CHANNEL_BINDINGS
-	&& (memcmp(p, zeros, sizeof(zeros)) != 0 || client_asserted_cb)) {
+	&& (ct_memcmp(p, zeros, sizeof(zeros)) != 0 || client_asserted_cb)) {
 	if(hash_input_chan_bindings(input_chan_bindings, hash) != 0) {
 	    *minor_status = 0;
 	    return GSS_S_BAD_BINDINGS;

--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -1359,7 +1359,7 @@ _gssapi_unwrap_iov_arcfour(OM_uint32 *minor_status,
 	return GSS_S_FAILURE;
     }
 
-    cmp = (memcmp(cksum_data, p0 + 16, 8) != 0); /* SGN_CKSUM */
+    cmp = (ct_memcmp(cksum_data, p0 + 16, 8) != 0); /* SGN_CKSUM */
     if (cmp) {
 	*minor_status = 0;
 	return GSS_S_BAD_MIC;

--- a/lib/gssapi/netlogon/crypto.c
+++ b/lib/gssapi/netlogon/crypto.c
@@ -588,7 +588,7 @@ _netlogon_unwrap_iov(OM_uint32 *minor_status,
 
     /* [MS-NRPC] 3.3.4.2.2.10: verify signature */
     _netlogon_digest(ctx, sig, iov, iov_count, checksum);
-    if (memcmp(sig->Checksum, checksum, _netlogon_checksum_length(sig)) != 0)
+    if (ct_memcmp(sig->Checksum, checksum, _netlogon_checksum_length(sig)) != 0)
         return GSS_S_BAD_SIG;
 
     HEIMDAL_MUTEX_lock(&ctx->Mutex);

--- a/lib/gssapi/ntlm/crypto.c
+++ b/lib/gssapi/ntlm/crypto.c
@@ -230,7 +230,7 @@ v2_verify_message(gss_buffer_t in,
     if (ret)
 	return ret;
 
-    if (memcmp(checksum, out, 16) != 0)
+    if (ct_memcmp(checksum, out, 16) != 0)
 	return GSS_S_BAD_MIC;
 
     return GSS_S_COMPLETE;

--- a/lib/hcrypto/des.c
+++ b/lib/hcrypto/des.c
@@ -851,7 +851,7 @@ DES_string_to_key(const char *str, DES_cblock *key)
 	k[7] ^= 0xF0;
     DES_set_key(key, &ks);
     DES_cbc_cksum(s, key, len, &ks, key);
-    memset(&ks, 0, sizeof(ks));
+    memset_s(&ks, sizeof(ks), 0, sizeof(ks));
     DES_set_odd_parity(key);
     if (DES_is_weak_key(key))
 	k[7] ^= 0xF0;

--- a/lib/hcrypto/dh.c
+++ b/lib/hcrypto/dh.c
@@ -145,7 +145,7 @@ DH_free(DH *dh)
     free_if(dh->counter);
 #undef free_if
 
-    memset(dh, 0, sizeof(*dh));
+    memset_s(dh, sizeof(*dh), 0, sizeof(*dh));
     free(dh);
 }
 

--- a/lib/hcrypto/dsa.c
+++ b/lib/hcrypto/dsa.c
@@ -70,7 +70,7 @@ DSA_free(DSA *dsa)
     free_if(dsa->r);
 #undef free_if
 
-    memset(dsa, 0, sizeof(*dsa));
+    memset_s(dsa, sizeof(*dsa), 0, sizeof(*dsa));
     free(dsa);
 
 }

--- a/lib/hcrypto/engine.c
+++ b/lib/hcrypto/engine.c
@@ -87,7 +87,7 @@ ENGINE_finish(ENGINE *engine)
     if (engine->dso_handle)
 	dlclose(engine->dso_handle);
 
-    memset(engine, 0, sizeof(*engine));
+    memset_s(engine, sizeof(*engine), 0, sizeof(*engine));
     engine->references = -1;
 
 

--- a/lib/hcrypto/evp-openssl.c
+++ b/lib/hcrypto/evp-openssl.c
@@ -204,7 +204,7 @@ get_EVP_CIPHER_once_cb(void *d)
      */
     ossl_evp = EVP_get_cipherbynid(arg->nid);
     if (ossl_evp == NULL) {
-        (void) memset(hc_evp, 0, sizeof(*hc_evp));
+        (void) memset_s(hc_evp, sizeof(*hc_evp), 0, sizeof(*hc_evp));
 #if HCRYPTO_FALLBACK
         *arg->hc_memoizep = arg->fallback;
 #endif
@@ -348,7 +348,7 @@ get_EVP_MD_once_cb(void *d)
     *arg->ossl_memoizep = ossl_evp = EVP_get_digestbynid(arg->nid);
 
     if (ossl_evp == NULL) {
-        (void) memset(hc_evp, 0, sizeof(*hc_evp));
+        (void) memset_s(hc_evp, sizeof(*hc_evp), 0, sizeof(*hc_evp));
 #if HCRYPTO_FALLBACK
         *arg->hc_memoizep = arg->fallback;
 #endif

--- a/lib/hcrypto/evp.c
+++ b/lib/hcrypto/evp.c
@@ -189,12 +189,12 @@ EVP_MD_CTX_cleanup(EVP_MD_CTX *ctx) HC_DEPRECATED
 	if (!ret)
 	    return ret;
     } else if (ctx->md) {
-	memset(ctx->ptr, 0, ctx->md->ctx_size);
+	memset_s(ctx->ptr, ctx->md->ctx_size, 0, ctx->md->ctx_size);
     }
     ctx->md = NULL;
     ctx->engine = NULL;
     free(ctx->ptr);
-    memset(ctx, 0, sizeof(*ctx));
+    memset_s(ctx, sizeof(*ctx), 0, sizeof(*ctx));
     return 1;
 }
 
@@ -607,7 +607,7 @@ EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *c)
     }
     if (c->cipher_data) {
         if (c->cipher)
-            memset(c->cipher_data, 0, c->cipher->ctx_size);
+            memset_s(c->cipher_data, c->cipher->ctx_size, 0, c->cipher->ctx_size);
 	free(c->cipher_data);
 	c->cipher_data = NULL;
     }
@@ -905,7 +905,7 @@ EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, void *out, int *outlen,
 	/* fill in local buffer and encrypt */
 	memcpy(ctx->buf + ctx->buf_len, in, left);
 	ret = (*ctx->cipher->do_cipher)(ctx, out, ctx->buf, blocksize);
-	memset(ctx->buf, 0, blocksize);
+	memset_s(ctx->buf, blocksize, 0, blocksize);
 	if (ret != 1)
 	    return ret;
 
@@ -966,7 +966,7 @@ EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, void *out, int *outlen)
 	/* zero fill local buffer */
 	memset(ctx->buf + ctx->buf_len, 0, left);
 	ret = (*ctx->cipher->do_cipher)(ctx, out, ctx->buf, blocksize);
-	memset(ctx->buf, 0, blocksize);
+	memset_s(ctx->buf, blocksize, 0, blocksize);
 	if (ret != 1)
 	    return ret;
 

--- a/lib/hcrypto/hmac.c
+++ b/lib/hcrypto/hmac.c
@@ -46,17 +46,17 @@ void
 HMAC_CTX_cleanup(HMAC_CTX *ctx)
 {
     if (ctx->buf) {
-	memset(ctx->buf, 0, ctx->key_length);
+	memset_s(ctx->buf, ctx->key_length, 0, ctx->key_length);
 	free(ctx->buf);
 	ctx->buf = NULL;
     }
     if (ctx->opad) {
-	memset(ctx->opad, 0, EVP_MD_block_size(ctx->md));
+	memset_s(ctx->opad, EVP_MD_block_size(ctx->md), 0, EVP_MD_block_size(ctx->md));
 	free(ctx->opad);
 	ctx->opad = NULL;
     }
     if (ctx->ipad) {
-	memset(ctx->ipad, 0, EVP_MD_block_size(ctx->md));
+	memset_s(ctx->ipad, EVP_MD_block_size(ctx->md), 0, EVP_MD_block_size(ctx->md));
 	free(ctx->ipad);
 	ctx->ipad = NULL;
     }

--- a/lib/hcrypto/md2.c
+++ b/lib/hcrypto/md2.c
@@ -133,6 +133,6 @@ MD2_Final (void *res, struct md2 *m)
     MD2_Update(m, pad, 16);
 
     memcpy(res, m->state, MD2_DIGEST_LENGTH);
-    memset(m, 0, sizeof(*m));
+    memset_s(m, sizeof(*m), 0, sizeof(*m));
     return 1;
 }

--- a/lib/hcrypto/passwd_dlg.c
+++ b/lib/hcrypto/passwd_dlg.c
@@ -77,11 +77,11 @@ pwd_dialog(char *buf, int size)
     {
     case IDOK:
 	strlcpy(buf, passwd, size);
-	memset (passwd, 0, sizeof(passwd));
+	memset_s (passwd, sizeof(passwd), 0, sizeof(passwd));
 	return 0;
     case IDCANCEL:
     default:
-	memset (passwd, 0, sizeof(passwd));
+	memset_s (passwd, sizeof(passwd), 0, sizeof(passwd));
 	return 1;
     }
 }

--- a/lib/hcrypto/rand-fortuna.c
+++ b/lib/hcrypto/rand-fortuna.c
@@ -336,7 +336,7 @@ add_entropy(FState * st, const unsigned char *data, unsigned len)
 	st->pool0_bytes += len;
 
     memset_s(hash, sizeof(hash), 0, sizeof(hash));
-    memset_s(&md, sizeof(hash), 0, sizeof(md));
+    memset_s(&md, sizeof(md), 0, sizeof(md));
 }
 
 /*

--- a/lib/hcrypto/rc2.c
+++ b/lib/hcrypto/rc2.c
@@ -105,7 +105,7 @@ RC2_set_key(RC2_KEY *key, int len, const unsigned char *data, int bits)
 
     for (j = 0; j < 64; j++)
 	key->data[j] = k[(j * 2) + 0] | (k[(j * 2) + 1] << 8);
-    memset(k, 0, sizeof(k));
+    memset_s(k, sizeof(k), 0, sizeof(k));
 }
 
 #define ROT16L(w,n)  ((w<<n)|(w>>(16-n)))

--- a/lib/hcrypto/rsa.c
+++ b/lib/hcrypto/rsa.c
@@ -426,7 +426,7 @@ RSA_verify(int type, const unsigned char *from, unsigned int flen,
 	    return -4;
 	}
 
-	if (flen != di.digest.length || memcmp(di.digest.data, from, flen) != 0) {
+	if (flen != di.digest.length || ct_memcmp(di.digest.data, from, flen) != 0) {
 	    free_DigestInfo(&di);
 	    return -5;
 	}

--- a/lib/hcrypto/rsa.c
+++ b/lib/hcrypto/rsa.c
@@ -160,7 +160,7 @@ RSA_free(RSA *rsa)
     free_if(rsa->iqmp);
 #undef free_if
 
-    memset(rsa, 0, sizeof(*rsa));
+    memset_s(rsa, sizeof(*rsa), 0, sizeof(*rsa));
     free(rsa);
 }
 

--- a/lib/ntlm/ntlm.c
+++ b/lib/ntlm/ntlm.c
@@ -682,7 +682,7 @@ heim_ntlm_decode_type1(const struct ntlm_buf *buf, struct ntlm_type1 *data)
     krb5_storage_set_byteorder(in, KRB5_STORAGE_BYTEORDER_LE);
 
     CHECK_SIZE(krb5_storage_read(in, sig, sizeof(sig)), sizeof(sig));
-    CHECK(memcmp(ntlmsigature, sig, sizeof(ntlmsigature)), 0);
+    CHECK(ct_memcmp(ntlmsigature, sig, sizeof(ntlmsigature)), 0);
     CHECK(krb5_ret_uint32(in, &type), 0);
     CHECK(type, 1);
     CHECK(krb5_ret_uint32(in, &data->flags), 0);
@@ -844,7 +844,7 @@ heim_ntlm_decode_type2(const struct ntlm_buf *buf, struct ntlm_type2 *type2)
     krb5_storage_set_byteorder(in, KRB5_STORAGE_BYTEORDER_LE);
 
     CHECK_SIZE(krb5_storage_read(in, sig, sizeof(sig)), sizeof(sig));
-    CHECK(memcmp(ntlmsigature, sig, sizeof(ntlmsigature)), 0);
+    CHECK(ct_memcmp(ntlmsigature, sig, sizeof(ntlmsigature)), 0);
     CHECK(krb5_ret_uint32(in, &type), 0);
     CHECK(type, 2);
 
@@ -1001,7 +1001,7 @@ heim_ntlm_decode_type3(const struct ntlm_buf *buf,
     krb5_storage_set_byteorder(in, KRB5_STORAGE_BYTEORDER_LE);
 
     CHECK_SIZE(krb5_storage_read(in, sig, sizeof(sig)), sizeof(sig));
-    CHECK(memcmp(ntlmsigature, sig, sizeof(ntlmsigature)), 0);
+    CHECK(ct_memcmp(ntlmsigature, sig, sizeof(ntlmsigature)), 0);
     CHECK(krb5_ret_uint32(in, &type), 0);
     CHECK(type, 3);
     CHECK(ret_sec_buffer(in, &lm), 0);
@@ -1825,7 +1825,7 @@ verify_ntlm2(const void *key, size_t len,
     if (ret)
         goto out;
 
-    if (memcmp(serveranswer, clientanswer, 16) != 0) {
+    if (ct_memcmp(serveranswer, clientanswer, 16) != 0) {
 	heim_ntlm_free_buf(infotarget);
 	return HNTLM_ERR_AUTH;
     }

--- a/lib/otp/otp_verify.c
+++ b/lib/otp/otp_verify.c
@@ -49,7 +49,7 @@ otp_verify_user_1 (OtpContext *ctx, const char *passwd)
   }
   memcpy (key2, key1, sizeof(key1));
   ctx->alg->next (key2);
-  if (memcmp (ctx->key, key2, sizeof(key2)) == 0) {
+  if (ct_memcmp (ctx->key, key2, sizeof(key2)) == 0) {
     --ctx->n;
     memcpy (ctx->key, key1, sizeof(key1));
     return 0;


### PR DESCRIPTION
Using memset_s() ensures that sensitive memory is cleared, and constant-time memory comparisons help to prevent timing attacks.