### PR TITLE
make --shuffle build fixes

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -10,6 +10,8 @@ TEXI2DVI = true # ARGH, make distcheck can't be disabled to not build dvifiles
 
 info_TEXINFOS = heimdal.texi hx509.texi
 
+BUILT_SOURCES = vars.texi
+
 dxy_subst = sed -e 's,[@]srcdir[@],$(srcdir),g' \
 	-e 's,[@]objdir[@],.,g' \
 	-e 's,[@]PACKAGE_VERSION[@],$(PACKAGE_VERSION),g'

--- a/lib/gssapi/Makefile.am
+++ b/lib/gssapi/Makefile.am
@@ -264,10 +264,6 @@ dist_libgssapi_la_SOURCES  = \
 	$(sanonsrc)
 
 nodist_libgssapi_la_SOURCES  = \
-	gkrb5_err.c \
-	gkrb5_err.h \
-	negoex_err.c \
-	negoex_err.h \
 	$(BUILT_SOURCES)
 
 libgssapi_la_DEPENDENCIES = version-script.map
@@ -333,7 +329,13 @@ $(test_context_OBJECTS): $(BUILTHEADERS)
 
 $(libgssapi_la_OBJECTS): $(srcdir)/version-script.map
 
-BUILT_SOURCES = $(spnego_files) $(gssapi_files)
+BUILT_SOURCES = \
+	$(spnego_files) \
+	$(gssapi_files) \
+	gkrb5_err.c \
+	gkrb5_err.h \
+	negoex_err.c \
+	negoex_err.h
 
 $(libgssapi_la_OBJECTS): gkrb5_err.h negoex_err.h
 gkrb5_err.h: $(srcdir)/krb5/gkrb5_err.et

--- a/lib/hdb/Makefile.am
+++ b/lib/hdb/Makefile.am
@@ -17,7 +17,9 @@ endif
 BUILT_SOURCES = \
 	$(gen_files_hdb)	\
 	hdb_err.c \
-	hdb_err.h
+	hdb_err.h \
+	$(srcdir)/hdb-protos.h \
+	$(srcdir)/hdb-private.h
 
 gen_files_hdb = \
 	asn1_Event.c \


### PR DESCRIPTION
`git` version of `GNU make` added `make --shuffle` mode in https://savannah.gnu.org/bugs/index.php?62100.

This mode managed to find a few missing build-time dependencies in `heimdal`:

      hdb: add missing build dependency on "hdb-protos.h"
      doc: add dependency on vars.texi
      gssapi: add dependency on gkrb5_err.h

Before the change `make --shuffle -j16` did not survive more than 2 consecutive builds for me.
After the change I saw 15 successful consecutive builds until I gave up.