### PR TITLE
hdb: fix ldap module build (missing 'is_file_based' and 'can_taste' i…

### DIFF
--- a/lib/hdb/hdb-ldap.c
+++ b/lib/hdb/hdb-ldap.c
@@ -2106,6 +2106,7 @@ struct hdb_method hdb_ldap_interface = {
 
 struct hdb_method hdb_ldapi_interface = {
     HDB_INTERFACE_VERSION,
+    0 /*is_file_based*/, 0 /*can_taste*/,
     init,
     fini,
     "ldapi",


### PR DESCRIPTION
…nitializers)

Without the change the build fails as:

      CC       hdb-ldap.lo
    hdb-ldap.c:2109:5: warning: initialization of 'unsigned char:1' from 'krb5_error_code (*)(struct krb5_context_data *, void **)' {aka 'int (*)(struct krb5_context_data *, void **)'} makes integer from pointer without a cast [-Wint-conversion]
     2109 |     init,
          |     ^~~~
    hdb-ldap.c:2109:5: note: (near initialization for 'hdb_ldapi_interface.is_file_based')
    hdb-ldap.c:2109:5: error: initializer element is not computable at load time
    hdb-ldap.c:2109:5: note: (near initialization for 'hdb_ldapi_interface.is_file_based')
    hdb-ldap.c:2110:5: warning: initialization of 'unsigned char:1' from 'void (*)(void *)' makes integer from pointer without a cast [-Wint-conversion]
     2110 |     fini,
          |     ^~~~
    hdb-ldap.c:2110:5: note: (near initialization for 'hdb_ldapi_interface.can_taste')
    hdb-ldap.c:2110:5: error: initializer element is not computable at load time
    hdb-ldap.c:2110:5: note: (near initialization for 'hdb_ldapi_interface.can_taste')
    hdb-ldap.c:2111:5: warning: initialization of 'krb5_error_code (*)(struct krb5_context_data *, void **)' {aka 'int (*)(struct krb5_context_data *, void **)'} from incompatible pointer type 'char *' [-Wincompatible-pointer-types]
     2111 |     "ldapi",
          |     ^~~~~~~
    hdb-ldap.c:2111:5: note: (near initialization for 'hdb_ldapi_interface.init')
    hdb-ldap.c:2112:5: warning: initialization of 'void (*)(void *)' from incompatible pointer type 'krb5_error_code (*)(struct krb5_context_data *, HDB **, const char *)' {aka 'int (*)(struct krb5_context_data *, HDB **, const char *)'} [-Wincompatible-pointer-types]
     2112 |     hdb_ldapi_create
          |     ^~~~~~~~~~~~~~~~
    hdb-ldap.c:2112:5: note: (near initialization for 'hdb_ldapi_interface.fini')
    hdb-ldap.c:2113:1: warning: missing initializer for field 'prefix' of 'struct hdb_method' [-Wmissing-field-initializers]
     2113 | };
          | ^
Started failing when commit 93ada1fbf ("hdb: Remove default HDB backend
footgun") added extra fields to 'struct hdb_method'.