### PR TITLE
kdc: support pkinit_kdc_revoke for pkinit anchors

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -518,7 +518,11 @@ pa_pkinit_validate(astgs_request_t r, const PA_DATA *pa)
 
     ret = _kdc_pk_rd_padata(r, pa, &pkp);
     if (ret || pkp == NULL) {
-	ret = KRB5KRB_AP_ERR_BAD_INTEGRITY;
+	if (ret == HX509_CERT_REVOKED) {
+	    ret = KRB5_KDC_ERR_CLIENT_NOT_TRUSTED;	
+	} else {
+	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY;
+	}
 	_kdc_r_log(r, 4, "Failed to decode PKINIT PA-DATA -- %s",
 		   r->cname);
 	goto out;


### PR DESCRIPTION
This adds support for revocation checking pkinit anchors.

Windows expects `KRB5_KDC_ERR_CLIENT_NOT_TRUSTED` when the anchor certificate is revoked.

BUG: https://bugzilla.samba.org/show_bug.cgi?id=9612