### PR TITLE
Add `/get-tgts` batch end-point for "prestash" service; also fix POST support in bx509d and httpkadmind

### DIFF
--- a/admin/Makefile.am
+++ b/admin/Makefile.am
@@ -37,6 +37,7 @@ LDADD = \
 	$(LIB_hcrypto) \
 	$(top_builddir)/lib/asn1/libasn1.la \
 	$(top_builddir)/lib/sl/libsl.la \
+	$(LIB_heimbase) \
 	$(LIB_readline) \
 	$(LIB_roken)
 

--- a/admin/add.c
+++ b/admin/add.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2005 Kungliga Tekniska Högskolan
+ * Copyright (c) 1997-2022 Kungliga Tekniska Högskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *
@@ -32,6 +32,8 @@
  */
 
 #include "ktutil_locl.h"
+#include <heimbase.h>
+#include <base64.h>
 
 RCSID("$Id$");
 
@@ -153,6 +155,178 @@ kt_add(struct add_options *opt, int argc, char **argv)
 	krb5_warn(context, ret, "add");
  out:
     krb5_kt_free_entry(context, &entry);
-    krb5_kt_close(context, keytab);
+    if (ret == 0) {
+        ret = krb5_kt_close(context, keytab);
+        if (ret)
+            krb5_warn(context, ret, "Could not write the keytab");
+    } else {
+        krb5_kt_close(context, keytab);
+    }
+    return ret != 0;
+}
+
+/* We might be reading from a pipe, so we can't use rk_undumpdata() */
+static char *
+read_file(FILE *f)
+{
+    size_t alloced;
+    size_t len = 0;
+    size_t bytes;
+    char *res, *end, *p;
+
+    if ((res = malloc(1024)) == NULL)
+        err(1, "Out of memory");
+    alloced = 1024;
+
+    end = res + alloced;
+    p = res;
+    do {
+        if (p == end) {
+            char *tmp;
+
+            if ((tmp = realloc(res, alloced + (alloced > 1))) == NULL)
+                err(1, "Out of memory");
+            alloced += alloced > 1;
+            p = tmp + (p - res);
+            res = tmp;
+            end = res + alloced;
+        }
+        bytes = fread(p, 1, end - p, f);
+        len += bytes;
+        p += bytes;
+    } while (bytes && !feof(f) && !ferror(f));
+
+    if (ferror(f))
+        errx(1, "Could not read all input");
+    if (p == end) {
+        char *tmp;
+
+        if ((tmp = strndup(res, len)) == NULL)
+            err(1, "Out of memory");
+        free(res);
+        res = tmp;
+    }
+    if (strlen(res) != len)
+        err(1, "Embedded NULs in input!");
+    return res;
+}
+
+static void
+json2keytab_entry(heim_dict_t d, krb5_keytab kt, size_t idx)
+{
+    krb5_keytab_entry e;
+    krb5_error_code ret;
+    heim_object_t v;
+    uint64_t u;
+    int64_t i;
+    char *buf = NULL;
+
+    memset(&e, 0, sizeof(e));
+
+    v = heim_dict_get_value(d, HSTR("timestamp"));
+    if (heim_get_tid(v) != HEIM_TID_NUMBER)
+        goto bad;
+    u = heim_number_get_long(v);
+    e.timestamp = u;
+    if (u != (uint64_t)e.timestamp)
+        goto bad;
+
+    v = heim_dict_get_value(d, HSTR("kvno"));
+    if (heim_get_tid(v) != HEIM_TID_NUMBER)
+        goto bad;
+    i = heim_number_get_long(v);
+    e.vno = i;
+    if (i != (int64_t)e.vno)
+        goto bad;
+
+    v = heim_dict_get_value(d, HSTR("enctype_number"));
+    if (heim_get_tid(v) != HEIM_TID_NUMBER)
+        goto bad;
+    i = heim_number_get_long(v);
+    e.keyblock.keytype = i;
+    if (i != (int64_t)e.keyblock.keytype)
+        goto bad;
+
+    v = heim_dict_get_value(d, HSTR("key"));
+    if (heim_get_tid(v) != HEIM_TID_STRING)
+        goto bad;
+    {
+        const char *s = heim_string_get_utf8(v);
+        int declen;
+
+        if ((buf = malloc(strlen(s))) == NULL)
+            err(1, "Out of memory");
+        declen = rk_base64_decode(s, buf);
+        if (declen < 0)
+            goto bad;
+        e.keyblock.keyvalue.data = buf;
+        e.keyblock.keyvalue.length = declen;
+    }
+
+    v = heim_dict_get_value(d, HSTR("principal"));
+    if (heim_get_tid(v) != HEIM_TID_STRING)
+        goto bad;
+    ret = krb5_parse_name(context, heim_string_get_utf8(v), &e.principal);
+    if (ret == 0)
+        ret = krb5_kt_add_entry(context, kt, &e);
+
+    /* For now, ignore aliases; besides, they're never set anywhere in-tree */
+
+    if (ret)
+        krb5_warn(context, ret,
+                  "Could not parse or write keytab entry %lu",
+                  (unsigned long)idx);
+bad:
+    krb5_free_principal(context, e.principal);
+}
+
+int
+kt_import(void *opt, int argc, char **argv)
+{
+    krb5_error_code ret;
+    krb5_keytab kt;
+    heim_object_t o;
+    heim_error_t json_err = NULL;
+    heim_json_flags_t flags = HEIM_JSON_F_STRICT;
+    FILE *f = argc == 0 ? stdin : fopen(argv[0], "r");
+    size_t alen, i;
+    char *json;
+
+    if (f == NULL)
+        err(1, "Could not open file %s", argv[0]);
+
+    json = read_file(f);
+    o = heim_json_create(json, 10, flags, &json_err);
+    free(json);
+    if (o == NULL) {
+        if (json_err != NULL) {
+            o = heim_error_copy_string(json_err);
+            if (o)
+                errx(1, "Could not parse JSON: %s", heim_string_get_utf8(o));
+        }
+        errx(1, "Could not parse JSON");
+    }
+
+    if (heim_get_tid(o) != HEIM_TID_ARRAY)
+        errx(1, "JSON text must be an array");
+
+    alen = heim_array_get_length(o);
+    if (alen == 0)
+        errx(1, "Empty JSON array; not overwriting keytab");
+
+    if ((kt = ktutil_open_keytab()) == NULL)
+	err(1, "Could not open keytab");
+
+    for (i = 0; i < alen; i++) {
+        heim_object_t e = heim_array_get_value(o, i);
+
+        if (heim_get_tid(e) != HEIM_TID_DICT)
+            warnx("Element %ld of JSON text array is not an object", (long)i);
+        else
+            json2keytab_entry(heim_array_get_value(o, i), kt, i);
+    }
+    ret = krb5_kt_close(context, kt);
+    if (ret)
+        krb5_warn(context, ret, "Could not write the keytab");
     return ret != 0;
 }

--- a/admin/get.c
+++ b/admin/get.c
@@ -197,23 +197,27 @@ kt_get(struct get_options *opt, int argc, char **argv)
 		break;
 	}
 
-	ret = kadm5_create_principal(kadm_handle, &princ, mask, "thisIs_aUseless.password123");
-	if(ret == 0)
-	    created = 1;
-	else if(ret != KADM5_DUP) {
-	    krb5_warn(context, ret, "kadm5_create_principal(%s)", argv[a]);
-	    krb5_free_principal(context, princ_ent);
-	    failed++;
-	    continue;
-	}
-        ret = kadm5_randkey_principal_3(kadm_handle, princ_ent, keep, nks, ks,
-                                        &keys, &n_keys);
-	if (ret) {
-	    krb5_warn(context, ret, "kadm5_randkey_principal(%s)", argv[a]);
-	    krb5_free_principal(context, princ_ent);
-	    failed++;
-	    continue;
-	}
+        if (opt->create_flag) {
+            ret = kadm5_create_principal(kadm_handle, &princ, mask, "thisIs_aUseless.password123");
+            if(ret == 0)
+                created = 1;
+            else if(ret != KADM5_DUP) {
+                krb5_warn(context, ret, "kadm5_create_principal(%s)", argv[a]);
+                krb5_free_principal(context, princ_ent);
+                failed++;
+                continue;
+            }
+        }
+        if (opt->change_keys_flag) {
+            ret = kadm5_randkey_principal_3(kadm_handle, princ_ent, keep, nks, ks,
+                                            &keys, &n_keys);
+            if (ret) {
+                krb5_warn(context, ret, "kadm5_randkey_principal(%s)", argv[a]);
+                krb5_free_principal(context, princ_ent);
+                failed++;
+                continue;
+            }
+        }
 
 	ret = kadm5_get_principal(kadm_handle, princ_ent, &princ,
 			      KADM5_PRINCIPAL | KADM5_KVNO | KADM5_ATTRIBUTES);

--- a/admin/ktutil-commands.in
+++ b/admin/ktutil-commands.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004 Kungliga Tekniska Högskolan
+ * Copyright (c) 2004-2022 Kungliga Tekniska Högskolan
  * (Royal Institute of Technology, Stockholm, Sweden). 
  * All rights reserved. 
  *
@@ -151,11 +151,17 @@ command = {
 }
 command = {
 	name = "copy"
+	name = "merge"
 	function = "kt_copy"
+	option = {
+		long = "copy-duplicates"
+		type = "flag"
+		help = "copy entries for the same principal and kvno, but different keys"
+	}
 	argument = "source destination"
 	min_args = "2"
 	max_args = "2"
-	help = "Copies one keytab to another."
+	help = "Merges one keytab into another."
 }
 command = {
 	name = "get"
@@ -165,6 +171,16 @@ command = {
 		type = "string"
 		help = "admin principal"
 		argument = "principal"
+	}
+	option = {
+		long = "create"
+		type = "-flag"
+		help = "do not create the principal"
+	}
+	option = {
+		long = "change-keys"
+		type = "-flag"
+		help = "do not change the principal's keys"
 	}
 	option = {
 		long = "enctypes"
@@ -213,6 +229,14 @@ command = {
 	min_args = "1"
 	argument = "principal..."
 	help = "Change keys for specified principals, and add them to the keytab."
+}
+command = {
+	name = "import"
+	function = "kt_import"
+	help = "Imports a keytab from JSON output of ktutil list --json --keys."
+        min_args = "0"
+        max_args = "1"
+	argument = "JSON-FILE"
 }
 command = {
 	name = "list"

--- a/admin/ktutil-commands.in
+++ b/admin/ktutil-commands.in
@@ -226,6 +226,11 @@ command = {
 		type = "flag"
 		help = "show timestamps"
 	}
+	option = {
+		long = "json"
+		type = "flag"
+		help = "output JSON representation"
+	}
 	max_args = "0"
 	function = "kt_list"
 	help = "Show contents of keytab."

--- a/admin/ktutil.1
+++ b/admin/ktutil.1
@@ -60,7 +60,7 @@ Verbose output.
 .Ar command
 can be one of the following:
 .Bl -tag -width srvconvert
-.It add Oo Fl p Ar principal Oc Oo Fl Fl principal= Ns Ar principal Oc \
+.It Nm add Oo Fl p Ar principal Oc Oo Fl Fl principal= Ns Ar principal Oc \
 Oo Fl V Ar kvno Oc Oo Fl Fl kvno= Ns Ar kvno Oc Oo Fl e Ar enctype Oc \
 Oo Fl Fl keepold | Fl Fl keepallold | Fl Fl pruneall Oc \
 Oo Fl Fl enctype= Ns Ar enctype Oc Oo Fl w Ar password Oc \
@@ -72,7 +72,7 @@ principal to add; if what you really want is to add a new principal to
 the keytab, you should consider the
 .Ar get
 command, which talks to the kadmin server.
-.It change Oo Fl r Ar realm Oc Oo Fl Fl realm= Ns Ar realm Oc \
+.It Nm change Oo Fl r Ar realm Oc Oo Fl Fl realm= Ns Ar realm Oc \
 Oo Fl Fl keepold | Fl Fl keepallold | Fl Fl pruneall Oc \
 Oo Fl Fl enctype= Ns Ar enctype Oc \
 Oo Fl Fl a Ar host Oc Oo Fl Fl admin-server= Ns Ar host Oc \
@@ -82,12 +82,12 @@ server for the realm of a keytab entry.  Otherwise it will use the
 values specified by the options.
 .Pp
 If no principals are given, all the ones in the keytab are updated.
-.It copy Ar keytab-src Ar keytab-dest
+.It Nm copy Ar keytab-src Ar keytab-dest
 Copies all the entries from
 .Ar keytab-src
 to
 .Ar keytab-dest .
-.It get Oo Fl p Ar admin principal Oc \
+.It Nm get Oo Fl p Ar admin principal Oc \
 Oo Fl Fl principal= Ns Ar admin principal Oc Oo Fl e Ar enctype Oc \
 Oo Fl Fl keepold | Fl Fl keepallold | Fl Fl pruneall Oc \
 Oo Fl Fl enctypes= Ns Ar enctype Oc Oo Fl r Ar realm Oc \
@@ -103,9 +103,9 @@ If no
 .Ar realm
 is specified, the realm to operate on is taken from the first
 principal.
-.It list Oo Fl Fl keys Oc Op Fl Fl timestamp
+.It Nm list Oo Fl Fl keys Oc Op Fl Fl timestamp Oo Op Fl Fl json Oc
 List the keys stored in the keytab.
-.It remove Oo Fl p Ar principal Oc Oo Fl Fl principal= Ns Ar principal Oc \
+.It Nm remove Oo Fl p Ar principal Oc Oo Fl Fl principal= Ns Ar principal Oc \
 Oo Fl V kvno Oc Oo Fl Fl kvno= Ns Ar kvno Oc Oo Fl e enctype Oc \
 Oo Fl Fl enctype= Ns Ar enctype Oc
 Removes the specified key or keys. Not specifying a
@@ -113,12 +113,12 @@ Removes the specified key or keys. Not specifying a
 removes keys with any version number. Not specifying an
 .Ar enctype
 removes keys of any type.
-.It rename Ar from-principal Ar to-principal
+.It Nm rename Ar from-principal Ar to-principal
 Renames all entries in the keytab that match the
 .Ar from-principal
 to
 .Ar to-principal .
-.It purge Op Fl Fl age= Ns Ar age
+.It Nm purge Op Fl Fl age= Ns Ar age
 Removes all old versions of a key for which there is a newer version
 that is at least
 .Ar age

--- a/admin/ktutil.1
+++ b/admin/ktutil.1
@@ -82,29 +82,67 @@ server for the realm of a keytab entry.  Otherwise it will use the
 values specified by the options.
 .Pp
 If no principals are given, all the ones in the keytab are updated.
-.It Nm copy Ar keytab-src Ar keytab-dest
+.It Nm copy Oo Fl Fl copy-duplicates Oc Ar keytab-src Ar keytab-dest
 Copies all the entries from
 .Ar keytab-src
 to
 .Ar keytab-dest .
+Because entries already in
+.Ar keytab-dest
+are kept, this command functions to merge keytabs.
+Entries for the same principal, key version number, and
+encryption type in the
+.Ar keytab-src
+that are also in the
+.Ar keytab-dest
+will not be copied to the
+.Ar keytab-dest
+unless the
+.Fl Fl copy-duplicates
+option is given.
 .It Nm get Oo Fl p Ar admin principal Oc \
 Oo Fl Fl principal= Ns Ar admin principal Oc Oo Fl e Ar enctype Oc \
+Oo Fl Fl no-create Oc \
+Oo Fl Fl no-change-keys Oc \
 Oo Fl Fl keepold | Fl Fl keepallold | Fl Fl pruneall Oc \
 Oo Fl Fl enctypes= Ns Ar enctype Oc Oo Fl r Ar realm Oc \
 Oo Fl Fl realm= Ns Ar realm Oc Oo Fl a Ar admin server Oc \
 Oo Fl Fl admin-server= Ns Ar admin server Oc Oo Fl s Ar server port Oc \
 Oo Fl Fl server-port= Ns Ar server port Oc Ar principal ...
+.Pp
 For each
 .Ar principal ,
-generate a new key for it (creating it if it doesn't already exist),
-and put that key in the keytab.
+get a the principal's keys from the KDC via the kadmin protocol,
+creating the principal if it doesn't exist (unless
+.Fl Fl no-create
+is given), and changing its keys to new random keys (unless
+.Fl Fl no-change-keys
+is given).
 .Pp
 If no
 .Ar realm
 is specified, the realm to operate on is taken from the first
 principal.
+.It Nm import Oo JSON-FILE Oc
+Read an array of keytab entries in a JSON file and copy them to
+the keytab.
+Use the
+.Nm list
+command with its
+.Fl Fl json
+option
+and
+.Fl Fl keys
+option to export a keytab.
 .It Nm list Oo Fl Fl keys Oc Op Fl Fl timestamp Oo Op Fl Fl json Oc
 List the keys stored in the keytab.
+Use the
+.Fl Fl json
+and
+.Fl Fl keys
+options to export a keytab as JSON for importing with the
+.Nm import
+command.
 .It Nm remove Oo Fl p Ar principal Oc Oo Fl Fl principal= Ns Ar principal Oc \
 Oo Fl V kvno Oc Oo Fl Fl kvno= Ns Ar kvno Oc Oo Fl e enctype Oc \
 Oo Fl Fl enctype= Ns Ar enctype Oc
@@ -113,8 +151,14 @@ Removes the specified key or keys. Not specifying a
 removes keys with any version number. Not specifying an
 .Ar enctype
 removes keys of any type.
+.It Nm merge Oo Fl Fl copy-duplicates Oc Ar keytab-src Ar keytab-dest
+An alias for the
+.Nm copy
+command.
 .It Nm rename Ar from-principal Ar to-principal
-Renames all entries in the keytab that match the
+Renames all entries for the
+.Ar from-principal
+in the keytab
 .Ar from-principal
 to
 .Ar to-principal .
@@ -123,6 +167,12 @@ Removes all old versions of a key for which there is a newer version
 that is at least
 .Ar age
 (default one week) old.
+Note that this does not update the KDC database.
+The
+.Xr kadmin 1
+command has a
+.Nm prune
+command that can do this on the KDC side.
 .El
 .Sh SEE ALSO
 .Xr kadmin 1

--- a/admin/list.c
+++ b/admin/list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2004 Kungliga Tekniska Högskolan
+ * Copyright (c) 1997-2022 Kungliga Tekniska Högskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *
@@ -32,6 +32,7 @@
  */
 
 #include "ktutil_locl.h"
+#include <heimbase.h>
 #include <rtbl.h>
 
 RCSID("$Id$");
@@ -131,7 +132,8 @@ do_list(struct list_options *opt, const char *keytab_str)
 	    struct rk_strpool *p = NULL;
 
 	    for (i = 0; i< entry.aliases->len; i++) {
-		krb5_unparse_name_fixed(context, entry.principal, buf, sizeof(buf));
+		krb5_unparse_name_fixed(context, &entry.aliases->val[i],
+                                        buf, sizeof(buf));
 		p = rk_strpoolprintf(p, "%s%s", buf,
                                      i + 1 < entry.aliases->len ? ", " : "");
 
@@ -152,6 +154,137 @@ out:
     return ret;
 }
 
+static int
+do_list1_json(struct list_options *opt,
+              const char *keytab_str,
+              heim_array_t a)
+{
+    krb5_error_code ret;
+    krb5_keytab keytab;
+    krb5_keytab_entry entry;
+    krb5_kt_cursor cursor;
+
+    ret = krb5_kt_resolve(context, keytab_str, &keytab);
+    if (ret) {
+	krb5_warn(context, ret, "resolving keytab %s", keytab_str);
+	return ret;
+    }
+
+    ret = krb5_kt_start_seq_get(context, keytab, &cursor);
+    if(ret) {
+	krb5_warn(context, ret, "krb5_kt_start_seq_get %s", keytab_str);
+	krb5_kt_close(context, keytab);
+	return ret;
+    }
+
+    //if (opt->timestamp_flag)
+    //if (opt->keys_flag)
+
+    while (krb5_kt_next_entry(context, keytab, &entry, &cursor) == 0) {
+        heim_dict_t d = heim_dict_create(5);
+        heim_object_t o;
+	char *s;
+
+        heim_array_append_value(a, d);
+        heim_dict_set_value(d, HSTR("keytab"),
+                            o = heim_string_create(keytab_str)); heim_release(o);
+        heim_dict_set_value(d, HSTR("kvno"), o = heim_number_create(entry.vno));
+        heim_release(o);
+        heim_dict_set_value(d, HSTR("enctype_number"),
+                            o = heim_number_create(entry.keyblock.keytype));
+        heim_release(o);
+        heim_dict_set_value(d, HSTR("flags"),
+                            o = heim_number_create(entry.flags));
+        heim_release(o);
+	ret = krb5_enctype_to_string(context, entry.keyblock.keytype, &s);
+	if (ret == 0) {
+            heim_dict_set_value(d, HSTR("enctype"), o = heim_string_create(s));
+            heim_release(o);
+            free(s);
+	}
+        heim_dict_set_value(d, HSTR("timestamp"),
+                            o = heim_number_create(entry.timestamp));
+        heim_release(o);
+
+	ret = krb5_unparse_name(context, entry.principal, &s);
+        if (ret)
+            krb5_err(context, 1, ret, "Could not format principal");
+        heim_dict_set_value(d, HSTR("principal"), o = heim_string_create(s));
+        heim_release(o);
+        free(s);
+
+	if (opt->keys_flag) {
+            o = heim_data_create(entry.keyblock.keyvalue.data,
+                                 entry.keyblock.keyvalue.length);
+            heim_dict_set_value(d, HSTR("key"), o);
+            heim_release(o);
+	}
+	if (entry.aliases) {
+            heim_array_t aliases = heim_array_create();
+	    unsigned int i;
+
+	    for (i = 0; i< entry.aliases->len; i++) {
+		ret = krb5_unparse_name(context, &entry.aliases->val[i], &s);
+                if (ret)
+                    krb5_err(context, 1, ret, "Could not format principal");
+                heim_array_append_value(aliases, o = heim_string_create(s));
+                heim_release(o);
+                free(s);
+	    }
+            heim_dict_set_value(d, HSTR("aliases"), aliases);
+            heim_release(aliases);
+            free(s);
+	}
+
+	krb5_kt_free_entry(context, &entry);
+        heim_release(d);
+    }
+
+    ret = krb5_kt_end_seq_get(context, keytab, &cursor);
+    krb5_kt_close(context, keytab);
+    return ret;
+}
+
+static int
+do_list_json(struct list_options *opt, const char *keytab_str)
+{
+    krb5_error_code ret = 0;
+    heim_json_flags_t flags =
+        (HEIM_JSON_F_STRICT | HEIM_JSON_F_INDENT2 | HEIM_JSON_F_NO_DATA_DICT) &
+        ~HEIM_JSON_F_NO_DATA;
+    heim_array_t a = heim_array_create();
+    heim_string_t s;
+
+    /*
+     * Special-case the ANY: keytab type.  What do we get from this?  We get to
+     * include the actual keytab name for each entry in its JSON
+     * representation.  Otherwise there would be no point because the ANY:
+     * keytab type iterates all the keytabs it joins.
+     *
+     * Why strncasecmp() though?  Because do_list() uses it, though it arguably
+     * never should have.
+     */
+    if (strncasecmp(keytab_str, "ANY:", 4) == 0) {
+	char buf[1024];
+
+	keytab_str += 4;
+	ret = 0;
+	while (strsep_copy((const char**)&keytab_str, ",",
+			   buf, sizeof(buf)) != -1) {
+	    if (do_list1_json(opt, buf, a))
+		ret = 1;
+	}
+    } else {
+        ret = do_list1_json(opt, keytab_str, a);
+    }
+
+    s = heim_json_copy_serialize(a, flags, NULL);
+    printf("%s", heim_string_get_utf8(s));
+    heim_release(a);
+    heim_release(s);
+    return ret;
+}
+
 int
 kt_list(struct list_options *opt, int argc, char **argv)
 {
@@ -168,5 +301,7 @@ kt_list(struct list_options *opt, int argc, char **argv)
 	}
 	keytab_string = kt;
     }
+    if (opt->json_flag)
+        return do_list_json(opt, keytab_string) != 0;
     return do_list(opt, keytab_string) != 0;
 }

--- a/kadmin/NTMakefile
+++ b/kadmin/NTMakefile
@@ -119,17 +119,17 @@ $(OBJ)\add_random_users.exe: $(OBJ)\add_random_users.obj $(LIBKADM5SRV) $(LIBKAD
 	$(EXECONLINK) Secur32.lib Shell32.lib
 	$(EXEPREP_NODIST)
 
-TEST_BINARIES=$(OBJ)\test_util.exe
-
-$(OBJ)\test_util.exe: $(OBJ)\test_util.obj $(OBJ)\util.obj $(KADMIN_LIBS)
-	$(EXECONLINK) Secur32.lib Shell32.lib
-	$(EXEPREP_NODIST)
-
-test-binaries: $(TEST_BINARIES)
-
-test-run:
-	cd $(OBJ)
-	test_util.exe
-	cd $(SRCDIR)
-
-test:: test-binaries test-run
+#TEST_BINARIES=$(OBJ)\test_util.exe
+#
+#$(OBJ)\test_util.exe: $(OBJ)\test_util.obj $(OBJ)\util.obj $(KADMIN_LIBS)
+#	$(EXECONLINK) Secur32.lib Shell32.lib
+#	$(EXEPREP_NODIST)
+#
+#test-binaries: $(TEST_BINARIES)
+#
+#test-run:
+#	cd $(OBJ)
+#	test_util.exe
+#	cd $(SRCDIR)
+#
+test:: #test-binaries test-run

--- a/kdc/Makefile.am
+++ b/kdc/Makefile.am
@@ -44,6 +44,7 @@ bx509d_LDADD =	-ldl \
 		 $(MICROHTTPD_LIBS) \
 		 $(LIB_roken) \
 		 $(LIB_heimbase) \
+		 $(LIB_hcrypto) \
 		 $(top_builddir)/lib/sl/libsl.la \
 		 $(top_builddir)/lib/asn1/libasn1.la \
 		 $(top_builddir)/lib/krb5/libkrb5.la \

--- a/kdc/bx509d.8
+++ b/kdc/bx509d.8
@@ -40,7 +40,11 @@
 .Op Fl Fl version
 .Op Fl H Ar HOSTNAME
 .Op Fl d | Fl Fl daemon
-.Op Fl Fl daemon-child
+.Op Fl Fl allow-GET
+.Op Fl Fl no-allow-GET
+.Op Fl Fl csrf-protection-type= Ns Ar CSRF-PROTECTION-TYPE
+.Op Fl Fl csrf-header= Ns Ar HEADER-NAME
+.Op Fl Fl csrf-key-file= Ns Ar FILE
 .Op Fl Fl reverse-proxied
 .Op Fl p Ar port number (default: 443)
 .Op Fl Fl cache-dir= Ns Ar DIRECTORY
@@ -53,11 +57,24 @@
 .Oc
 .Sh DESCRIPTION
 Serves RESTful (HTTPS) GETs of
-.Ar /bx509 and
-.Ar /bnegotiate ,
-end-points
-performing corresponding kx509 and, possibly, PKINIT requests
-to the KDCs of the requested realms (or just the given REALM).
+.Ar /get-cert ,
+.Ar /get-tgt ,
+.Ar /get-tgts ,
+and
+.Ar /get-negotiate-token ,
+end-points that implement various experimental Heimdal features:
+.Bl -bullet -compact -offset indent
+.It
+.Li an online CA service over HTTPS,
+.It
+.Li a kinit-over-HTTPS service, and
+.It
+.Li a Negotiate token over HTTPS service.
+.El
+.Pp
+As well, a
+.Ar /health
+service can be used for checking service status.
 .Pp
 Supported options:
 .Bl -tag -width Ds
@@ -75,6 +92,64 @@ Print version.
 .Xc
 Expected audience(s) of bearer tokens (i.e., acceptor name).
 .It Xo
+.Fl Fl allow-GET
+.Xc
+If given, then HTTP GET will be allowed for the various
+end-points other than
+.Ar /health .
+Otherwise only HEAD and POST will be allowed.
+By default GETs are allowed, but this will change soon.
+.It Xo
+.Fl Fl no-allow-GET
+.Xc
+If given then HTTP GETs will be rejected for the various
+end-points other than
+.Ar /health .
+.It Xo
+.Fl Fl csrf-protection-type= Ns Ar CSRF-PROTECTION-TYPE
+.Xc
+Possible values of
+.Ar CSRF-PROTECTION-TYPE
+are
+.Bl -bullet -compact -offset indent
+.It
+.Li GET-with-header
+.It
+.Li GET-with-token
+.It
+.Li POST-with-header
+.It
+.Li POST-with-token
+.El
+This may be given multiple times.
+The default is to require CSRF tokens for POST requests, and to
+require neither a non-simple header nor a CSRF token for GET
+requests.
+.Pp
+See
+.Sx CROSS-SITE REQUEST FORGERY PROTECTION .
+.It Xo
+.Fl Fl csrf-header= Ns Ar HEADER-NAME
+.Xc
+If given, then all requests other than to the
+.Ar /health
+service must have the given request
+.Ar HEADER-NAME
+set (the value is irrelevant).
+The
+.Ar HEADER-NAME
+must be a request header name such that a request having it makes
+it not a
+.Dq simple
+request (see the Cross-Origin Resource Sharing specification).
+Defaults to
+.Ar X-CSRF .
+.It Xo
+.Fl Fl csrf-key-file= Ns Ar FILE
+.Xc
+If given, this file must contain a 16 byte binary key for keying
+the HMAC used in CSRF token construction.
+.It Xo
 .Fl d ,
 .Fl Fl daemon
 .Xc
@@ -82,7 +157,8 @@ Detach from TTY and run in the background.
 .It Xo
 .Fl Fl reverse-proxied
 .Xc
-Serves HTTP instead of HTTPS, accepting only looped-back connections.
+Serves HTTP instead of HTTPS, accepting only looped-back
+connections.
 .It Xo
 .Fl p Ar port number (default: 443)
 .Xc
@@ -90,29 +166,106 @@ PORT
 .It Xo
 .Fl Fl cache-dir= Ns Ar DIRECTORY
 .Xc
-Directory for various caches.  If not specified then a temporary directory will
-be made.
+Directory for various caches.
+If not specified then a temporary directory will be made.
 .It Xo
 .Fl Fl cert= Ns Ar HX509-STORE
 .Xc
-Certificate file path (PEM) for HTTPS service.  May contain private key as
-well.
+Certificate file path (PEM) for HTTPS service.
+May contain private key as well.
 .It Xo
 .Fl Fl private-key= Ns Ar HX509-STORE
 .Xc
-Private key file path (PEM), if the private key is not stored along with the
-certificiate.
+Private key file path (PEM), if the private key is not stored
+along with the certificiate.
 .It Xo
 .Fl t ,
 .Fl Fl thread-per-client
 .Xc
-Uses a thread per-client instead of as many threads as there are CPUs.
+Uses a thread per-client instead of as many threads as there are
+CPUs.
 .It Xo
 .Fl v ,
 .Fl Fl verbose= Ns Ar run verbosely
 .Xc
 verbose
 .El
+.Sh HTTP APIS
+All HTTP APIs served by this program accept POSTs, with all
+request parameters given as URI query parameters and/or as
+form data in the POST request body, in either
+.Ar application/x-www-form-urlencoded
+or
+.Ar multipart/formdata .
+If request parameters are given both as URI query parameters
+and as POST forms, then they are merged into a set.
+.Pp
+If GETs are enabled, then request parameters must be supplied
+only as URI query parameters, as GET requests do not have request
+bodies.
+.Pp
+URI query parameters must be of the form
+.Ar param0=value&param1=value...
+.Pp
+Some request parameters can only have one value.
+If multiple values are given for such parameters, then either an
+error will be produced, or only the first URI query parameter
+value will be used, or the first POST form data parameter will be
+used.
+Other request parameters can have multiple values.
+See below.
+.Sh CROSS-SITE REQUEST FORGERY PROTECTION
+.Em None
+of the resources service by this service are intended to be
+executed by web pages.
+.Pp
+All the resources provided by this service are
+.Dq safe
+in the sense that they do not change server-side state besides
+logging, and in that they are idempotent, but they are
+only safe to execute
+.Em if and only if
+the requesting party is trusted to see the response.
+Since none of these resources are intended to be used from web
+pages, it is important that web pages not be able to execute them
+.Em and
+observe the responses.
+.Pp
+In a web browser context, pages from other origins will be able
+to attempt requests to this service, but should never be able to
+see the responses because browsers normally wouldn't allow that.
+Nonetheless, anti cross site request forgery (CSRF) protection
+may be desirable.
+.Pp
+This service provides the following CSRF protection features:
+.Bl -tag -width Ds -offset indent
+.It requests are rejected if they have a
+.Dq Referer
+(except the experimental /get-negotiate-token end-point)
+.It the service can be configured to require a header that would make the
+request not Dq simple
+.It GETs can be disabled (see options), thus requiring POSTs
+.It GETs can be required to have a CSRF token (see below)
+.It POSTs can be required to have a CSRF token
+.El
+.Pp
+The experimental
+.Ar /get-negotiate-token
+end-point, however, always accepts
+.Dq Referer
+requests.
+.Pp
+To obtain a CSRF token, first execute the request without the
+CSRF token, and the resulting error
+response will include a
+.Ar X-CSRF-Token
+response header.
+.Pp
+To execute a request with a CSRF token, first obtain a CSRF token
+as described above, then copy the token to the request as the
+value of the request's
+.Ar X-CSRF-Token
+header.
 .Sh ONLINE CERTIFICATION AUTHORITY HTTP API
 This service provides an HTTP-based Certification Authority (CA).
 CA credentials and configuration are specified in the
@@ -128,8 +281,8 @@ with the base-63 encoding of a DER encoding of a PKCS#10
 .Ar CertificationRequest
 (Certificate Signing Request, or CSR) in a
 .Ar csr
-required query parameter.
-In a successful query, the response body will contain a PEM
+required request parameter.
+In a successful request, the response body will contain a PEM
 encoded end entity certificate and certification chain.
 .Pp
 Or
@@ -146,9 +299,9 @@ Unauthorized requests will elicit a 403 response.
 .Pp
 Subject Alternative Names (SANs) and Extended Key Usage values
 may be requested, both in-band in the CSR as a requested
-extensions attribute, and/or via optional query parameters.
+extensions attribute, and/or via optional request parameters.
 .Pp
-Supported query parameters (separated by ampersands)
+Supported request parameters:
 .Bl -tag -width Ds -offset indent
 .It Li csr = Va base64-encoded-DER-encoded-CSR
 .It Li dNSName = Va hostname
@@ -178,20 +331,20 @@ of
 .Ar /get-negotiate-token
 with a
 .Ar target = Ar service@host
-query parameter.
+request parameter.
 .Pp
-In a successful query, the response body will contain a Negotiate
-token for the authenticated client principal to the requested
-target.
+In a successful request, the response body will contain a
+Negotiate token for the authenticated client principal to the
+requested target.
 .Pp
 Authentication is required.
 Unauthenticated requests will elicit a 401 response.
 .Pp
 Subject Alternative Names (SANs) and Extended Key Usage values
 may be requested, both in-band in the CSR as a requested
-extensions attribute, and/or via optional query parameters.
+extensions attribute, and/or via optional request parameters.
 .Pp
-Supported query parameters (separated by ampersands)
+Supported request parameters:
 .Bl -tag -width Ds -offset indent
 .It Li target = Va service@hostname
 .It Li redirect = Va URI
@@ -221,13 +374,14 @@ The protocol consists of a
 of
 .Ar /get-tgt .
 .Pp
-Supported query parameters (separated by ampersands)
+Supported request parameters:
 .Bl -tag -width Ds -offset indent
 .It Li cname = Va principal-name
 .It Li address = Va IP-address
+.It Li lifetime = Va relative-time
 .El
 .Pp
-In a successful query, the response body will contain a TGT and
+In a successful request, the response body will contain a TGT and
 its session key encoded as a "ccache" file contents.
 .Pp
 Authentication is required.
@@ -239,13 +393,14 @@ same as for
 by the authenticated client principal to get a certificate with
 a PKINIT SAN for itself or the requested principal if a
 .Va cname
-query parameter was included.
+request parameter was included.
 .Pp
 Unauthorized requests will elicit a 403 response.
 .Pp
-Requested IP addresses will be added to the issued TGT if allowed.
-The IP address of the client will be included if address-less TGTs
-are not allowed.
+Requested IP addresses will be added to the issued TGT if
+allowed.
+The IP address of the client will be included if address-less
+TGTs are not allowed.
 See the
 .Va [get-tgt]
 section of
@@ -257,6 +412,48 @@ end-point, but as configured in the
 .Va [get-tgt]
 section of
 .Xr krb5.conf 5 .
+.Sh BATCH TGT HTTP API
+Some sites may have special users that operate batch jobs systems
+and that can impersonate many others by obtaining TGTs for them,
+and which
+.Dq prestash
+credentials for those users in their credentials caches.
+To support these sytems, a
+.Ar GET
+of
+.Ar /get-tgts
+with multiple
+.Ar cname
+request parameters will return those principals' TGTs (if the
+caller is authorized).
+.Pp
+This is similar to the
+.Ar /get-tgt
+end-point, but a) multiple
+.Ar cname
+request parameter values may be given, and b) the caller's
+principal name is not used as a default for the
+.Ar cname
+request parameter.
+The
+.Ar address
+and
+.Ar lifetime
+request parameters are honored.
+.Pp
+For successful
+.Ar GETs
+the response body is a sequence of JSON texts each of which is a
+JSON object with two keys:
+.Bl -tag -width Ds -offset indent
+.It Ar ccache
+with a base64-encoded FILE-type ccache;
+.It Ar name
+the name of the principal whose credentials are in that ccache.
+.El
+.Sh NOTES
+A future release may split all these end-points into separate
+services.
 .Sh ENVIRONMENT
 .Bl -tag -width Ds
 .It Ev KRB5_CONFIG

--- a/kdc/httpkadmind.8
+++ b/kdc/httpkadmind.8
@@ -43,6 +43,10 @@
 .Op Fl Fl daemon-child
 .Op Fl Fl reverse-proxied
 .Op Fl p Ar port number (default: 443)
+.Op Fl Fl allow-GET
+.Op Fl Fl no-allow-GET
+.Op Fl Fl GET-with-csrf-token
+.Op Fl Fl csrf-header= Ns Ar HEADER-NAME
 .Op Fl Fl temp-dir= Ns Ar DIRECTORY
 .Op Fl Fl cert=HX509-STORE
 .Op Fl Fl private-key=HX509-STORE
@@ -64,7 +68,7 @@
 .Xc
 .Oc
 .Sh DESCRIPTION
-Serves the following resources:
+Serves the following resources over HTTP:
 .Ar /get-keys and
 .Ar /get-config .
 .Pp
@@ -75,6 +79,12 @@ end-point allows callers to get a principal's keys in
 format for named principals, possibly performing write operations
 such as creating a non-existent principal, or rotating its keys,
 if requested.
+Note that this end-point can cause KDC HDB principal entries to
+be modified or created incidental to fetching the principal's
+keys.
+The use of the HTTP POST method is required when this end-point
+writes to the KDC's HDB.
+See below.
 .Pp
 The
 .Ar /get-config
@@ -98,7 +108,87 @@ end-point accepts a single query parameter:
 .Bl -tag -width Ds -offset indent
 .It Ar princ=PRINCIPAL .
 .El
+.Sh HTTP APIS
+All HTTP APIs served by this program accept POSTs, with all
+request parameters given as either URI query parameters, and/or
+as form data in the POST request body, in either
+.Ar application/x-www-form-urlencoded
+or
+.Ar multipart/formdata .
+If GETs are enabled, then request parameters must be supplied as
+URI query parameters.
 .Pp
+Note that requests that cause changes to the HDB must always be
+done via POST, never GET.
+.Pp
+URI query parameters must be of the form
+.Ar param0=value&param1=value...
+Some parameters can be given multiple values -- see the
+descriptions of the end-points.
+.Sh CROSS-SITE REQUEST FORGERY PROTECTION
+.Em None
+of the resources service by this service are intended to be
+executed by web pages.
+.Pp
+Most of the resources provided by this service are
+.Dq safe
+in the sense that they do not change server-side state besides
+logging, and in that they are idempotent, but they are
+only safe to execute
+.Em if and only if
+the requesting party is trusted to see the response.
+Since none of these resources are intended to be used from web
+pages, it is important that web pages not be able to execute them
+.Em and
+observe the responses.
+.Pp
+Some of the resources provided by this service do change
+server-side state, specifically principal entries in the KDC's
+HDB.
+Those always require the use of POST, not GET.
+.Pp
+In a web browser context, pages from other origins will be able
+to attempt requests to this service, but should never be able to
+see the responses because browsers normally wouldn't allow that.
+Nonetheless, anti cross site request forgery (CSRF) protection
+may be desirable.
+.Pp
+This service provides the following CSRF protection features:
+.Bl -tag -width Ds -offset indent
+.It requests are rejected if they have a
+.Dq Referer
+(except the experimental /get-negotiate-token end-point)
+.It the service can be configured to require a header that would make the
+request not Dq simple
+.It GETs can be disabled (see options), thus requiring POSTs
+.It GETs can be required to have a CSRF token (see below)
+.It POSTs can be required to have a CSRF token
+.El
+.Pp
+The experimental
+.Ar /get-negotiate-token
+end-point, however, always accepts
+.Dq Referer
+requests.
+.Pp
+To obtain a CSRF token, first execute the request without the
+CSRF token, and the resulting error
+response will include a
+.Ar X-CSRF-Token
+response header.
+.Pp
+To execute a request with a CSRF token, first obtain a CSRF token
+as described above, then copy the token to the request as the
+value of the request's
+.Ar X-CSRF-Token
+header.
+.Pp
+The key for keying the CSRF token HMAC is that of the first
+current key for the
+.Sq WELLKNOWN/CSRFTOKEN
+principal for the realm being used.
+Every realm served by this service must have this principal.
+.Sh GETTING KEYTABS
 The
 .Ar /get-keys
 end-point accepts various parameters:
@@ -242,6 +332,51 @@ Serves HTTP instead of HTTPS, accepting only looped-back connections.
 .Fl p Ar port number (default: 443)
 .Xc
 PORT
+.It Xo
+.Fl Fl allow-GET
+.Xc
+If given, then HTTP GET will be allowed for the various end-points
+other than
+.Ar /health .
+Otherwise only HEAD and POST will be allowed.
+By default GETs are allowed, but this will change soon.
+.It Xo
+.Fl Fl no-allow-GET
+.Xc
+If given then HTTP GETs will be rejected for the various
+end-points other than
+.Ar /health .
+.It Xo
+.Fl Fl csrf-protection-type= Ns Ar CSRF-PROTECTION-TYPE
+.Xc
+Possible values of
+.Ar CSRF-PROTECTION-TYPE
+are
+.Bl -bullet -compact -offset indent
+.It
+.Li GET-with-header
+.It
+.Li GET-with-token
+.It
+.Li POST-with-header
+.It
+.Li POST-with-token
+.El
+This may be given multiple times.
+The default is to require CSRF tokens for POST requests, and to
+require neither a non-simple header nor a CSRF token for GET
+requests.
+.Pp
+See
+.Sx CROSS-SITE REQUEST FORGERY PROTECTION .
+.It Xo
+.Fl Fl csrf-header= Ns Ar HEADER-NAME
+.Xc
+If given, then all requests other than to the
+.Ar /health
+service must have the given request
+.Ar HEADER-NAME
+set (the value is irrelevant).
 .It Xo
 .Fl Fl temp-dir= Ns Ar DIRECTORY
 .Xc

--- a/kdc/httpkadmind.c
+++ b/kdc/httpkadmind.c
@@ -128,6 +128,12 @@ typedef enum MHD_Result heim_mhd_result;
  *        here.
  */
 
+struct free_tend_list {
+    void *freeme1;
+    void *freeme2;
+    struct free_tend_list *next;
+};
+
 /* Our request description structure */
 typedef struct kadmin_request_desc {
     HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS;
@@ -165,6 +171,8 @@ typedef struct kadmin_request_desc {
      * be damned.
      */
     hx509_request req;          /* For authz only */
+    struct free_tend_list *free_list;
+    struct MHD_PostProcessor *pp;
     heim_array_t service_names;
     heim_array_t hostnames;
     heim_array_t spns;
@@ -176,8 +184,11 @@ typedef struct kadmin_request_desc {
     char *keytab_name;
     char *freeme1;
     char *enctypes;
+    char *cache_control;
+    char *csrf_token;
     const char *method;
     krb5_timestamp pw_end;
+    size_t post_data_size;
     unsigned int response_set:1;
     unsigned int materialize:1;
     unsigned int rotate_now:1;
@@ -306,8 +317,18 @@ get_krb5_context(krb5_context *contextp)
     return ret;
 }
 
+typedef enum {
+    CSRF_PROT_UNSPEC            = 0,
+    CSRF_PROT_GET_WITH_HEADER   = 1,
+    CSRF_PROT_GET_WITH_TOKEN    = 2,
+    CSRF_PROT_POST_WITH_HEADER  = 8,
+    CSRF_PROT_POST_WITH_TOKEN   = 16,
+} csrf_protection_type;
+
+static csrf_protection_type csrf_prot_type = CSRF_PROT_UNSPEC;
 static int port = -1;
 static int help_flag;
+static int allow_GET_flag = -1;
 static int daemonize;
 static int daemon_child_fd = -1;
 static int local_hdb;
@@ -318,6 +339,8 @@ static int version_flag;
 static int reverse_proxied_flag;
 static int thread_per_client_flag;
 struct getarg_strings audiences;
+static getarg_strings csrf_prot_type_strs;
+static const char *csrf_header = "X-CSRF";
 static const char *cert_file;
 static const char *priv_key_file;
 static const char *cache_dir;
@@ -426,7 +449,7 @@ out:
 
 static krb5_error_code resp(kadmin_request_desc, int, krb5_error_code,
                             enum MHD_ResponseMemoryMode, const char *,
-                            const void *, size_t, const char *, const char *);
+                            const void *, size_t, const char *);
 static krb5_error_code bad_req(kadmin_request_desc, krb5_error_code, int,
                                const char *, ...)
                                HEIMDAL_PRINTF_ATTRIBUTE((__printf__, 4, 5));
@@ -435,7 +458,7 @@ static krb5_error_code bad_enomem(kadmin_request_desc, krb5_error_code);
 static krb5_error_code bad_400(kadmin_request_desc, krb5_error_code, const char *);
 static krb5_error_code bad_401(kadmin_request_desc, const char *);
 static krb5_error_code bad_403(kadmin_request_desc, krb5_error_code, const char *);
-static krb5_error_code bad_404(kadmin_request_desc, const char *);
+static krb5_error_code bad_404(kadmin_request_desc, krb5_error_code, const char *);
 static krb5_error_code bad_405(kadmin_request_desc, const char *);
 /*static krb5_error_code bad_500(kadmin_request_desc, krb5_error_code, const char *);*/
 static krb5_error_code bad_503(kadmin_request_desc, krb5_error_code, const char *);
@@ -636,8 +659,7 @@ resp(kadmin_request_desc r,
      const char *content_type,
      const void *body,
      size_t bodylen,
-     const char *token,
-     const char *csrf)
+     const char *token)
 {
     struct MHD_Response *response;
     int mret = MHD_YES;
@@ -660,16 +682,15 @@ resp(kadmin_request_desc r,
         return -1;
     mret = MHD_add_response_header(response, MHD_HTTP_HEADER_AGE, "0");
     if (mret == MHD_YES && http_status_code == MHD_HTTP_OK) {
-        static HEIMDAL_THREAD_LOCAL char *cache_control = NULL;
         krb5_timestamp now;
 
-        free(cache_control);
-        cache_control = NULL;
+        free(r->cache_control);
+        r->cache_control = NULL;
         krb5_timeofday(r->context, &now);
         if (r->pw_end && r->pw_end > now) {
-            if (asprintf(&cache_control, "no-store, max-age=%lld",
+            if (asprintf(&r->cache_control, "no-store, max-age=%lld",
                          (long long)r->pw_end - now) == -1 ||
-                cache_control == NULL)
+                r->cache_control == NULL)
                 /* Soft handling of ENOMEM here */
                 mret = MHD_add_response_header(response,
                                                MHD_HTTP_HEADER_CACHE_CONTROL,
@@ -677,7 +698,7 @@ resp(kadmin_request_desc r,
             else
                 mret = MHD_add_response_header(response,
                                                MHD_HTTP_HEADER_CACHE_CONTROL,
-                                               cache_control);
+                                               r->cache_control);
 
         } else
             mret = MHD_add_response_header(response,
@@ -709,10 +730,10 @@ resp(kadmin_request_desc r,
             http_status_code = MHD_HTTP_SERVICE_UNAVAILABLE;
     }
 
-    if (mret == MHD_YES && csrf)
+    if (mret == MHD_YES && r->csrf_token)
         mret = MHD_add_response_header(response,
                                        "X-CSRF-Token",
-                                       csrf);
+                                       r->csrf_token);
 
     if (mret == MHD_YES && content_type) {
         mret = MHD_add_response_header(response,
@@ -751,7 +772,7 @@ bad_reqv(kadmin_request_desc r,
         if (context)
             krb5_log_msg(context, logfac, 1, NULL, "Out of memory");
         return resp(r, http_status_code, code, MHD_RESPMEM_PERSISTENT,
-                    NULL, fmt, BODYLEN_IS_STRLEN, NULL, NULL);
+                    NULL, fmt, BODYLEN_IS_STRLEN, NULL);
     }
 
     if (code) {
@@ -778,11 +799,11 @@ bad_reqv(kadmin_request_desc r,
             krb5_log_msg(context, logfac, 1, NULL, "Out of memory");
         return resp(r, MHD_HTTP_SERVICE_UNAVAILABLE, ENOMEM,
                     MHD_RESPMEM_PERSISTENT, NULL,
-                    "Out of memory", BODYLEN_IS_STRLEN, NULL, NULL);
+                    "Out of memory", BODYLEN_IS_STRLEN, NULL);
     }
 
     ret = resp(r, http_status_code, code, MHD_RESPMEM_MUST_COPY,
-               NULL, msg, BODYLEN_IS_STRLEN, NULL, NULL);
+               NULL, msg, BODYLEN_IS_STRLEN, NULL);
     free(formatted);
     free(msg);
     return ret == -1 ? -1 : code;
@@ -830,9 +851,9 @@ bad_403(kadmin_request_desc r, krb5_error_code ret, const char *reason)
 }
 
 static krb5_error_code
-bad_404(kadmin_request_desc r, const char *name)
+bad_404(kadmin_request_desc r, krb5_error_code ret, const char *name)
 {
-    return bad_req(r, ENOENT, MHD_HTTP_NOT_FOUND,
+    return bad_req(r, ret, MHD_HTTP_NOT_FOUND,
                    "Resource not found: %s", name);
 }
 
@@ -841,6 +862,13 @@ bad_405(kadmin_request_desc r, const char *method)
 {
     return bad_req(r, EPERM, MHD_HTTP_METHOD_NOT_ALLOWED,
                    "Method not supported: %s", method);
+}
+
+static krb5_error_code
+bad_413(kadmin_request_desc r)
+{
+    return bad_req(r, E2BIG, MHD_HTTP_METHOD_NOT_ALLOWED,
+                   "POST request body too large");
 }
 
 static krb5_error_code
@@ -888,7 +916,7 @@ good_ext_keytab(kadmin_request_desc r)
         return bad_503(r, ret, "Could not recover keytab from temp file");
 
     ret = resp(r, MHD_HTTP_OK, 0, MHD_RESPMEM_MUST_COPY,
-               "application/octet-stream", body, bodylen, NULL, NULL);
+               "application/octet-stream", body, bodylen, NULL);
     free(body);
     return ret;
 }
@@ -1543,7 +1571,7 @@ static krb5_error_code check_csrf(kadmin_request_desc);
  * When this returns a response will have been set.
  */
 static krb5_error_code
-get_keysN(kadmin_request_desc r, const char *method)
+get_keysN(kadmin_request_desc r)
 {
     krb5_error_code ret;
     size_t nhosts;
@@ -1556,11 +1584,17 @@ get_keysN(kadmin_request_desc r, const char *method)
     if (ret)
         return ret; /* authorize_req() calls bad_req() on error */
 
+    /*
+     * If we have a r->kadm_handle already it's because we validated a CSRF
+     * token.  It may not be a handle to a realm we wanted though.
+     */
+    if (r->kadm_handle)
+        kadm5_destroy(r->kadm_handle);
+    r->kadm_handle = NULL;
     ret = get_kadm_handle(r->context, r->realm ? r->realm : realm,
                           0 /* want_write */, &r->kadm_handle);
-
-    if (strcmp(method, "POST") == 0 && (ret = check_csrf(r)))
-        return ret; /* check_csrf() calls bad_req() on error */
+    if (ret)
+        return bad_404(r, ret, "Could not connect to realm");
 
     nhosts = heim_array_get_length(r->hostnames);
     nsvcs = heim_array_get_length(r->service_names);
@@ -1631,7 +1665,7 @@ get_keysN(kadmin_request_desc r, const char *method)
             krb5_log_msg(r->context, logfac, 1, NULL,
                          "Redirect %s to primary server", r->cname);
             return resp(r, MHD_HTTP_TEMPORARY_REDIRECT, KADM5_READ_ONLY,
-                        MHD_RESPMEM_PERSISTENT, NULL, "", 0, NULL, NULL);
+                        MHD_RESPMEM_PERSISTENT, NULL, "", 0, NULL);
         } else {
             krb5_log_msg(r->context, logfac, 1, NULL, "HDB is read-only");
             return bad_403(r, ret, "HDB is read-only");
@@ -1664,25 +1698,33 @@ addr_to_string(krb5_context context,
         snprintf(str, len, "<family=%d>", addr->sa_family);
 }
 
+static void clean_req_desc(kadmin_request_desc);
+
 static krb5_error_code
 set_req_desc(struct MHD_Connection *connection,
              const char *method,
              const char *url,
-             kadmin_request_desc r)
+             kadmin_request_desc *rp)
 {
     const union MHD_ConnectionInfo *ci;
+    kadmin_request_desc r;
     const char *token;
     krb5_error_code ret;
 
-    memset(r, 0, sizeof(*r));
-    (void) gettimeofday(&r->tv_start, NULL);
+    *rp = NULL;
+    if ((r = calloc(1, sizeof(*r))) == NULL)
+        return ENOMEM;
 
-    if ((ret = get_krb5_context(&r->context)))
+    (void) gettimeofday(&r->tv_start, NULL);
+    if ((ret = get_krb5_context(&r->context))) {
+        free(r);
         return ret;
+    }
     /* HEIM_SVC_REQUEST_DESC_COMMON_ELEMENTS fields */
     r->request.data = "<HTTP-REQUEST>";
     r->request.length = sizeof("<HTTP-REQUEST>");
     r->from = r->frombuf;
+    r->free_list = NULL;
     r->config = NULL;
     r->logf = logfac;
     r->reqtype = url;
@@ -1692,6 +1734,7 @@ set_req_desc(struct MHD_Connection *connection,
     r->cname = NULL;
     r->addr = NULL;
     r->kv = heim_dict_create(10);
+    r->pp = NULL;
     r->attributes = heim_dict_create(1);
     /* Our fields */
     r->connection = connection;
@@ -1702,6 +1745,7 @@ set_req_desc(struct MHD_Connection *connection,
     r->spns = heim_array_create();
     r->keytab_name = NULL;
     r->enctypes = NULL;
+    r->cache_control = NULL;
     r->freeme1 = NULL;
     r->method = method;
     r->cprinc = NULL;
@@ -1736,6 +1780,10 @@ set_req_desc(struct MHD_Connection *connection,
         krb5_log_msg(r->context, logfac, 1, NULL, "Out of memory");
         ret = r->error_code = ENOMEM;
     }
+    if (ret == 0)
+        *rp = r;
+    else
+        clean_req_desc(r);
     return ret;
 }
 
@@ -1751,32 +1799,49 @@ clean_req_desc(kadmin_request_desc r)
         (void) unlink(strchr(r->keytab_name, ':') + 1);
     if (r->kadm_handle)
         kadm5_destroy(r->kadm_handle);
+    if (r->pp)
+        MHD_destroy_post_processor(r->pp);
     hx509_request_free(&r->req);
     heim_release(r->service_names);
+    heim_release(r->attributes);
     heim_release(r->hostnames);
     heim_release(r->reason);
     heim_release(r->spns);
     heim_release(r->kv);
     krb5_free_principal(r->context, r->cprinc);
+    free(r->cache_control);
     free(r->keytab_name);
+    free(r->csrf_token);
     free(r->enctypes);
     free(r->freeme1);
     free(r->cname);
     free(r->sname);
+    free(r->realm);
+    free(r);
+}
+
+static void
+cleanup_req(void *cls,
+            struct MHD_Connection *connection,
+            void **con_cls,
+            enum MHD_RequestTerminationCode toe)
+{
+    kadmin_request_desc r = *con_cls;
+
+    (void)cls;
+    (void)connection;
+    (void)toe;
+    clean_req_desc(r);
+    *con_cls = NULL;
 }
 
 /* Implements GETs of /get-keys */
 static krb5_error_code
-get_keys(kadmin_request_desc r, const char *method)
+get_keys(kadmin_request_desc r)
 {
-    krb5_error_code ret;
-
-    if ((ret = validate_token(r)))
-        return ret; /* validate_token() calls bad_req() */
     if (r->cname == NULL || r->cprinc == NULL)
-        return bad_403(r, EINVAL,
-                       "Could not extract principal name from token");
-    return get_keysN(r, method); /* Sets an HTTP response */
+        return bad_401(r, "Could not extract principal name from token");
+    return get_keysN(r); /* Sets an HTTP response */
 }
 
 /* Implements GETs of /get-config */
@@ -1795,11 +1860,8 @@ get_config(kadmin_request_desc r)
     void *body = "include /etc/krb5.conf\n";
     int freeit = 0;
 
-    if ((ret = validate_token(r)))
-        return ret; /* validate_token() calls bad_req() */
     if (r->cname == NULL || r->cprinc == NULL)
-        return bad_403(r, EINVAL,
-                       "Could not extract principal name from token");
+        return bad_401(r, "Could not extract principal name from token");
     /*
      * No authorization needed -- configs are public.  Though we do require
      * authentication (above).
@@ -1832,7 +1894,7 @@ get_config(kadmin_request_desc r)
             }
         } else {
             r->error_code = ret;
-            return bad_404(r, "/get-config");
+            return bad_404(r, ret, "/get-config");
         }
     }
 
@@ -1840,7 +1902,7 @@ get_config(kadmin_request_desc r)
         krb5_log_msg(r->context, logfac, 1, NULL,
                      "Returned krb5.conf contents to %s", r->cname);
         ret = resp(r, MHD_HTTP_OK, 0, MHD_RESPMEM_MUST_COPY,
-                   "application/text", body, bodylen, NULL, NULL);
+                   "application/text", body, bodylen, NULL);
     } else {
         ret = bad_503(r, ret, "Could not retrieve principal configuration");
     }
@@ -1866,7 +1928,9 @@ mac_csrf_token(kadmin_request_desc r, krb5_storage *sp)
     memset(&princ, 0, sizeof(princ));
     ret = krb5_storage_to_data(sp, &data);
     if (r->kadm_handle == NULL)
-        ret = get_kadm_handle(r->context, r->realm, 0 /* want_write */,
+        ret = get_kadm_handle(r->context,
+                              r->realm ? r->realm : realm,
+                              0 /* want_write */,
                               &r->kadm_handle);
     if (ret == 0)
         ret = krb5_make_principal(r->context, &p,
@@ -1922,7 +1986,6 @@ make_csrf_token(kadmin_request_desc r,
                 char **token,
                 int64_t *age)
 {
-    static HEIMDAL_THREAD_LOCAL char tokenbuf[128]; /* See below, be sad */
     krb5_error_code ret = 0;
     unsigned char given_decoded[128];
     krb5_storage *sp = NULL;
@@ -1973,17 +2036,6 @@ make_csrf_token(kadmin_request_desc r,
     if (ret == 0 &&
         (dlen = rk_base64_encode(data.data, data.length, token)) < 0)
         ret = errno;
-    if (ret == 0 && dlen >= sizeof(tokenbuf))
-        ret = ERANGE;
-    if (ret == 0) {
-        /*
-         * Work around for older versions of libmicrohttpd do not strdup()ing
-         * response header values.
-         */
-        memcpy(tokenbuf, *token, dlen);
-        free(*token);
-        *token = tokenbuf;
-    }
     krb5_storage_free(sp);
     krb5_data_free(&data);
     return ret;
@@ -2000,11 +2052,28 @@ check_csrf(kadmin_request_desc r)
     const char *given;
     int64_t age;
     size_t givenlen, expectedlen;
-    char *expected = NULL;
+
+    if ((((csrf_prot_type & CSRF_PROT_GET_WITH_HEADER) &&
+          strcmp(r->method, "GET") == 0) ||
+         ((csrf_prot_type & CSRF_PROT_POST_WITH_HEADER) &&
+          strcmp(r->method, "POST") == 0)) &&
+        MHD_lookup_connection_value(r->connection, MHD_HEADER_KIND,
+                                    csrf_header) == NULL) {
+        ret = bad_req(r, EACCES, MHD_HTTP_FORBIDDEN,
+                      "Request must have header \"%s\"", csrf_header);
+        return ret == -1 ? MHD_NO : MHD_YES;
+    }
+
+    if (strcmp(r->method, "GET") == 0 &&
+        !(csrf_prot_type & CSRF_PROT_GET_WITH_TOKEN))
+        return 0;
+    if (strcmp(r->method, "POST") == 0 &&
+        !(csrf_prot_type & CSRF_PROT_POST_WITH_TOKEN))
+        return 0;
 
     given = MHD_lookup_connection_value(r->connection, MHD_HEADER_KIND,
                                         "X-CSRF-Token");
-    ret = make_csrf_token(r, given, &expected, &age);
+    ret = make_csrf_token(r, given, &r->csrf_token, &age);
     if (ret)
         return bad_503(r, ret, "Could not create a CSRF token");
     /*
@@ -2014,15 +2083,14 @@ check_csrf(kadmin_request_desc r)
     if (given == NULL) {
         (void) resp(r, MHD_HTTP_FORBIDDEN, ENOSYS, MHD_RESPMEM_PERSISTENT,
                     NULL, "CSRF token needed; copy the X-CSRF-Token: response "
-                    "header to your next POST", BODYLEN_IS_STRLEN, NULL,
-                    expected);
+                    "header to your next POST", BODYLEN_IS_STRLEN, NULL);
         return ENOSYS;
     }
 
     /* Validate the CSRF token for this request */
     givenlen = strlen(given);
-    expectedlen = strlen(expected);
-    if (givenlen != expectedlen || ct_memcmp(given, expected, givenlen)) {
+    expectedlen = strlen(r->csrf_token);
+    if (givenlen != expectedlen || ct_memcmp(given, r->csrf_token, givenlen)) {
         (void) bad_403(r, EACCES, "Invalid CSRF token");
         return EACCES;
     }
@@ -2038,15 +2106,60 @@ health(const char *method, kadmin_request_desc r)
 {
     if (strcmp(method, "HEAD") == 0) {
         return resp(r, MHD_HTTP_OK, 0, MHD_RESPMEM_PERSISTENT, NULL, "", 0,
-                    NULL, NULL);
+                    NULL);
     }
     return resp(r, MHD_HTTP_OK, 0, MHD_RESPMEM_PERSISTENT, NULL,
                 "To determine the health of the service, use the /get-config "
-                "end-point.\n", BODYLEN_IS_STRLEN, NULL, NULL);
+                "end-point.\n", BODYLEN_IS_STRLEN, NULL);
 
 }
 
-/* Implements the entirety of this REST service */
+static heim_mhd_result
+ip(void *cls,
+   enum MHD_ValueKind kind,
+   const char *key,
+   const char *content_name,
+   const char *content_type,
+   const char *transfer_encoding,
+   const char *val,
+   uint64_t off,
+   size_t size)
+{
+    kadmin_request_desc r = cls;
+    struct free_tend_list *ftl = calloc(1, sizeof(*ftl));
+    char *keydup = strdup(key);
+    char *valdup = strndup(val, size);
+
+    (void)content_name;         /* MIME attachment name */
+    (void)content_type;
+    (void)transfer_encoding;
+    (void)off;                  /* Offset in POST data */
+
+    /* We're going to MHD_set_connection_value(), but we need copies */
+    if (ftl == NULL || keydup == NULL || valdup == NULL) {
+        free(ftl);
+        free(keydup);
+        return MHD_NO;
+    }
+    ftl->freeme1 = keydup;
+    ftl->freeme2 = valdup;
+    ftl->next = r->free_list;
+    r->free_list = ftl;
+
+    return MHD_set_connection_value(r->connection, MHD_GET_ARGUMENT_KIND,
+                                    keydup, valdup);
+}
+
+typedef krb5_error_code (*handler)(struct kadmin_request_desc *);
+
+struct route {
+    const char *local_part;
+    handler h;
+} routes[] = {
+    { "/get-keys", get_keys },
+    { "/get-config", get_config },
+};
+
 static heim_mhd_result
 route(void *cls,
       struct MHD_Connection *connection,
@@ -2057,50 +2170,131 @@ route(void *cls,
       size_t *upload_data_size,
       void **ctx)
 {
-    static int aptr = 0;
-    struct kadmin_request_desc r;
+    struct kadmin_request_desc *r = *ctx;
+    size_t i;
     int ret;
 
-    if (*ctx == NULL) {
+    if (r == NULL) {
         /*
          * This is the first call, right after headers were read.
          *
          * We must return quickly so that any 100-Continue might be sent with
-         * celerity.
+         * celerity.  We want to make sure to send any 401s early, so we check
+         * WWW-Authenticate now, not later.
          *
-         * We'll get called again to really do the processing.  If we handled
-         * POSTs then we'd also get called with upload_data != NULL between the
-         * first and last calls.  We need to keep no state between the first
-         * and last calls, but we do need to distinguish first and last call,
-         * so we use the ctx argument for this.
+         * We'll get called again to really do the processing.  If we're
+         * handling a POST then we'll also get called with upload_data != NULL,
+         * possibly multiple times.
          */
-        *ctx = &aptr;
+        if ((ret = set_req_desc(connection, method, url, &r))) {
+            return
+                bad_503(r, ret, "Could not initialize request state") == -1
+                    ? MHD_NO : MHD_YES;
+        }
+        *ctx = r;
+
+        /*
+         * All requests other than /health require authentication and CSRF
+         * protection.
+         */
+        if (strcmp(url, "/health") == 0)
+            return MHD_YES;
+
+        /* Authenticate and do CSRF protection */
+        ret = validate_token(r);
+        if (ret == 0)
+            ret = check_csrf(r);
+
+        /*
+         * As this is the initial call to this handler, we must return now.
+         *
+         * If authentication or CSRF protection failed then we'll already have
+         * enqueued a 401, 403, or 5xx response and then we're done.
+         *
+         * If both authentication and CSRF protection succeeded then no
+         * response has been queued up and we'll get called again to finally
+         * process the request, then this entire if block will not be executed.
+         */
+        return ret == -1 ? MHD_NO : MHD_YES;
+    }
+
+    /* Validate HTTP method */
+    if (strcmp(method, "GET") != 0 &&
+        strcmp(method, "POST") != 0 &&
+        strcmp(method, "HEAD") != 0) {
+        return bad_405(r, method) == -1 ? MHD_NO : MHD_YES;
+    }
+
+    if ((strcmp(method, "HEAD") == 0 || strcmp(method, "GET") == 0) &&
+        (strcmp(url, "/health") == 0 || strcmp(url, "/") == 0)) {
+        /* /health end-point -- no authentication, no CSRF, no nothing */
+        return health(method, r) == -1 ? MHD_NO : MHD_YES;
+    }
+
+    if (strcmp(method, "POST") == 0 && *upload_data_size != 0) {
+        /*
+         * Consume all the POST body and set form data as MHD_GET_ARGUMENT_KIND
+         * (as if they had been URI query parameters).
+         *
+         * We have to do this before we can MHD_queue_response() as MHD will
+         * not consume the rest of the request body on its own, so it's an
+         * error to MHD_queue_response() before we've done this, and if we do
+         * then MHD just closes the connection.
+         *
+         * 4KB should be more than enough buffer space for all the keys we
+         * expect.
+         */
+        if (r->pp == NULL)
+            r->pp = MHD_create_post_processor(connection, 4096, ip, r);
+        if (r->pp == NULL) {
+            ret = bad_503(r, errno ? errno : ENOMEM,
+                          "Could not consume POST data");
+            return ret == -1 ? MHD_NO : MHD_YES;
+        }
+        if (r->post_data_size + *upload_data_size > 1UL<<17) {
+            return bad_413(r) == -1 ? MHD_NO : MHD_YES;
+        }
+        r->post_data_size += *upload_data_size;
+        if (MHD_post_process(r->pp, upload_data,
+                             *upload_data_size) == MHD_NO) {
+            ret = bad_503(r, errno ? errno : ENOMEM,
+                          "Could not consume POST data");
+            return ret == -1 ? MHD_NO : MHD_YES;
+        }
+        *upload_data_size = 0;
         return MHD_YES;
     }
 
     /*
-     * Note that because we attempt to connect to the HDB in set_req_desc(),
-     * this early 503 if we fail to serves to do all of what /health should do.
+     * Either this is a HEAD, a GET, or a POST whose request body has now been
+     * received completely and processed.
      */
-    if ((ret = set_req_desc(connection, method, url, &r)))
-        return bad_503(&r, ret, "Could not initialize request state");
-    if ((strcmp(method, "HEAD") == 0 || strcmp(method, "GET") == 0) &&
-        (strcmp(url, "/health") == 0 || strcmp(url, "/") == 0)) {
-        ret = health(method, &r);
-    } else if (strcmp(method, "GET") != 0 && strcmp(method, "POST") != 0) {
-        ret = bad_405(&r, method);
-    } else if (strcmp(url, "/get-keys") == 0) {
-        ret = get_keys(&r, method);
-    } else if (strcmp(url, "/get-config") == 0) {
-        if (strcmp(method, "GET") != 0)
-            ret = bad_405(&r, method);
-        else
-            ret = get_config(&r);
-    } else {
-        ret = bad_404(&r, url);
+
+    /* Allow GET? */
+    if (strcmp(method, "GET") == 0 && !allow_GET_flag) {
+        /* No */
+        return bad_405(r, method) == -1 ? MHD_NO : MHD_YES;
     }
 
-    clean_req_desc(&r);
+    for (i = 0; i < sizeof(routes)/sizeof(routes[0]); i++) {
+        if (strcmp(url, routes[i].local_part) != 0)
+            continue;
+        if (MHD_lookup_connection_value(r->connection,
+                                        MHD_HEADER_KIND,
+                                        "Referer") != NULL) {
+            ret = bad_req(r, EACCES, MHD_HTTP_FORBIDDEN,
+                          "GET from browser not allowed");
+            return ret == -1 ? MHD_NO : MHD_YES;
+        }
+        if (strcmp(method, "HEAD") == 0)
+            ret = resp(r, MHD_HTTP_OK, 0, MHD_RESPMEM_PERSISTENT, NULL, "", 0,
+                       NULL);
+        else
+            ret = routes[i].h(r);
+        return ret == -1 ? MHD_NO : MHD_YES;
+    }
+
+    ret = bad_404(r, ENOENT, url);
     return ret == -1 ? MHD_NO : MHD_YES;
 }
 
@@ -2109,6 +2303,10 @@ static struct getargs args[] = {
     { "version", '\0', arg_flag, &version_flag, "Print version", NULL },
     { NULL, 'H', arg_strings, &audiences,
         "expected token audience(s) of the service", "HOSTNAME" },
+    { "allow-GET", 0, arg_negative_flag,
+        &allow_GET_flag, NULL, NULL },
+    { "csrf-header", 0, arg_string, &csrf_header,
+        "required request header", "HEADER-NAME" },
     { "daemon", 'd', arg_flag, &daemonize, "daemonize", "daemonize" },
     { "daemon-child", 0, arg_flag, &daemon_child_fd, NULL, NULL }, /* priv */
     { "reverse-proxied", 0, arg_flag, &reverse_proxied_flag,
@@ -2222,6 +2420,67 @@ load_plugins(krb5_context context)
 #endif
 }
 
+static void
+get_csrf_prot_type(krb5_context context)
+{
+    char * const *strs = csrf_prot_type_strs.strings;
+    size_t n = csrf_prot_type_strs.num_strings;
+    size_t i;
+    char **freeme = NULL;
+
+    if (csrf_header == NULL)
+        csrf_header = krb5_config_get_string(context, NULL, "bx509d",
+                                             "csrf_protection_csrf_header",
+                                             NULL);
+
+    if (n == 0) {
+        char * const *p;
+
+        strs = freeme = krb5_config_get_strings(context, NULL, "bx509d",
+                                                "csrf_protection_type", NULL);
+        for (p = strs; p && p; p++)
+            n++;
+    }
+
+    for (i = 0; i < n; i++) {
+        if (strcmp(strs[i], "GET-with-header") == 0)
+            csrf_prot_type |= CSRF_PROT_GET_WITH_HEADER;
+        else if (strcmp(strs[i], "GET-with-token") == 0)
+            csrf_prot_type |= CSRF_PROT_GET_WITH_TOKEN;
+        else if (strcmp(strs[i], "POST-with-header") == 0)
+            csrf_prot_type |= CSRF_PROT_POST_WITH_HEADER;
+        else if (strcmp(strs[i], "POST-with-token") == 0)
+            csrf_prot_type |= CSRF_PROT_POST_WITH_TOKEN;
+    }
+    free(freeme);
+
+    /*
+     * For GETs we default to no CSRF protection as our GETable resources are
+     * safe and idempotent and we count on the browser not to make the
+     * responses available to cross-site requests.
+     *
+     * But, really, we don't want browsers even making these requests since, if
+     * the browsers behave correctly, then there's no point, and if they don't
+     * behave correctly then that could be catastrophic.  Of course, there's no
+     * guarantee that a browser won't have other catastrophic bugs, but still,
+     * we should probably change this default in the future:
+     *
+     *  if (!(csrf_prot_type & CSRF_PROT_GET_WITH_HEADER) &&
+     *      !(csrf_prot_type & CSRF_PROT_GET_WITH_TOKEN))
+     *      csrf_prot_type |= <whatever-the-new-default-should-be>;
+     */
+
+    /*
+     * For POSTs we default to CSRF protection with anti-CSRF tokens even
+     * though out POSTable resources are safe and idempotent when POSTed and we
+     * could count on the browser not to make the responses available to
+     * cross-site requests.
+     */
+    if (!(csrf_prot_type & CSRF_PROT_POST_WITH_HEADER) &&
+        !(csrf_prot_type & CSRF_PROT_POST_WITH_TOKEN))
+        csrf_prot_type |= CSRF_PROT_POST_WITH_TOKEN;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -2282,6 +2541,8 @@ main(int argc, char **argv)
     if ((errno = get_krb5_context(&context)))
         err(1, "Could not init krb5 context (config file issue?)");
 
+    get_csrf_prot_type(context);
+
     if (!realm) {
         char *s;
 
@@ -2295,6 +2556,7 @@ main(int argc, char **argv)
                                  &kadm_handle)))
         err(1, "Could not connect to HDB");
     kadm5_destroy(kadm_handle);
+    kadm_handle = NULL;
 
     my_openlog(context, "httpkadmind", &logfac);
     load_plugins(context);
@@ -2419,11 +2681,18 @@ again:
         sin.sin_family = AF_INET;
         sin.sin_port = htons(port);
         current = MHD_start_daemon(flags, port,
+                                   /*
+                                    * This is a connection access callback.  We
+                                    * don't use it.
+                                    */
                                    NULL, NULL,
+                                   /* This is our request handler */
                                    route, (char *)NULL,
                                    MHD_OPTION_SOCK_ADDR, &sin,
                                    MHD_OPTION_CONNECTION_LIMIT, (unsigned int)200,
                                    MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int)10,
+                                   /* This is our request cleanup handler */
+                                   MHD_OPTION_NOTIFY_COMPLETED, cleanup_req, NULL,
                                    MHD_OPTION_END);
     } else if (sock != MHD_INVALID_SOCKET) {
         /*
@@ -2438,6 +2707,7 @@ again:
                                    MHD_OPTION_CONNECTION_LIMIT, (unsigned int)200,
                                    MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int)10,
                                    MHD_OPTION_LISTEN_SOCKET, sock,
+                                   MHD_OPTION_NOTIFY_COMPLETED, cleanup_req, NULL,
                                    MHD_OPTION_END);
         sock = MHD_INVALID_SOCKET;
     } else {
@@ -2448,6 +2718,7 @@ again:
                                    MHD_OPTION_HTTPS_MEM_CERT, cert_pem,
                                    MHD_OPTION_CONNECTION_LIMIT, (unsigned int)200,
                                    MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int)10,
+                                   MHD_OPTION_NOTIFY_COMPLETED, cleanup_req, NULL,
                                    MHD_OPTION_END);
     }
     if (current == NULL)

--- a/kuser/Makefile.am
+++ b/kuser/Makefile.am
@@ -47,6 +47,7 @@ heimtools_LDADD = \
 	$(top_builddir)/lib/sl/libsl.la \
 	$(kinit_LDADD) \
 	$(LIB_readline) \
+        $(LIB_heimbase) \
 	$(LIB_hx509)
 
 dist_heimtools_SOURCES = heimtools.c klist.c kx509.c kswitch.c copy_cred_cache.c

--- a/kuser/klist.c
+++ b/kuser/klist.c
@@ -38,7 +38,7 @@
 #include "heimtools-commands.h"
 #undef HC_DEPRECATED_CRYPTO
 
-static char*
+static const char *
 printable_time_internal(time_t t, int x)
 {
     static char s[128];
@@ -52,13 +52,13 @@ printable_time_internal(time_t t, int x)
     return s;
 }
 
-static char*
+static const char *
 printable_time(time_t t)
 {
     return printable_time_internal(t, 20);
 }
 
-static char*
+static const char *
 printable_time_long(time_t t)
 {
     return printable_time_internal(t, 20);
@@ -136,17 +136,172 @@ print_cred(krb5_context context, krb5_creds *cred, rtbl_t ct, int do_flags)
 }
 
 static void
-print_cred_verbose(krb5_context context, krb5_creds *cred, int do_json)
+cred2json(krb5_context context, krb5_creds *cred, heim_array_t tix)
+{
+    heim_dict_t t = heim_dict_create(10); /* ticket top-level */
+    heim_dict_t e = heim_dict_create(10); /* ticket times */
+    heim_dict_t f = heim_dict_create(20); /* flags */
+    heim_object_t o;
+    char buf[16], *sp = buf;
+    char *str;
+    krb5_error_code ret;
+    krb5_timestamp sec;
+
+    heim_array_append_value(tix, t);
+    krb5_timeofday(context, &sec);
+
+    /*
+     * JSON object names (keys) that start with capitals are for compatibility
+     * with the JSON we used to output.  The others are new.
+     */
+    heim_dict_set_value(t, HSTR("times"), e);
+    heim_dict_set_value(t, HSTR("flags"), f);
+
+    heim_dict_set_value(e, HSTR("authtime"),
+                        o = heim_number_create(cred->times.authtime));
+    heim_release(o);
+    heim_dict_set_value(t, HSTR("Issued"),
+                        o = heim_string_create(printable_time(cred->times.authtime)));
+    heim_release(o);
+        heim_dict_set_value(e, HSTR("starttime"), heim_null_create());
+    if (cred->times.starttime) {
+        heim_dict_set_value(e, HSTR("starttime"),
+                            o = heim_number_create(cred->times.starttime));
+        heim_release(o);
+        heim_dict_set_value(t, HSTR("Starttime"),
+                            o = heim_string_create(printable_time(cred->times.starttime)));
+        heim_release(o);
+    }
+
+    if (cred->times.renew_till) {
+        heim_dict_set_value(e, HSTR("renew_till"),
+                            o = heim_number_create(cred->times.starttime));
+        heim_release(o);
+        heim_dict_set_value(t, HSTR("Renew till"),
+                            o = heim_string_create(printable_time(cred->times.starttime)));
+        heim_release(o);
+    }
+
+    heim_dict_set_value(e, HSTR("endtime"),
+                        o = heim_number_create(cred->times.endtime));
+    heim_release(o);
+
+    if (cred->times.endtime > sec) {
+        heim_dict_set_value(t, HSTR("Expires"),
+                            o = heim_string_create(printable_time(cred->times.endtime)));
+        heim_release(o);
+        heim_dict_set_value(t, HSTR("expired"), heim_bool_create(0));
+    } else {
+        heim_dict_set_value(t, HSTR("Expires"), HSTR(">>>Expired<<<"));
+        heim_dict_set_value(t, HSTR("expired"), heim_bool_create(1));
+    }
+
+    ret = krb5_unparse_name(context, cred->server, &str);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_unparse_name");
+    heim_dict_set_value(t, HSTR("Principal"), o = heim_string_create(str));
+    heim_release(o);
+
+    if (cred->flags.b.forwardable) {
+        heim_dict_set_value(f, HSTR("forwardable"), heim_bool_create(1));
+        *sp++ = 'F';
+    } else {
+        heim_dict_set_value(f, HSTR("forwardable"), heim_bool_create(0));
+    }
+    if (cred->flags.b.forwarded) {
+        heim_dict_set_value(f, HSTR("forwarded"), heim_bool_create(1));
+        *sp++ = 'f';
+    } else {
+        heim_dict_set_value(f, HSTR("forwarded"), heim_bool_create(0));
+    }
+    if (cred->flags.b.proxiable) {
+        heim_dict_set_value(f, HSTR("proxiable"), heim_bool_create(1));
+        *sp++ = 'P';
+    } else {
+        heim_dict_set_value(f, HSTR("proxiable"), heim_bool_create(0));
+    }
+    if (cred->flags.b.proxy) {
+        heim_dict_set_value(f, HSTR("proxy"), heim_bool_create(1));
+        *sp++ = 'p';
+    } else {
+        heim_dict_set_value(f, HSTR("proxy"), heim_bool_create(0));
+    }
+    if (cred->flags.b.may_postdate) {
+        heim_dict_set_value(f, HSTR("may_postdate"), heim_bool_create(1));
+        *sp++ = 'D';
+    } else {
+        heim_dict_set_value(f, HSTR("may_postdate"), heim_bool_create(0));
+    }
+    if (cred->flags.b.postdated) {
+        heim_dict_set_value(f, HSTR("postdated"), heim_bool_create(1));
+        *sp++ = 'd';
+    } else {
+        heim_dict_set_value(f, HSTR("postdated"), heim_bool_create(0));
+    }
+    if (cred->flags.b.renewable) {
+        heim_dict_set_value(f, HSTR("renewable"), heim_bool_create(1));
+        *sp++ = 'R';
+    } else {
+        heim_dict_set_value(f, HSTR("renewable"), heim_bool_create(0));
+    }
+    if (cred->flags.b.initial) {
+        heim_dict_set_value(f, HSTR("initial"), heim_bool_create(1));
+        *sp++ = 'I';
+    } else {
+        heim_dict_set_value(f, HSTR("initial"), heim_bool_create(0));
+    }
+    if (cred->flags.b.invalid) {
+        heim_dict_set_value(f, HSTR("invalid"), heim_bool_create(1));
+        *sp++ = 'i';
+    } else {
+        heim_dict_set_value(f, HSTR("invalid"), heim_bool_create(0));
+    }
+    if (cred->flags.b.pre_authent) {
+        heim_dict_set_value(f, HSTR("pre_authent"), heim_bool_create(1));
+        *sp++ = 'A';
+    } else {
+        heim_dict_set_value(f, HSTR("pre_authent"), heim_bool_create(0));
+    }
+    if (cred->flags.b.hw_authent) {
+        heim_dict_set_value(f, HSTR("hw_authent"), heim_bool_create(1));
+        *sp++ = 'H';
+    } else {
+        heim_dict_set_value(f, HSTR("hw_authent"), heim_bool_create(0));
+    }
+    if (cred->flags.b.transited_policy_checked) {
+        heim_dict_set_value(f, HSTR("transited_policy_checked"), heim_bool_create(1));
+        *sp++ = 'T';
+    } else {
+        heim_dict_set_value(f, HSTR("transited_policy_checked"), heim_bool_create(0));
+    }
+    if (cred->flags.b.ok_as_delegate) {
+        heim_dict_set_value(f, HSTR("ok_as_delegate"), heim_bool_create(1));
+        *sp++ = 'O';
+    } else {
+        heim_dict_set_value(f, HSTR("ok_as_delegate"), heim_bool_create(0));
+    }
+    if (cred->flags.b.anonymous) {
+        heim_dict_set_value(f, HSTR("anonymous"), heim_bool_create(1));
+        *sp++ = 'a';
+    } else {
+        heim_dict_set_value(f, HSTR("anonymous"), heim_bool_create(0));
+    }
+    *sp = '\0';
+    heim_dict_set_value(t, HSTR("Flags"), o = heim_string_create(sp));
+    heim_release(e);
+    heim_release(f);
+    heim_release(t);
+    heim_release(o);
+    free(str);
+}
+
+static void
+print_cred_verbose(krb5_context context, krb5_creds *cred)
 {
     size_t j;
     char *str;
     krb5_error_code ret;
     krb5_timestamp sec;
-
-    if (do_json) { /* XXX support more json formating later */
-	printf("{ \"verbose-supported\" : false }");
-	return;
-    }
 
     krb5_timeofday (context, &sec);
 
@@ -252,6 +407,74 @@ print_cred_verbose(krb5_context context, krb5_creds *cred, int do_json)
     printf("\n\n");
 }
 
+static void
+cache2json(krb5_context context,
+	   krb5_ccache ccache,
+	   krb5_principal principal,
+	   heim_dict_t dict)
+{
+    heim_array_t tix = heim_array_create();
+    heim_object_t o;
+    char *str, *fullname;
+    char *name = NULL;
+    krb5_error_code ret;
+    krb5_cc_cursor cursor;
+    krb5_creds creds;
+    krb5_deltat sec;
+
+    ret = krb5_unparse_name(context, principal, &str);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_unparse_name");
+
+    ret = krb5_cc_get_full_name(context, ccache, &fullname);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_cc_get_full_name");
+
+    heim_dict_set_value(dict, HSTR("cache"),
+                        o = heim_string_create(fullname));
+    heim_release(o);
+    heim_dict_set_value(dict, HSTR("principal"),
+                        o = heim_string_create(str));
+    heim_release(o);
+    heim_dict_set_value(dict, HSTR("cache_version"),
+                        o = heim_number_create(krb5_cc_get_version(context,
+                                                                   ccache)));
+    heim_release(o);
+    free(str);
+	
+    ret = krb5_cc_get_friendly_name(context, ccache, &name);
+    if (ret == 0) {
+        heim_dict_set_value(dict, HSTR("friendly_name"),
+                            o = heim_string_create(name));
+        heim_release(o);
+    }
+    free(name);
+
+    ret = krb5_cc_get_kdc_offset(context, ccache, &sec);
+    if (ret == 0) {
+        heim_dict_set_value(dict, HSTR("kdc_offset"),
+                            o = heim_number_create(sec));
+        heim_release(o);
+    }
+
+    heim_dict_set_value(dict, HSTR("tickets"), tix);
+    ret = krb5_cc_start_seq_get(context, ccache, &cursor);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_cc_start_seq_get");
+
+    while ((ret = krb5_cc_next_cred(context, ccache, &cursor, &creds)) == 0) {
+        cred2json(context, &creds, tix);
+	krb5_free_cred_contents(context, &creds);
+    }
+    if (ret != KRB5_CC_END)
+	krb5_err(context, 1, ret, "krb5_cc_get_next");
+    ret = krb5_cc_end_seq_get(context, ccache, &cursor);
+    if (ret)
+	krb5_err(context, 1, ret, "krb5_cc_end_seq_get");
+    heim_release(tix);
+    free(fullname);
+}
+
 /*
  * Print all tickets in `ccache' on stdout, verbosely if do_verbose.
  */
@@ -262,8 +485,7 @@ print_tickets(krb5_context context,
 	      krb5_principal principal,
 	      int do_verbose,
 	      int do_flags,
-	      int do_hidden,
-	      int do_json)
+	      int do_hidden)
 {
     char *str, *name, *fullname;
     krb5_error_code ret;
@@ -271,7 +493,6 @@ print_tickets(krb5_context context,
     krb5_creds creds;
     krb5_deltat sec;
     rtbl_t ct = NULL;
-    int print_comma = 0;
 
     ret = krb5_unparse_name (context, principal, &str);
     if (ret)
@@ -281,27 +502,26 @@ print_tickets(krb5_context context,
     if (ret)
 	krb5_err (context, 1, ret, "krb5_cc_get_full_name");
 
-    if (!do_json) {
-	printf ("%17s: %s\n", N_("Credentials cache", ""), fullname);
-	printf ("%17s: %s\n", N_("Principal", ""), str);
+    printf ("%17s: %s\n", N_("Credentials cache", ""), fullname);
+    printf ("%17s: %s\n", N_("Principal", ""), str);
 	
-	ret = krb5_cc_get_friendly_name(context, ccache, &name);
-	if (ret == 0) {
-	    if (strcmp(name, str) != 0)
-		printf ("%17s: %s\n", N_("Friendly name", ""), name);
-	    free(name);
-	}
+    ret = krb5_cc_get_friendly_name(context, ccache, &name);
+    if (ret == 0) {
+        if (strcmp(name, str) != 0) {
+            printf ("%17s: %s\n", N_("Friendly name", ""), name);
+        }
+        free(name);
+    }
+
+    if(do_verbose) {
+        printf ("%17s: %d\n", N_("Cache version", ""),
+                krb5_cc_get_version(context, ccache));
+    }
 	
-	if(do_verbose) {
-	    printf ("%17s: %d\n", N_("Cache version", ""),
-		    krb5_cc_get_version(context, ccache));
-	} else {
-	    krb5_cc_set_flags(context, ccache, KRB5_TC_NOTICKET);
-	}
+    ret = krb5_cc_get_kdc_offset(context, ccache, &sec);
+    if (ret == 0) {
+        if (do_verbose && sec != 0) {
 	
-	ret = krb5_cc_get_kdc_offset(context, ccache, &sec);
-	
-	if (ret == 0 && do_verbose && sec != 0) {
 	    char buf[BUFSIZ];
 	    int val;
 	    int sig;
@@ -317,18 +537,16 @@ print_tickets(krb5_context context,
 
 	    printf ("%17s: %s%s\n", N_("KDC time offset", ""),
 		    sig == -1 ? "-" : "", buf);
-	}
-	printf("\n");
-    } else {
-	printf ("{ \"cache\" : \"%s\", \"principal\" : \"%s\", ", fullname, str);
+        }
     }
+    printf("\n");
     free(str);
 
     ret = krb5_cc_start_seq_get (context, ccache, &cursor);
     if (ret)
 	krb5_err(context, 1, ret, "krb5_cc_start_seq_get");
 
-    if(!do_verbose) {
+    if (!do_verbose) {
 	ct = rtbl_create();
 	rtbl_add_column(ct, COL_ISSUED, 0);
 	rtbl_add_column(ct, COL_EXPIRES, 0);
@@ -336,21 +554,12 @@ print_tickets(krb5_context context,
 	    rtbl_add_column(ct, COL_FLAGS, 0);
 	rtbl_add_column(ct, COL_PRINCIPAL, 0);
 	rtbl_set_separator(ct, "  ");
-	if (do_json) {
-	    rtbl_set_flags(ct, RTBL_JSON);
-	    printf("\"tickets\" : ");
-	}
     }
-    if (do_verbose && do_json)
-	printf("\"tickets\" : [");
     while ((ret = krb5_cc_next_cred(context, ccache, &cursor, &creds)) == 0) {
 	if (!do_hidden && krb5_is_config_principal(context, creds.server)) {
 	    ;
 	} else if (do_verbose) {
-            if (do_json && print_comma)
-                printf(",");
-	    print_cred_verbose(context, &creds, do_json);
-            print_comma = 1;
+	    print_cred_verbose(context, &creds);
 	} else {
 	    print_cred(context, &creds, ct, do_flags);
 	}
@@ -365,11 +574,6 @@ print_tickets(krb5_context context,
     if(!do_verbose) {
 	rtbl_format(ct, stdout);
 	rtbl_destroy(ct);
-    }
-    if (do_json) {
-	if (do_verbose)
-	    printf("]");
-	printf("}");
     }
     free(fullname);
 }
@@ -475,10 +679,10 @@ display_tokens(int do_verbose)
  */
 
 static int
-display_v5_ccache (krb5_context context, krb5_ccache ccache,
-		   int do_test, int do_verbose,
-		   int do_flags, int do_hidden,
-		   int do_json)
+display_v5_ccache(krb5_context context, krb5_ccache ccache,
+		  int do_test, int do_verbose,
+		  int do_flags, int do_hidden,
+		  heim_dict_t dict)
 {
     krb5_error_code ret;
     krb5_principal principal;
@@ -487,10 +691,8 @@ display_v5_ccache (krb5_context context, krb5_ccache ccache,
 
     ret = krb5_cc_get_principal (context, ccache, &principal);
     if (ret) {
-	if (do_json) {
-	    printf("{}");
+	if (dict)
 	    return 0;
-	}
 	if(ret == ENOENT) {
 	    if (!do_test)
 		krb5_warnx(context, N_("No ticket file: %s", ""),
@@ -499,11 +701,18 @@ display_v5_ccache (krb5_context context, krb5_ccache ccache,
 	} else
 	    krb5_err (context, 1, ret, "krb5_cc_get_principal");
     }
-    if (do_test)
-	exit_status = check_expiration(context, ccache, NULL);
-    else
-	print_tickets (context, ccache, principal, do_verbose,
-		       do_flags, do_hidden, do_json);
+    exit_status = check_expiration(context, ccache, NULL);
+    if (!do_test) {
+        if (dict) {
+            heim_dict_set_value(dict, HSTR("expired"),
+                                heim_bool_create(!!exit_status));
+            cache2json(context, ccache, principal, dict);
+        } else {
+            print_tickets(context, ccache, principal, do_verbose,
+                          do_flags, do_hidden);
+        }
+        exit_status = 0;
+    }
 
     ret = krb5_cc_close (context, ccache);
     if (ret)
@@ -512,6 +721,87 @@ display_v5_ccache (krb5_context context, krb5_ccache ccache,
     krb5_free_principal (context, principal);
 
     return exit_status;
+}
+
+static int
+caches2json(krb5_context context)
+{
+    krb5_cccol_cursor cursor;
+    const char *cdef_name = krb5_cc_default_name(context);
+    char *def_name;
+    heim_object_t o;
+    heim_array_t a = heim_array_create();
+    krb5_error_code ret;
+    krb5_ccache id;
+
+    if ((def_name = krb5_cccol_get_default_ccname(context)) == NULL)
+        cdef_name = krb5_cc_default_name(context);
+    if (!def_name && cdef_name && (def_name = strdup(cdef_name)) == NULL)
+        krb5_err(context, 1, ENOMEM, "Out of memory");
+
+    ret = krb5_cccol_cursor_new(context, &cursor);
+    if (ret == KRB5_CC_NOSUPP) {
+        free(def_name);
+	return 0;
+    }
+    else if (ret)
+	krb5_err (context, 1, ret, "krb5_cc_cache_get_first");
+
+    while (krb5_cccol_cursor_next(context, cursor, &id) == 0 && id != NULL) {
+        heim_dict_t dict = heim_dict_create(10);
+	int expired = 0;
+	char *name;
+	time_t t;
+
+	expired = check_expiration(context, id, &t);
+	ret = krb5_cc_get_friendly_name(context, id, &name);
+	if (ret == 0) {
+	    char *fname;
+
+            heim_dict_set_value(dict, HSTR("Name"),
+                                o = heim_string_create(name));
+            heim_release(o);
+	    free(name);
+
+	    if (expired)
+		o = heim_string_create(N_(">>> Expired <<<", ""));
+	    else
+		o = heim_string_create(printable_time(t));
+            heim_dict_set_value(dict, HSTR("Expires"), o);
+            heim_release(o);
+
+	    ret = krb5_cc_get_full_name(context, id, &fname);
+	    if (ret)
+		krb5_err (context, 1, ret, "krb5_cc_get_full_name");
+
+            heim_dict_set_value(dict, HSTR("Cache Name"),
+                                o = heim_string_create(fname));
+            heim_release(o);
+
+	    if (def_name && strcmp(fname, def_name) == 0)
+                heim_dict_set_value(dict, HSTR("is_default_cache"),
+                                    heim_bool_create(1));
+	    else
+                heim_dict_set_value(dict, HSTR("is_default_cache"),
+                                    heim_bool_create(0));
+            heim_array_append_value(a, dict);
+            heim_release(dict);
+
+	    krb5_xfree(fname);
+	}
+	krb5_cc_close(context, id);
+    }
+
+    krb5_cccol_cursor_free(context, &cursor);
+    free(def_name);
+
+    o = heim_json_copy_serialize(a, HEIM_JSON_F_STRICT | HEIM_JSON_F_INDENT2,
+                                 NULL);
+    printf("%s", heim_string_get_utf8(o));
+    heim_release(a);
+    heim_release(o);
+
+    return 0;
 }
 
 /*
@@ -550,8 +840,6 @@ list_caches(krb5_context context, struct klist_options *opt)
     rtbl_set_prefix(ct, "   ");
     rtbl_set_column_prefix(ct, COL_DEFCACHE, "");
     rtbl_set_column_prefix(ct, COL_NAME, " ");
-    if (opt->json_flag)
-	rtbl_set_flags(ct, RTBL_JSON);
 
     while (krb5_cccol_cursor_next(context, cursor, &id) == 0 && id != NULL) {
 	int expired = 0;
@@ -579,9 +867,7 @@ list_caches(krb5_context context, struct klist_options *opt)
 		krb5_err (context, 1, ret, "krb5_cc_get_full_name");
 
 	    rtbl_add_column_entry(ct, COL_CACHENAME, fname);
-	    if (opt->json_flag)
-		;
-	    else if (def_name && strcmp(fname, def_name) == 0)
+	    if (def_name && strcmp(fname, def_name) == 0)
 		rtbl_add_column_entry(ct, COL_DEFCACHE, "*");
 	    else
 		rtbl_add_column_entry(ct, COL_DEFCACHE, "");
@@ -597,9 +883,6 @@ list_caches(krb5_context context, struct klist_options *opt)
     rtbl_format(ct, stdout);
     rtbl_destroy(ct);
 
-    if (opt->json_flag)
-	printf("\n");
-
     return 0;
 }
 
@@ -611,6 +894,7 @@ int
 klist(struct klist_options *opt, int argc, char **argv)
 {
     krb5_error_code ret;
+    heim_object_t o = NULL;
     int exit_status = 0;
 
     int do_verbose =
@@ -627,7 +911,10 @@ klist(struct klist_options *opt, int argc, char **argv)
     }
 
     if (opt->list_all_flag) {
-	exit_status = list_caches(heimtools_context, opt);
+        if (opt->json_flag)
+            exit_status = caches2json(heimtools_context);
+        else
+            exit_status = list_caches(heimtools_context, opt);
 	return exit_status;
     }
 
@@ -635,32 +922,28 @@ klist(struct klist_options *opt, int argc, char **argv)
 	krb5_ccache id;
 
 	if (opt->all_content_flag) {
+            heim_array_t a = opt->json_flag ? heim_array_create() : NULL;
 	    krb5_cc_cache_cursor cursor;
-	    int first = 1;
 
 	    ret = krb5_cc_cache_get_first(heimtools_context, NULL, &cursor);
 	    if (ret)
 		krb5_err(heimtools_context, 1, ret, "krb5_cc_cache_get_first");
 
-	    if (opt->json_flag)
-		printf("[");
 	    while (krb5_cc_cache_next(heimtools_context, cursor, &id) == 0) {
-		if (opt->json_flag && !first)
-		    printf(",");
+                heim_dict_t dict = opt->json_flag ? heim_dict_create(10) : NULL;
 
 		exit_status |= display_v5_ccache(heimtools_context, id, do_test,
 						 do_verbose, opt->flags_flag,
                                                  opt->hidden_flag,
-                                                 opt->json_flag);
-		if (!opt->json_flag)
-		    printf("\n\n");
-
-		first = 0;
+                                                 dict);
+                if (a)
+                    heim_array_append_value(a, dict);
+                heim_release(dict);
 	    }
 	    krb5_cc_cache_end_seq_get(heimtools_context, cursor);
-	    if (opt->json_flag)
-		printf("]");
+            o = a;
 	} else {
+            heim_dict_t dict = opt->json_flag ? heim_dict_create(10) : NULL;
 	    if(opt->cache_string) {
 		ret = krb5_cc_resolve(heimtools_context, opt->cache_string, &id);
 		if (ret)
@@ -672,8 +955,23 @@ klist(struct klist_options *opt, int argc, char **argv)
 	    }
 	    exit_status = display_v5_ccache(heimtools_context, id, do_test,
 					    do_verbose, opt->flags_flag,
-                                            opt->hidden_flag, opt->json_flag);
+                                            opt->hidden_flag, dict);
+            o = dict;
 	}
+    }
+
+    if (o) {
+        heim_string_t s = heim_json_copy_serialize(o,
+                                                   HEIM_JSON_F_STRICT |
+                                                   HEIM_JSON_F_INDENT2,
+                                                   NULL);
+        
+        if (s == NULL)
+            errx(1, "Could not format JSON text");
+
+        printf("%s", heim_string_get_utf8(s));
+        heim_release(o);
+        heim_release(s);
     }
 
     if (!do_test) {

--- a/lib/base/heimbase.h
+++ b/lib/base/heimbase.h
@@ -464,10 +464,12 @@ typedef enum heim_json_flags {
 	HEIM_JSON_F_CNULL2JSNULL = 32,
 	HEIM_JSON_F_TRY_DECODE_DATA = 64,
 	HEIM_JSON_F_ONE_LINE = 128,
+        HEIM_JSON_F_ESCAPE_NON_ASCII = 256,
+        HEIM_JSON_F_NO_ESCAPE_NON_ASCII = 512,
         /* The default is to indent with one tab */
-	HEIM_JSON_F_INDENT2 = 256,
-	HEIM_JSON_F_INDENT4 = 512,
-	HEIM_JSON_F_INDENT8 = 1024,
+	HEIM_JSON_F_INDENT2 = 1024,
+	HEIM_JSON_F_INDENT4 = 2048,
+	HEIM_JSON_F_INDENT8 = 4096,
 } heim_json_flags_t;
 
 heim_object_t heim_json_create(const char *, size_t, heim_json_flags_t,

--- a/lib/base/heimbase.h
+++ b/lib/base/heimbase.h
@@ -463,7 +463,11 @@ typedef enum heim_json_flags {
 	HEIM_JSON_F_STRICT = 31,
 	HEIM_JSON_F_CNULL2JSNULL = 32,
 	HEIM_JSON_F_TRY_DECODE_DATA = 64,
-	HEIM_JSON_F_ONE_LINE = 128
+	HEIM_JSON_F_ONE_LINE = 128,
+        /* The default is to indent with one tab */
+	HEIM_JSON_F_INDENT2 = 256,
+	HEIM_JSON_F_INDENT4 = 512,
+	HEIM_JSON_F_INDENT8 = 1024,
 } heim_json_flags_t;
 
 heim_object_t heim_json_create(const char *, size_t, heim_json_flags_t,

--- a/lib/base/heimbase.h
+++ b/lib/base/heimbase.h
@@ -134,6 +134,28 @@ typedef struct heim_config_binding heim_config_section;
  * CF-like, JSON APIs
  */
 
+typedef enum heim_tid_enum {
+    HEIM_TID_NUMBER = 0,
+    HEIM_TID_NULL = 1,
+    HEIM_TID_BOOL = 2,
+    HEIM_TID_TAGGED_UNUSED2 = 3, /* reserved for tagged object types */
+    HEIM_TID_TAGGED_UNUSED3 = 4, /* reserved for tagged object types */
+    HEIM_TID_TAGGED_UNUSED4 = 5, /* reserved for tagged object types */
+    HEIM_TID_TAGGED_UNUSED5 = 6, /* reserved for tagged object types */
+    HEIM_TID_TAGGED_UNUSED6 = 7, /* reserved for tagged object types */
+    HEIM_TID_MEMORY = 128,
+    HEIM_TID_ARRAY = 129,
+    HEIM_TID_DICT = 130,
+    HEIM_TID_STRING = 131,
+    HEIM_TID_AUTORELEASE = 132,
+    HEIM_TID_ERROR = 133,
+    HEIM_TID_DATA = 134,
+    HEIM_TID_DB = 135,
+    HEIM_TID_PA_AUTH_MECH = 136,
+    HEIM_TID_PAC = 137,
+    HEIM_TID_USER = 255
+} heim_tid;
+
 typedef void * heim_object_t;
 typedef unsigned int heim_tid_t;
 typedef heim_object_t heim_bool_t;

--- a/lib/base/heimbasepriv.h
+++ b/lib/base/heimbasepriv.h
@@ -47,29 +47,6 @@ typedef heim_string_t (*heim_type_description)(void *);
 
 typedef struct heim_type_data *heim_type_t;
 
-enum {
-    HEIM_TID_NUMBER = 0,
-    HEIM_TID_NULL = 1,
-    HEIM_TID_BOOL = 2,
-    HEIM_TID_TAGGED_UNUSED2 = 3, /* reserved for tagged object types */
-    HEIM_TID_TAGGED_UNUSED3 = 4, /* reserved for tagged object types */
-    HEIM_TID_TAGGED_UNUSED4 = 5, /* reserved for tagged object types */
-    HEIM_TID_TAGGED_UNUSED5 = 6, /* reserved for tagged object types */
-    HEIM_TID_TAGGED_UNUSED6 = 7, /* reserved for tagged object types */
-    HEIM_TID_MEMORY = 128,
-    HEIM_TID_ARRAY = 129,
-    HEIM_TID_DICT = 130,
-    HEIM_TID_STRING = 131,
-    HEIM_TID_AUTORELEASE = 132,
-    HEIM_TID_ERROR = 133,
-    HEIM_TID_DATA = 134,
-    HEIM_TID_DB = 135,
-    HEIM_TID_PA_AUTH_MECH = 136,
-    HEIM_TID_PAC = 137,
-    HEIM_TID_USER = 255
-
-};
-
 struct heim_type_data {
     heim_tid_t tid;
     const char *name;

--- a/lib/base/json.c
+++ b/lib/base/json.c
@@ -43,8 +43,6 @@
 
 static heim_base_once_t heim_json_once = HEIM_BASE_ONCE_INIT;
 static heim_string_t heim_tid_data_uuid_key = NULL;
-static const char base64_chars[] =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 static void
 json_init_once(void *arg)
@@ -981,33 +979,6 @@ parse_string(struct parse_ctx *ctx)
     if (binary) {
         o = heim_data_ref_create(p0, (p - 1) - p0, free);
         return o;
-    }
-
-    /* If we can decode as base64, then let's */
-    if (ctx->flags & HEIM_JSON_F_TRY_DECODE_DATA) {
-        void *buf;
-        size_t len = p - p0;
-
-        if (len > 0)
-            len--;
-
-        if (len >= 4 && strspn(p0, base64_chars) >= len - 2) {
-            buf = malloc(len);
-            if (buf == NULL) {
-                ctx->error = heim_error_create_enomem();
-                free(p0);
-                return NULL;
-            }
-            len = rk_base64_decode(p0, buf);
-            if (len > -1) {
-                /* Yes base64, return the decoded data */
-                o = heim_data_ref_create(buf, len, free);
-                free(p0);
-                return o;
-            }
-            /* Not base64, so return what we had */
-            free(buf);
-        }
     }
 
     /* Sadly this will copy `p0' */

--- a/lib/base/json.c
+++ b/lib/base/json.c
@@ -166,12 +166,175 @@ base2json(heim_object_t obj, struct twojson *j)
 	j->first = first;
 	break;
 
-    case HEIM_TID_STRING:
+    case HEIM_TID_STRING: {
+	const unsigned char *s = (const unsigned char *)heim_string_get_utf8(obj);
+	const unsigned char *p;
+        unsigned int c, cp, ctop, cbot;
+        char e[sizeof("\\u0123\\u3210")];
+        int good;
+        size_t i;
+
 	indent(j);
 	j->out(j->ctx, "\"");
-	j->out(j->ctx, heim_string_get_utf8(obj));
+        for (p = s; (c = *p); p++) {
+            switch (c) {
+            /* ASCII control characters w/ C-like escapes */
+            case '\b': j->out(j->ctx, "\\b");  continue;
+            case '\f': j->out(j->ctx, "\\f");  continue;
+            case '\n': j->out(j->ctx, "\\n");  continue;
+            case '\r': j->out(j->ctx, "\\r");  continue;
+            case '\t': j->out(j->ctx, "\\t");  continue;
+            /* Other must-escape non-control ASCII characters */
+            case '"':  j->out(j->ctx, "\\\""); continue;
+            case '\\': j->out(j->ctx, "\\\\"); continue;
+            default: break;
+            }
+
+            /*
+             * JSON string encoding is... complex.
+             *
+             * Invalid UTF-8 w/  HEIM_JSON_F_STRICT_STRINGS set -> return 1
+             *
+             * Invalid UTF-8 w/o HEIM_JSON_F_STRICT_STRINGS set -> pass
+             * through, a sort of Heimdal WTF-8, but not _the_ WTF-8.
+             */
+            if (c < 0x20) {
+                /* ASCII control character w/o C-like escape */
+                e[0] = '\\';
+                e[1] = 'u';
+                e[2] = '0';
+                e[3] = '0';
+                e[4] = "0123456789ABCDEF"[c>>4];
+                e[5] = "0123456789ABCDEF"[c & 0x0f];
+                e[6] = '\0';
+                j->out(j->ctx, e);
+                continue;
+            }
+            if (c < 0x80) {
+                /* ASCII */
+                e[0] = c;
+                e[1] = '\0';
+                j->out(j->ctx, e);
+                continue;
+            }
+            if ((c & 0xc0) == 0x80) {
+                /* UTF-8 bare non-leading byte */
+                if (!(j->flags & HEIM_JSON_F_STRICT_STRINGS)) {
+                    e[0] = c;
+                    e[1] = '\0';
+                    j->out(j->ctx, e);
+                    continue;
+                }
+                return 1;
+            }
+            if ((c & 0xe0) == 0xc0) {
+                /* UTF-8 leading byte of two-byte sequence */
+                good = 1;
+                for (i = 1; i < 2 && good && p[i]; i++) {
+                    if ((p[i] & 0xc0) != 0x80)
+                        good = 0;
+                }
+                if (i != 2)
+                    good = 0;
+                if (!good && !(j->flags & HEIM_JSON_F_STRICT_STRINGS)) {
+                    e[0] = c;
+                    e[1] = '\0';
+                    j->out(j->ctx, e);
+                    continue;
+                } else if (!good) {
+                    return 1;
+                }
+                e[0] = c;
+                e[1] = p[1];
+                e[2] = '\0';
+                j->out(j->ctx, e);
+                p += 1;
+                continue;
+            }
+            if ((c & 0xf0) == 0xe0) {
+                /* UTF-8 leading byte of three-byte sequence */
+                good = 1;
+                for (i = 1; i < 3 && good && p[i]; i++) {
+                    if ((p[i] & 0xc0) != 0x80)
+                        good = 0;
+                }
+                if (i != 3)
+                    good = 0;
+                if (!good && !(j->flags & HEIM_JSON_F_STRICT_STRINGS)) {
+                    e[0] = c;
+                    e[1] = '\0';
+                    j->out(j->ctx, e);
+                    continue;
+                } else if (!good) {
+                    return 1;
+                }
+                e[0] = c;
+                e[1] = p[1];
+                e[2] = p[2];
+                e[3] = '\0';
+                j->out(j->ctx, e);
+                p += 2;
+                continue;
+            }
+
+            if (c > 0xf7) {
+                /* Invalid UTF-8 leading byte */
+                if (!(j->flags & HEIM_JSON_F_STRICT_STRINGS)) {
+                    e[0] = c;
+                    e[1] = '\0';
+                    j->out(j->ctx, e);
+                    continue;
+                }
+                return 1;
+            }
+
+            /*
+             * A codepoint > U+FFFF, needs encoding a la UTF-16 surrogate
+             * pair because JSON takes after JS which uses UTF-16.  Ugly.
+             */
+            cp = c & 0x7;
+            good = 1;
+            for (i = 1; i < 4 && good && p[i]; i++) {
+                if ((p[i] & 0xc0) == 0x80)
+                    cp = (cp << 6) | (p[i] & 0x3f);
+                else
+                    good = 0;
+            }
+            if (i != 4)
+                good = 0;
+            if (!good && !(j->flags & HEIM_JSON_F_STRICT_STRINGS)) {
+                e[0] = c;
+                e[1] = '\0';
+                j->out(j->ctx, e);
+                continue;
+            } else if (!good) {
+                return 1;
+            }
+            p += 3;
+
+            cp -= 0x10000;
+            ctop = 0xD800 + (cp >>   10);
+            cbot = 0xDC00 + (cp & 0x3ff);
+
+            e[0 ] = '\\';
+            e[1 ] = 'u';
+            e[2 ] = "0123456789ABCDEF"[(ctop         ) >> 12];
+            e[3 ] = "0123456789ABCDEF"[(ctop & 0x0f00) >>  8];
+            e[4 ] = "0123456789ABCDEF"[(ctop & 0x00f0) >>  4];
+            e[5 ] = "0123456789ABCDEF"[(ctop & 0x000f)      ];
+            e[6 ] = '\\';
+            e[7 ] = 'u';
+            e[8 ] = "0123456789ABCDEF"[(cbot         ) >> 12];
+            e[9 ] = "0123456789ABCDEF"[(cbot & 0x0f00) >>  8];
+            e[10] = "0123456789ABCDEF"[(cbot & 0x00f0) >>  4];
+            e[11] = "0123456789ABCDEF"[(cbot & 0x000f)      ];
+            e[12] = '\0';
+            j->out(j->ctx, e);
+            continue;
+        }
 	j->out(j->ctx, "\"");
 	break;
+    }
 
     case HEIM_TID_DATA: {
 	heim_dict_t d;
@@ -254,9 +417,6 @@ heim_base2json(heim_object_t obj, void *ctx, heim_json_flags_t flags,
 	       void (*out)(void *, const char *))
 {
     struct twojson j;
-
-    if (flags & HEIM_JSON_F_STRICT_STRINGS)
-	return ENOTSUP; /* Sorry, not yet! */
 
     heim_base_once_f(&heim_json_once, NULL, json_init_once);
 
@@ -342,93 +502,428 @@ parse_number(struct parse_ctx *ctx)
     return heim_number_create(number * neg);
 }
 
+/*
+ * Read 4 hex digits from ctx->p.
+ *
+ * If we don't have enough, rewind ctx->p and return -1 .
+ */
+static int
+unescape_unicode(struct parse_ctx *ctx)
+{
+    int c = 0;
+    int i;
+
+    for (i = 0; i < 4 && ctx->p < ctx->pend; i++, ctx->p++) {
+        if (*ctx->p >= '0' && *ctx->p <= '9') {
+            c = (c << 4) + (*ctx->p - '0');
+        } else if (*ctx->p >= 'A' && *ctx->p <= 'F') {
+            c = (c << 4) + (10 + *ctx->p - 'A');
+        } else if (*ctx->p >= 'a' && *ctx->p <= 'f') {
+            c = (c << 4) + (10 + *ctx->p - 'a');
+        } else {
+            ctx->p -= i;
+            return -1;
+        }
+    }
+    return c;
+}
+
+static int
+encode_utf8(struct parse_ctx *ctx, char **pp, char *pend, int c)
+{
+    char *p = *pp;
+
+    if (c < 0x80) {
+        /* ASCII */
+        if (p >= pend) return 0;
+        *(p++) = c;
+        *pp = p;
+        return 1;
+    }
+    if (c < 0x800) {
+        /* 2 code unit UTF-8 sequence */
+        if (p >= pend) return 0;
+        *(p++) = 0xc0 | ((c >>  6)       );
+        if (p == pend) return 0;
+        *(p++) = 0x80 | ((c      ) & 0x3f);
+        *pp = p;
+        return 1;
+    }
+    if (c < 0x10000) {
+        /* 3 code unit UTF-8 sequence */
+        if (p >= pend) return 0;
+        *(p++) = 0xe0 | ((c >> 12)       );
+        if (p == pend) return 0;
+        *(p++) = 0x80 | ((c >>  6) & 0x3f);
+        if (p == pend) return 0;
+        *(p++) = 0x80 | ((c)       & 0x3f);
+        *pp = p;
+        return 1;
+    }
+    if (c < 0x110000) {
+        /* 4 code unit UTF-8 sequence */
+        if (p >= pend) return 0;
+        *(p++) = 0xf0 | ((c >> 18)       );
+        if (p == pend) return 0;
+        *(p++) = 0x80 | ((c >> 12) & 0x3f);
+        if (p == pend) return 0;
+        *(p++) = 0x80 | ((c >>  6) & 0x3f);
+        if (p == pend) return 0;
+        *(p++) = 0x80 | ((c)       & 0x3f);
+        *pp = p;
+        return 1;
+    }
+    return 0;
+}
+
+static heim_string_t
+parse_string_error(struct parse_ctx *ctx,
+                   char *freeme,
+                   const char *msg)
+{
+    free(freeme);
+    ctx->error = heim_error_create(EINVAL, "%s at %lu", msg, ctx->lineno);
+    return NULL;
+}
+
 static heim_string_t
 parse_string(struct parse_ctx *ctx)
 {
     const uint8_t *start;
-    int quote = 0;
+    heim_object_t o;
+    size_t alloc_len = 0;
+    size_t need = 0;
+    char *p0, *p, *pend;
+    int strict = ctx->flags & HEIM_JSON_F_STRICT_STRINGS;
+    int binary = 0;
 
-    if (ctx->flags & HEIM_JSON_F_STRICT_STRINGS) {
-	ctx->error = heim_error_create(EINVAL, "Strict JSON string encoding "
-				       "not yet supported");
-	return NULL;
+    if (*ctx->p != '"')
+        return parse_string_error(ctx, NULL,
+                                  "Expected a JSON string but found "
+                                  "something else");
+    start = ++(ctx->p);
+
+    /* Estimate how many bytes we need to allocate */
+    p0 = p = pend = NULL;
+    for (need = 1; ctx->p < ctx->pend; ctx->p++) {
+        need++;
+        if (*ctx->p == '\\')
+            ctx->p++;
+        else if (*ctx->p == '"')
+            break;
     }
+    if (ctx->p == ctx->pend)
+        return parse_string_error(ctx, NULL, "Unterminated JSON string");
 
-    if (*ctx->p != '"') {
-	ctx->error = heim_error_create(EINVAL, "Expected a JSON string but "
-				       "found something else at line %lu",
-				       ctx->lineno);
-	return NULL;
-    }
-    start = ++ctx->p;
-
+    ctx->p = start;
     while (ctx->p < ctx->pend) {
-	if (*ctx->p == '\n') {
-	    ctx->lineno++;
-	} else if (*ctx->p == '\\') {
-	    if (ctx->p + 1 == ctx->pend)
-		goto out;
-	    ctx->p++;
-	    quote = 1;
-	} else if (*ctx->p == '"') {
-	    heim_object_t o;
+        const unsigned char *p_save;
+        int32_t ctop, cbot;
 
-	    if (quote) {
-		char *p0, *p;
-		p = p0 = malloc(ctx->p - start);
-		if (p == NULL)
-		    goto out;
-		while (start < ctx->p) {
-		    if (*start == '\\') {
-			start++;
-			/* XXX validate quoted char */
-		    }
-		    *p++ = *start++;
-		}
-		o = heim_string_create_with_bytes(p0, p - p0);
-		free(p0);
-	    } else {
-		o = heim_string_create_with_bytes(start, ctx->p - start);
-		if (o == NULL) {
-		    ctx->error = heim_error_create_enomem();
-		    return NULL;
-		}
+        if (*ctx->p == '"') {
+            ctx->p++;
+            break;
+        }
 
-		/* If we can decode as base64, then let's */
-		if (ctx->flags & HEIM_JSON_F_TRY_DECODE_DATA) {
-		    void *buf;
-		    size_t len;
-		    const char *s;
+        /* Allocate or resize our output buffer if need be */
+        if (need || p == pend) {
+            char *tmp = realloc(p0, alloc_len + need + 5 /* slop? */);
 
-		    s = heim_string_get_utf8(o);
-		    len = strlen(s);
+            if (tmp == NULL) {
+                ctx->error = heim_error_create_enomem();
+                free(p0);
+                return NULL;
+            }
+            alloc_len += need + 5;
+            p = tmp + (p - p0);
+            p0 = tmp;
+            pend = p0 + alloc_len;
 
-		    if (len >= 4 && strspn(s, base64_chars) >= len - 2) {
-			buf = malloc(len);
-			if (buf == NULL) {
-			    heim_release(o);
-			    ctx->error = heim_error_create_enomem();
-			    return NULL;
-			}
-			len = rk_base64_decode(s, buf);
-			if (len == -1) {
-			    free(buf);
-			    return o;
-			}
-			heim_release(o);
-			o = heim_data_ref_create(buf, len, free);
-		    }
-		}
-	    }
-	    ctx->p += 1;
+            need = 0;
+        }
 
-	    return o;
-	}
-	ctx->p += 1;
+        if (*ctx->p != '\\') {
+            unsigned char c = *ctx->p;
+
+            /*
+             * Not backslashed -> consume now.
+             *
+             * NOTE: All cases in this block must continue or return w/ error.
+             */
+
+            /* Check for unescaped ASCII control characters */
+            if (c == '\n') {
+                if (strict)
+                    return parse_string_error(ctx, p0,
+                                              "Unescaped newline in JSON string");
+                /* Count the newline but don't add it to the decoding */
+                ctx->lineno++;
+            } else if (strict && *ctx->p <= 0x1f) {
+                return parse_string_error(ctx, p0, "Unescaped ASCII control character");
+            } else if (c == 0) {
+                binary = 1;
+            }
+            if (!strict || c < 0x80) {
+                /* ASCII, or not strict -> no need to validate */
+                *(p++) = c;
+                ctx->p++;
+                continue;
+            }
+
+            /*
+             * Being strict for parsing means we want to detect malformed UTF-8
+             * sequences.
+             *
+             * If not strict then we just go on below and add to `p' whatever
+             * bytes we find in `ctx->p' as we find them.
+             *
+             * For each two-byte sequence we need one more byte in `p[]'.  For
+             * each three-byte sequence we need two more bytes in `p[]'.
+             *
+             * Setting `need' and looping will cause `p0' to be grown.
+             *
+             * NOTE: All cases in this block must continue or return w/ error.
+             */
+            if ((c & 0xe0) == 0xc0) {
+                /* Two-byte UTF-8 encoding */
+                if (pend - p < 2) {
+                    need = 2;
+                    continue; /* realloc p0 */
+                }
+
+                *(p++) = c;
+                ctx->p++;
+                if (ctx->p == ctx->pend)
+                    return parse_string_error(ctx, p0, "Truncated UTF-8");
+                c = *(ctx->p++);
+                if ((c & 0xc0) != 0x80)
+                    return parse_string_error(ctx, p0, "Truncated UTF-8");
+                *(p++) = c;
+                continue;
+            }
+            if ((c & 0xf0) == 0xe0) {
+                /* Three-byte UTF-8 encoding */
+                if (pend - p < 3) {
+                    need = 3;
+                    continue; /* realloc p0 */
+                }
+
+                *(p++) = c;
+                ctx->p++;
+                if (ctx->p == ctx->pend)
+                    return parse_string_error(ctx, p0, "Truncated UTF-8");
+                c = *(ctx->p++);
+                if ((c & 0xc0) != 0x80)
+                    return parse_string_error(ctx, p0, "Truncated UTF-8");
+                *(p++) = c;
+                c = *(ctx->p++);
+                if ((c & 0xc0) != 0x80)
+                    return parse_string_error(ctx, p0, "Truncated UTF-8");
+                *(p++) = c;
+                continue;
+            }
+            if ((c & 0xf8) == 0xf0)
+                return parse_string_error(ctx, p0, "UTF-8 sequence not "
+                                          "encoded as escaped UTF-16");
+            if ((c & 0xc0) == 0x80)
+                return parse_string_error(ctx, p0,
+                                          "Invalid UTF-8 "
+                                          "(bare continuation code unit)");
+
+            return parse_string_error(ctx, p0, "Not UTF-8");
+        }
+
+        /* Backslash-quoted character */
+        ctx->p++;
+        if (ctx->p == ctx->pend) {
+            ctx->error =
+                heim_error_create(EINVAL,
+                                  "Unterminated JSON string at line %lu",
+                                  ctx->lineno);
+            free(p0);
+            return NULL;
+        }
+        switch (*ctx->p) {
+        /* Simple escapes */
+        case  'b': *(p++) = '\b'; ctx->p++; continue;
+        case  'f': *(p++) = '\f'; ctx->p++; continue;
+        case  'n': *(p++) = '\n'; ctx->p++; continue;
+        case  'r': *(p++) = '\r'; ctx->p++; continue;
+        case  't': *(p++) = '\t'; ctx->p++; continue;
+        case  '"': *(p++) = '"';  ctx->p++; continue;
+        case '\\': *(p++) = '\\'; ctx->p++; continue;
+        /* Escaped Unicode handled below */
+        case  'u':
+            /*
+             * Worst case for !strict we need 11 bytes for a truncated non-BMP
+             * codepoint escape.  Call it 12.
+             */
+            if (strict)
+                need = 4;
+            else
+                need = 12;
+            if (pend - p < need) {
+                /* Go back to the backslash, realloc, try again */
+                ctx->p--;
+                continue;
+            }
+
+            need = 0;
+            ctx->p++;
+            break;
+        default:
+            if (!strict) {
+                *(p++) = *ctx->p;
+                ctx->p++;
+                continue;
+            }
+            ctx->error =
+                heim_error_create(EINVAL,
+                                  "Invalid backslash escape at line %lu",
+                                  ctx->lineno);
+            free(p0);
+            return NULL;
+        }
+
+        /* Unicode code point */
+        if (pend - p < 12) {
+            need = 12;
+            ctx->p -= 2; /* for "\\u" */
+            continue; /* This will cause p0 to be realloc'ed */
+        }
+        p_save = ctx->p;
+        ctop = cbot = -3;
+        ctop = unescape_unicode(ctx);
+        if (ctop == -1 && strict)
+            return parse_string_error(ctx, p0, "Invalid escaped Unicode");
+        if (ctop == -1) {
+            /*
+             * Not strict; tolerate bad input.
+             *
+             * Output "\\u" and then loop to treat what we expected to be four
+             * digits as if they were not part of an escaped Unicode codepoint.
+             */
+            ctx->p = p_save;
+            if (p < pend)
+                *(p++) = '\\';
+            if (p < pend)
+                *(p++) = 'u';
+            continue;
+        }
+        if (ctop == 0) {
+            *(p++) = '\0';
+            binary = 1;
+            continue;
+        }
+        if (ctop < 0xd800) {
+            if (!encode_utf8(ctx, &p, pend, ctop))
+                return parse_string_error(ctx, p0,
+                                          "Internal JSON string parse error");
+            continue;
+        }
+
+        /*
+         * We parsed the top escaped codepoint of a surrogate pair encoding
+         * of a non-BMP Unicode codepoint.  What follows must be another
+         * escaped codepoint.
+         */
+        if (ctx->p < ctx->pend && ctx->p[0] == '\\')
+            ctx->p++;
+        else
+            ctop = -1;
+        if (ctop > -1 && ctx->p < ctx->pend && ctx->p[0] == 'u')
+            ctx->p++;
+        else
+            ctop = -1;
+        if (ctop > -1) {
+            /* Parse the hex digits of the bottom half of the surrogate pair */
+            cbot = unescape_unicode(ctx);
+            if (cbot == -1 || cbot < 0xdc00)
+                ctop = -1;
+        }
+        if (ctop == -1) {
+            if (strict)
+                return parse_string_error(ctx, p0,
+                                          "Invalid surrogate pair");
+
+            /*
+             * Output "\\u", rewind, output the digits of `ctop'.
+             *
+             * When we get to what should have been the bottom half of the
+             * pair we'll necessarily fail to parse it as a normal escaped
+             * Unicode codepoint, and once again, rewind and output its digits.
+             */
+            if (p < pend)
+                *(p++) = '\\';
+            if (p < pend)
+                *(p++) = 'u';
+            ctx->p = p_save;
+            continue;
+        }
+
+        /* Finally decode the surrogate pair then encode as UTF-8 */
+        ctop -= 0xd800;
+        cbot -= 0xdc00;
+        if (!encode_utf8(ctx, &p, pend, 0x10000 + ((ctop << 10) | (cbot & 0x3ff))))
+            return parse_string_error(ctx, p0,
+                                      "Internal JSON string parse error");
     }
-    out:
-    ctx->error = heim_error_create(EINVAL, "ran out of string");
-    return NULL;
+
+    if (p0 == NULL)
+        return heim_string_create("");
+
+    /* NUL-terminate for rk_base64_decode() and plain paranoia */
+    if (p0 != NULL && p == pend) {
+        char *tmp = realloc(p0, 1 + pend - p);
+
+        if (tmp == NULL) {
+            ctx->error = heim_error_create_enomem();
+            free(p0);
+            return NULL;
+        }
+        p = tmp + (p - p0);
+        pend = tmp + 1 + (pend - p0);
+        p0 = tmp;
+    }
+    *(p++) = '\0';
+
+    /* If there's embedded NULs, it's not a C string */
+    if (binary) {
+        o = heim_data_ref_create(p0, (p - 1) - p0, free);
+        return o;
+    }
+
+    /* If we can decode as base64, then let's */
+    if (ctx->flags & HEIM_JSON_F_TRY_DECODE_DATA) {
+        void *buf;
+        size_t len = p - p0;
+
+        if (len > 0)
+            len--;
+
+        if (len >= 4 && strspn(p0, base64_chars) >= len - 2) {
+            buf = malloc(len);
+            if (buf == NULL) {
+                ctx->error = heim_error_create_enomem();
+                free(p0);
+                return NULL;
+            }
+            len = rk_base64_decode(p0, buf);
+            if (len > -1) {
+                /* Yes base64, return the decoded data */
+                o = heim_data_ref_create(buf, len, free);
+                free(p0);
+                return o;
+            }
+            /* Not base64, so return what we had */
+            free(buf);
+        }
+    }
+
+    /* Sadly this will copy `p0' */
+    o = heim_string_create_with_bytes(p0, p - p0);
+    free(p0);
+    return o;
 }
 
 static int
@@ -808,4 +1303,84 @@ heim_json_copy_serialize(heim_object_t obj, heim_json_flags_t flags, heim_error_
 	free(strbuf.str);
     }
     return str;
+}
+
+struct heim_eq_f_ctx {
+    heim_dict_t other;
+    int ret;
+};
+
+static void
+heim_eq_dict_iter_f(heim_object_t key, heim_object_t val, void *d)
+{
+    struct heim_eq_f_ctx *ctx = d;
+    heim_object_t other_val;
+
+    if (!ctx->ret)
+        return;
+
+    /*
+     * This doesn't work if the key is an array or a dict, which, anyways,
+     * isn't allowed in JSON, though we allow it.
+     */
+    other_val = heim_dict_get_value(ctx->other, key);
+    ctx->ret = heim_json_eq(val, other_val);
+}
+
+int
+heim_json_eq(heim_object_t a, heim_object_t b)
+{
+    heim_tid_t atid, btid;
+
+    if (a == b)
+        return 1;
+    if (a == NULL || b == NULL)
+        return 0;
+    atid = heim_get_tid(a);
+    btid = heim_get_tid(b);
+    if (atid != btid)
+        return 0;
+    switch (atid) {
+    case HEIM_TID_ARRAY: {
+        size_t len = heim_array_get_length(b);
+        size_t i;
+
+        if (heim_array_get_length(a) != len)
+            return 0;
+        for (i = 0; i < len; i++) {
+            if (!heim_json_eq(heim_array_get_value(a, i),
+                              heim_array_get_value(b, i)))
+                return 0;
+        }
+        return 1;
+    }
+    case HEIM_TID_DICT: {
+        struct heim_eq_f_ctx ctx;
+
+        ctx.other = b;
+        ctx.ret = 1;
+        heim_dict_iterate_f(a, &ctx, heim_eq_dict_iter_f);
+
+        if (ctx.ret) {
+            ctx.other = a;
+            heim_dict_iterate_f(b, &ctx, heim_eq_dict_iter_f);
+        }
+        return ctx.ret;
+    }
+    case HEIM_TID_STRING:
+        return strcmp(heim_string_get_utf8(a), heim_string_get_utf8(b)) == 0;
+    case HEIM_TID_DATA: {
+        return heim_data_get_length(a) == heim_data_get_length(b) &&
+               memcmp(heim_data_get_ptr(a), heim_data_get_ptr(b),
+                      heim_data_get_length(a)) == 0;
+    }
+    case HEIM_TID_NUMBER:
+        return heim_number_get_long(a) == heim_number_get_long(b);
+    case HEIM_TID_NULL:
+    case HEIM_TID_BOOL:
+        return heim_bool_val(a) == heim_bool_val(b);
+    default:
+        break;
+    }
+    return 0;
 }

--- a/lib/base/string.c
+++ b/lib/base/string.c
@@ -153,7 +153,8 @@ heim_string_create_with_bytes(const void *data, size_t len)
 
     s = _heim_alloc_object(&_heim_string_object, len + 1);
     if (s) {
-	memcpy(s, data, len);
+        if (len)
+            memcpy(s, data, len);
 	((char *)s)[len] = '\0';
     }
     return s;

--- a/lib/base/string.c
+++ b/lib/base/string.c
@@ -239,7 +239,7 @@ heim_string_t
 __heim_string_constant(const char *_str)
 {
     static HEIMDAL_MUTEX mutex = HEIMDAL_MUTEX_INITIALIZER;
-    static heim_base_once_t once;
+    static heim_base_once_t once = HEIM_BASE_ONCE_INIT;
     static heim_dict_t dict = NULL;
     heim_string_t s, s2;
 

--- a/lib/base/test_base.c
+++ b/lib/base/test_base.c
@@ -244,26 +244,266 @@ test_json(void)
     };
     char *s;
     size_t i, k;
-    heim_object_t o, o2;
+    heim_object_t o, o2, o3;
     heim_string_t k1 = heim_string_create("k1");
 
     o = heim_json_create("\"string\"", 10, 0, NULL);
     heim_assert(o != NULL, "string");
     heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
     heim_assert(strcmp("string", heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
     heim_release(o);
 
+    /*
+     * Test string escaping:
+     *
+     *  - C-like must-escapes
+     *  - ASCII control character must-escapes
+     *  - surrogate pairs
+     *
+     * We test round-tripping.  First we parse, then we serialize, then parse,
+     * then compare the second parse to the first for equality.
+     *
+     * We do compare serialized forms in spite of their not being canonical.
+     * That means that some changes to serialization can cause failures here.
+     */
+    o = heim_json_create("\""
+        "\\b\\f\\n\\r\\t"   /* ASCII C-like escapes */
+        "\x1e"              /* ASCII control character w/o C-like escape */
+        "\\u00e1"           /* &aacute; */
+        "\\u07ff"
+        "\\u0801"
+        "\\u8001"
+        "\\uD834\\udd1e"    /* U+1D11E, as shown in RFC 7159 */
+        "\"", 10, 0, NULL);
+    heim_assert(o != NULL, "string");
+    heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
+    heim_assert(strcmp(
+        "\b\f\n\r\t"
+        "\x1e"
+        "\xc3\xa1"
+        "\xdf\xbf"
+        "\xe0\xA0\x81"
+        "\xe8\x80\x81"
+        "\xf0\x9d\x84\x9e", heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(strcmp("\"\\b\\f\\n\\r\\t\\u001Eá߿ࠁ老\\uD834\\uDD1E\"",
+                       heim_string_get_utf8(o2)) == 0,
+                "JSON encoding changed; please check that it is till valid");
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
+    heim_release(o);
+
+    o = heim_json_create("\""
+        "\\b\\f\\n\\r\\t"   /* ASCII C-like escapes */
+        "\x1e"              /* ASCII control character w/o C-like escape */
+        "\xc3\xa1"
+        "\xdf\xbf"
+        "\xe0\xa0\x81"
+        "\xE8\x80\x81"
+        "\\uD834\\udd1e"    /* U+1D11E, as shown in RFC 7159 */
+        "\"", 10, 0, NULL);
+    heim_assert(o != NULL, "string");
+    heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
+    heim_assert(strcmp(
+        "\b\f\n\r\t"
+        "\x1e"
+        "\xc3\xa1"
+        "\xdf\xbf"
+        "\xe0\xA0\x81"
+        "\xe8\x80\x81"
+        "\xf0\x9d\x84\x9e", heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(strcmp("\"\\b\\f\\n\\r\\t\\u001Eá߿ࠁ老\\uD834\\uDD1E\"",
+                       heim_string_get_utf8(o2)) == 0,
+                "JSON encoding changed; please check that it is till valid");
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
+    heim_release(o);
+
+    /* Test rejection of unescaped ASCII control characters */
+    o = heim_json_create("\"\b\\f\"", 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o == NULL, "strict parse accepted bad input");
+    o = heim_json_create("\"\b\x1e\"", 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o == NULL, "strict parse accepted bad input");
+
+    o = heim_json_create("\"\b\\f\"", 10, 0, NULL);
+    heim_assert(o != NULL, "string");
+    heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
+    heim_assert(strcmp("\b\f", heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(strcmp("\"\\b\\f\"", heim_string_get_utf8(o2)) == 0,
+                "JSON encoding changed; please check that it is till valid");
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
+    heim_release(o);
+
+    /* Test bogus backslash escape */
+    o = heim_json_create("\""
+        "\\ "
+        "\"", 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o == NULL, "malformed string accepted");
+    o = heim_json_create("\""
+        "\\ "
+        "\"", 10, 0, NULL);
+    heim_assert(o != NULL, "malformed string rejected (not strict)");
+    heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
+    heim_assert(strcmp(" ", heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(strcmp("\" \"", heim_string_get_utf8(o2)) == 0,
+                "JSON encoding changed; please check that it is till valid");
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
+    heim_release(o);
+
+    /* Test truncated surrogate encoding (bottom code unit) */
+    o = heim_json_create("\""
+        "\xE8\x80\x81"
+        "\\uD834\\udd"
+        "\"", 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o == NULL, "malformed string accepted");
+    o = heim_json_create("\""
+        "\xE8\x80\x81"
+        "\\uD834\\udd"
+        "\"", 10, 0, NULL);
+    heim_assert(o != NULL, "malformed string rejected (not strict)");
+    heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
+    heim_assert(strcmp(
+        "\xe8\x80\x81"
+        "\\uD834\\udd", heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(strcmp("\"老\\\\uD834\\\\udd\"",
+                       heim_string_get_utf8(o2)) == 0,
+                "JSON encoding changed; please check that it is till valid");
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
+    heim_release(o);
+
+    /* Test truncated surrogate encodings (top code unit) */
+    o = heim_json_create("\""
+        "\xE8\x80\x81"
+        "\\uD83"
+        "\"", 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o == NULL, "malformed string accepted");
+    o = heim_json_create("\""
+        "\xE8\x80\x81"
+        "\\uD83"
+        "\"", 10, 0, NULL);
+    heim_assert(o != NULL, "malformed string rejected (not strict)");
+    heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
+    heim_assert(strcmp(
+        "\xe8\x80\x81"
+        "\\uD83", heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(strcmp("\"老\\\\uD83\"",
+                       heim_string_get_utf8(o2)) == 0,
+                "JSON encoding changed; please check that it is till valid");
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
+    heim_release(o);
+
+    /*
+     * Test handling of truncated UTF-8 multi-byte sequences.
+     */
+    o = heim_json_create("\""
+        "\xE8\x80"
+        "\"", 10, 0, NULL);
+    heim_assert(o != NULL, "malformed string rejected (not strict)");
+    heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
+    heim_assert(strcmp("\xe8\x80",
+                       heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o2 == NULL, "malformed string serialized");
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o3 == NULL, "malformed string accepted (not strict)");
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(strcmp("\xe8\x80",
+                       heim_string_get_utf8(o3)) == 0, "wrong string");
+    heim_release(o3);
+    heim_release(o2);
+    heim_release(o);
+
+    /* Test handling of unescaped / embedded newline */
+    o = heim_json_create("\"\n\"", 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o == NULL, "malformed string accepted (strict)");
+    o = heim_json_create("\"\n\"", 10, 0, NULL);
+    heim_assert(o != NULL, "malformed string rejected (not strict)");
+    heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
+    heim_assert(strcmp("\n", heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o2 != NULL, "string not serialized");
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o3 != NULL, "string not accepted");
+    heim_assert(strcmp("\n", heim_string_get_utf8(o3)) == 0, "wrong string");
+    heim_release(o3);
+    heim_release(o2);
+    heim_release(o);
+
+    /* Test handling of embedded NULs (must decode as data, not string) */
+    o = heim_json_create("\"\\u0000\"", 10, HEIM_JSON_F_STRICT, NULL);
+    heim_assert(o != NULL, "string with NULs rejected");
+    heim_assert(heim_get_tid(o) == heim_data_get_type_id(), "data-tid");
+    heim_assert(heim_data_get_length(o) == 1, "wrong data length");
+    heim_assert(((const char *)heim_data_get_ptr(o))[0] == '\0',
+                "wrong data NUL");
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    heim_assert(o2 != NULL, "data not serialized");
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10,
+                          HEIM_JSON_F_TRY_DECODE_DATA, NULL);
+    heim_assert(o3 != NULL, "data not accepted");
+    heim_assert(heim_data_get_length(o3) == 1, "wrong data length");
+    heim_assert(((const char *)heim_data_get_ptr(o3))[0] == '\0',
+                "wrong data NUL");
+    heim_release(o3);
+    heim_release(o2);
+    heim_release(o);
+
+    /*
+     * Note that the trailing ']' is not part of the JSON text (which is just a
+     * string).
+     */
     o = heim_json_create(" \"foo\\\"bar\" ]", 10, 0, NULL);
     heim_assert(o != NULL, "string");
     heim_assert(heim_get_tid(o) == heim_string_get_type_id(), "string-tid");
     heim_assert(strcmp("foo\"bar", heim_string_get_utf8(o)) == 0, "wrong string");
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
     heim_release(o);
 
     o = heim_json_create(" { \"key\" : \"value\" }", 10, 0, NULL);
     heim_assert(o != NULL, "dict");
     heim_assert(heim_get_tid(o) == heim_dict_get_type_id(), "dict-tid");
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
     heim_release(o);
 
+    /*
+     * heim_json_eq() can't handle dicts with dicts as keys, so we don't check
+     * for round-tripping here
+     */
     o = heim_json_create("{ { \"k1\" : \"s1\", \"k2\" : \"s2\" } : \"s3\", "
 			 "{ \"k3\" : \"s4\" } : -1 }", 10, 0, NULL);
     heim_assert(o != NULL, "dict");
@@ -281,6 +521,11 @@ test_json(void)
     o2 = heim_dict_copy_value(o, k1);
     heim_assert(heim_get_tid(o2) == heim_string_get_type_id(), "string-tid");
     heim_release(o2);
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
     heim_release(o);
 
     o = heim_json_create(" { \"k1\" : { \"k2\" : \"s2\" } }", 10, 0, NULL);
@@ -288,6 +533,11 @@ test_json(void)
     heim_assert(heim_get_tid(o) == heim_dict_get_type_id(), "dict-tid");
     o2 = heim_dict_copy_value(o, k1);
     heim_assert(heim_get_tid(o2) == heim_dict_get_type_id(), "dict-tid");
+    heim_release(o2);
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
     heim_release(o2);
     heim_release(o);
 
@@ -297,26 +547,51 @@ test_json(void)
     o2 = heim_dict_copy_value(o, k1);
     heim_assert(heim_get_tid(o2) == heim_number_get_type_id(), "number-tid");
     heim_release(o2);
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
     heim_release(o);
 
     o = heim_json_create("-10", 10, 0, NULL);
     heim_assert(o != NULL, "number");
     heim_assert(heim_get_tid(o) == heim_number_get_type_id(), "number-tid");
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
     heim_release(o);
 
     o = heim_json_create("99", 10, 0, NULL);
     heim_assert(o != NULL, "number");
     heim_assert(heim_get_tid(o) == heim_number_get_type_id(), "number-tid");
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
     heim_release(o);
 
     o = heim_json_create(" [ 1 ]", 10, 0, NULL);
     heim_assert(o != NULL, "array");
     heim_assert(heim_get_tid(o) == heim_array_get_type_id(), "array-tid");
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
     heim_release(o);
 
     o = heim_json_create(" [ -1 ]", 10, 0, NULL);
     heim_assert(o != NULL, "array");
     heim_assert(heim_get_tid(o) == heim_array_get_type_id(), "array-tid");
+    o2 = heim_json_copy_serialize(o, 0, NULL);
+    o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+    heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+    heim_release(o3);
+    heim_release(o2);
     heim_release(o);
 
     for (i = 0; i < (sizeof (j) / sizeof (j[0])); i++) {
@@ -325,6 +600,11 @@ test_json(void)
 	    fprintf(stderr, "Failed to parse this JSON: %s\n", j[i]);
 	    return 1;
 	}
+        o2 = heim_json_copy_serialize(o, 0, NULL);
+        o3 = heim_json_create(heim_string_get_utf8(o2), 10, 0, NULL);
+        heim_assert(heim_json_eq(o, o3), "JSON text did not round-trip");
+        heim_release(o3);
+        heim_release(o2);
 	heim_release(o);
 	/* Simple fuzz test */
 	for (k = strlen(j[i]) - 1; k > 0; k--) {

--- a/lib/base/test_base.c
+++ b/lib/base/test_base.c
@@ -525,13 +525,6 @@ test_json(void)
                 "wrong data NUL");
     o2 = heim_json_copy_serialize(o, 0, NULL);
     heim_assert(o2 != NULL, "data not serialized");
-    o3 = heim_json_create(heim_string_get_utf8(o2), 10,
-                          HEIM_JSON_F_TRY_DECODE_DATA, NULL);
-    heim_assert(o3 != NULL, "data not accepted");
-    heim_assert(heim_data_get_length(o3) == 1, "wrong data length");
-    heim_assert(((const char *)heim_data_get_ptr(o3))[0] == '\0',
-                "wrong data NUL");
-    heim_release(o3);
     heim_release(o2);
     heim_release(o);
 

--- a/lib/base/version-script.map
+++ b/lib/base/version-script.map
@@ -148,6 +148,7 @@ HEIMDAL_BASE_1.0 {
 		heim_json_create_with_bytes;
 		heim_json_eq;
 		heim_load_plugins;
+		heim_locale_is_utf8;
 		heim_log;
 		heim_log_msg;
 		_heim_make_permanent;

--- a/lib/base/version-script.map
+++ b/lib/base/version-script.map
@@ -146,6 +146,7 @@ HEIMDAL_BASE_1.0 {
 		heim_json_copy_serialize;
 		heim_json_create;
 		heim_json_create_with_bytes;
+		heim_json_eq;
 		heim_load_plugins;
 		heim_log;
 		heim_log_msg;

--- a/lib/kadm5/iprop.8
+++ b/lib/kadm5/iprop.8
@@ -68,6 +68,8 @@
 .Oo Fl r Ar string \*(Ba Xo Fl Fl realm= Ns Ar string Xc Oc
 .Oo Fl d Ar file \*(Ba Xo Fl Fl database= Ns Ar file Xc Oc
 .Oo Fl k Ar kspec \*(Ba Xo Fl Fl keytab= Ns Ar kspec Xc Oc
+.Oo Xo Fl Fl no-keytab Xc Oc
+.Oo Xo Fl Fl cache= Ns Ar cspec Xc Oc
 .Op Fl Fl statusfile= Ns Ar file
 .Op Fl Fl hostname= Ns Ar hostname
 .Op Fl Fl port= Ns Ar port
@@ -125,10 +127,40 @@ This should normally be defined as
 in
 .Pa /etc/services
 or another source of the services database.
-The master and slaves
-must each have access to a keytab with keys for the
-.Nm iprop
-service principal on the local host.
+.Pp
+The
+.Nm ipropd-master
+and
+.Nm ipropd-slave
+programs require acceptor and initiator credentials,
+respectively, for host-based principals for the
+.Ar iprop
+service and the fully-qualified hostnames of the hosts on which
+they run.
+.Pp
+The
+.Nm ipropd-master
+program uses, by default, the HDB-backed keytab
+.Ar HDBGET: ,
+though a file-based keytab can also be specified.
+.Pp
+The
+.Nm ipropd-slave
+program uses the default keytab, which is specified by the
+.Ev KRB5_KTNAME
+environment variable, or the value of the
+.Ar default_keytab_name
+configuration parameter in the
+.Ar [libdefaults]
+section.
+However, if the
+.Fl Fl no-keytab
+option is given, then
+.Nm ipropd-slave
+will use the given or default credentials cache, and it will
+expect that cache to be kept fresh externally (such as by the
+.Nm kinit
+program).
 .Pp
 There is a keep-alive feature logged in the master's
 .Pa slave-stats
@@ -150,6 +182,11 @@ Supported options for
 Keytab for authenticating
 .Nm ipropd-slave
 clients.
+.It Fl Fl cache= Ns Ar cspec
+If the keytab given is the empty string then credentials will be
+used from the default credentials cache, or from the
+.Ar cspec
+if given.
 .It Fl d Ar file , Fl Fl database= Ns Ar file
 Database (default per KDC)
 .It Fl Fl slave-stats-file= Ns Ar file
@@ -201,6 +238,7 @@ in the database directory, or in the directory named by the
 .Ev HEIM_PIDFILE_DIR
 environment variable.
 .Sh SEE ALSO
+.Xr kinit 1 ,
 .Xr krb5.conf 5 ,
 .Xr hprop 8 ,
 .Xr hpropd 8 ,

--- a/lib/krb5/keytab.c
+++ b/lib/krb5/keytab.c
@@ -883,7 +883,8 @@ krb5_kt_add_entry(krb5_context context,
 			       id->prefix);
 	return KRB5_KT_NOWRITE;
     }
-    entry->timestamp = time(NULL);
+    if (entry->timestamp == 0)
+        entry->timestamp = time(NULL);
     return (*id->add)(context, id,entry);
 }
 

--- a/tests/kdc/check-bx509.in
+++ b/tests/kdc/check-bx509.in
@@ -42,18 +42,21 @@ testfailed="echo test failed; cat messages.log; exit 1"
 # If there is no useful db support compiled in, disable test
 ${have_db} || exit 77
 
+umask 077
+
 R=TEST.H5L.SE
 DCs="DC=test,DC=h5l,DC=se"
 
 port=@port@
 bx509port=@bx509port@
 
-kadmin="${kadmin} -l -r $R"
-bx509d="${bx509d} --reverse-proxied -p $bx509port"
-kdc="${kdc} --addresses=localhost -P $port"
-
 server=datan.test.h5l.se
 otherserver=other.test.h5l.se
+
+kadmin="${kadmin} -l -r $R"
+bx509d="${bx509d} --allow-GET --reverse-proxied -p $bx509port -H $server --cert=${objdir}/bx509.pem -t"
+kdc="${kdc} --addresses=localhost -P $port"
+
 cachefile="${objdir}/cache.krb5"
 cache="FILE:${cachefile}"
 cachefile2="${objdir}/cache2.krb5"
@@ -129,6 +132,55 @@ get_cert() {
     curl -g --resolve ${server}:${bx509port}:127.0.0.1                  \
          -H "Authorization: Negotiate $token"                           \
          "$@" "$url"
+}
+
+get_with_token() {
+    if [ -n "$csr" ]; then
+        url="http://${server}:${bx509port}/${1}?csr=$csr${2}"
+    else
+        url="http://${server}:${bx509port}/${1}?${2}"
+    fi
+    shift 2
+
+    curl -fg --resolve ${server}:${bx509port}:127.0.0.1                 \
+         -H "Authorization: Negotiate $token"                           \
+         -D response-headers                                            \
+         "$@" "$url"                                                    &&
+        { echo "GET w/o CSRF token succeeded!"; exit 2; }
+    curl -g --resolve ${server}:${bx509port}:127.0.0.1                  \
+         -H "Authorization: Negotiate $token"                           \
+         -D response-headers                                            \
+         "$@" "$url"
+    grep ^X-CSRF-Token: response-headers >/dev/null ||
+        { echo "GET w/o CSRF token did not output a CSRF token!"; exit 2; }
+    curl -fg --resolve ${server}:${bx509port}:127.0.0.1                 \
+         -H "Authorization: Negotiate $token"                           \
+         -H "$(sed -e 's/\r//' response-headers | grep ^X-CSRF-Token:)" \
+         "$@" "$url"                                                    ||
+        { echo "GET w/ CSRF failed"; exit 2; }
+}
+
+get_via_POST() {
+    endpoint=$1
+    shift
+
+    curl -fg --resolve ${server}:${bx509port}:127.0.0.1                 \
+         -H "Authorization: Negotiate $token"                           \
+         -X POST -D response-headers                                    \
+         "$@" "http://${server}:${bx509port}/${endpoint}" &&
+        { echo "POST w/o CSRF token succeeded!"; exit 2; }
+    curl -g --resolve ${server}:${bx509port}:127.0.0.1                  \
+         -H "Authorization: Negotiate $token"                           \
+         -X POST -D response-headers                                    \
+         "$@" "http://${server}:${bx509port}/${endpoint}"
+    grep ^X-CSRF-Token: response-headers >/dev/null ||
+        { echo "POST w/o CSRF token did not output a CSRF token!"; exit 2; }
+    curl -fg --resolve ${server}:${bx509port}:127.0.0.1                 \
+         -H "Authorization: Negotiate $token"                           \
+         -H "$(sed -e 's/\r//' response-headers | grep ^X-CSRF-Token:)" \
+         -X POST                                                        \
+         "$@" "http://${server}:${bx509port}/${endpoint}" ||
+        { echo "POST w/ CSRF failed"; exit 2; }
 }
 
 rm -f $kt $ukt
@@ -292,15 +344,15 @@ ${kadmin} init \
     ${R} || exit 1
 ${kadmin} add -r --use-defaults foo@${R} || exit 1
 ${kadmin} add -r --use-defaults bar@${R} || exit 1
+${kadmin} add -r --use-defaults baz@${R} || exit 1
 ${kadmin} modify --pkinit-acl="CN=foo,DC=test,DC=h5l,DC=se" foo@${R} || exit 1
 
 
 echo "Starting bx509d"
-${bx509d} -H $server --cert=${objdir}/bx509.pem -t --daemon ||
-    { echo "bx509 failed to start"; exit 2; }
+${bx509d} --daemon || { echo "bx509 failed to start"; exit 2; }
 bx509pid=`getpid bx509d`
 
-trap "kill -9 ${bx509pid}; echo signal killing bx509d; exit 1;" EXIT
+trap 'kill -9 ${bx509pid}; echo signal killing bx509d; exit 1;' EXIT
 ec=0
 
 rm -f trivial.pem server.pem email.pem
@@ -310,14 +362,64 @@ csr_revoke
 $hxtool request-create  --subject='' --generate-key=rsa --key-bits=1024 \
                         --key=FILE:"${objdir}/k.der" "${objdir}/req" ||
     { echo "Failed to make a CSR"; exit 2; }
-csr=$($rkbase64 -- ${objdir}/req | $rkvis -h --stdin)
 
 # XXX Add autoconf check for curl?
 #     Create a barebones bx509 HTTP/1.1 client test program?
 
+echo "Fetching a trivial user certificate (no authentication, must fail)"
+# Encode the CSR in base64, then URL-encode it
+csr=$($rkbase64 -- ${objdir}/req | $rkvis -h --stdin)
+if (set -vx;
+    curl -g --resolve ${server}:${bx509port}:127.0.0.1                  \
+         -sf -o "${objdir}/trivial.pem"                                 \
+         "http://${server}:${bx509port}/bx509?csr=$csr"); then
+    $hxtool print --content "FILE:${objdir}/trivial.pem"
+    echo 'Got a certificate without authenticating!'
+    exit 1
+fi
+
 echo "Fetching a trivial user certificate"
+# Encode the CSR in base64, then URL-encode it
+csr=$($rkbase64 -- ${objdir}/req | $rkvis -h --stdin)
 token=$(KRB5CCNAME=$cache $gsstoken HTTP@$server)
 if (set -vx; get_cert '' -sf -o "${objdir}/trivial.pem"); then
+    $hxtool print --content "FILE:${objdir}/trivial.pem"
+    if $hxtool acert --end-entity                                            \
+                    --expr="%{certificate.subject} == \"CN=foo,$DCs\""  \
+                    -P "foo@${R}" "FILE:${objdir}/trivial.pem"; then
+        echo 'Successfully obtained a trivial client certificate!'
+    else
+        echo 'FAIL: Obtained a trivial client certificate w/o expected PKINIT SAN)'
+        exit 1
+    fi
+    if $hxtool acert --expr="%{certificate.subject} == \"OU=Users,$DCs\""   \
+                     --has-private-key "FILE:${objdir}/trivial.pem"; then
+        echo 'Successfully obtained a trivial client certificate!'
+    fi
+else
+    echo 'Failed to get a certificate!'
+    exit 1
+fi
+
+echo "Fetching a trivial user certificate (with POST, no auth, must fail)"
+# Encode the CSR in base64; curl will URL-encode it for us
+csr=$($rkbase64 -- ${objdir}/req)
+if (set -vx;
+    curl -fg --resolve ${server}:${bx509port}:127.0.0.1                 \
+         -X POST -D response-headers                                    \
+         -F csr="$csr" -o "${objdir}/trivial.pem"                       \
+         "http://${server}:${bx509port}/bx509" ); then
+    $hxtool print --content "FILE:${objdir}/trivial.pem"
+    echo 'Got a certificate without authenticating!'
+    exit 1
+fi
+
+echo "Fetching a trivial user certificate (with POST)"
+# Encode the CSR in base64; curl will URL-encode it for us
+csr=$($rkbase64 -- ${objdir}/req)
+token=$(KRB5CCNAME=$cache $gsstoken HTTP@$server)
+if (set -vx;
+    get_via_POST bx509 -F csr="$csr" -o "${objdir}/trivial.pem"); then
     $hxtool print --content "FILE:${objdir}/trivial.pem"
     if $hxtool acert --end-entity                                            \
                     --expr="%{certificate.subject} == \"CN=foo,$DCs\""  \
@@ -430,10 +532,10 @@ ${kadmin} ext_keytab -r -k $ukeytab foo@${R} || exit 1
 echo "Starting kdc";
 ${kdc} --detach --testing || { echo "kdc failed to start"; cat messages.log; exit 1; }
 kdcpid=`getpid kdc`
-trap "kill -9 ${kdcpid} ${bx509pid}; echo signal killing kdc and bx509d; exit 1;" EXIT
+trap 'kill -9 ${kdcpid} ${bx509pid}; echo signal killing kdc and bx509d; exit 1;' EXIT
 
 ${kinit} -kt $ukeytab foo@${R} || exit 1
-$klist || { echo "failed to setup kimpersonate credentials"; exit 2; }
+$klist || { echo "failed to kinit"; exit 2; }
 
 echo "Fetch TGT (not granted for other)"
 token=$(KRB5CCNAME=$cache $gsstoken HTTP@$server)
@@ -474,7 +576,7 @@ if ! (set -vx;
     exit 2
 fi
 ${kgetcred} -H HTTP/${server}@${R} ||
-    { echo "Trivial offline CA test failed (TGS)"; exit 2; }
+    { echo "Fetched TGT didn't work"; exit 2; }
 ${klist} | grep Addresses:.IPv4:8.8.8.8 ||
     { echo "Failed to get a TGT with /get-tgt end-point with addresses"; exit 2; }
 
@@ -491,7 +593,7 @@ if ! (set -vx;
     exit 2
 fi
 ${kgetcred} -H HTTP/${server}@${R} ||
-    { echo "Trivial offline CA test failed (TGS)"; exit 2; }
+    { echo "Fetched TGT didn't work"; exit 2; }
 ${klist} | grep Addresses:.IPv4:8.8.8.8 ||
     { echo "Failed to get a TGT with /get-tgt end-point with addresses"; exit 2; }
 
@@ -509,7 +611,7 @@ if ! (set -vx;
     exit 2
 fi
 ${kgetcred} -H HTTP/${server}@${R} ||
-    { echo "Trivial offline CA test failed (TGS)"; exit 2; }
+    { echo "Fetched TGT didn't work"; exit 2; }
 if which jq >/dev/null; then
     if ! ${klistjson} | jq -e '
             (reduce (.tickets[0]|(.Issued,.Expires)|
@@ -535,7 +637,7 @@ if ! (set -vx;
     exit 2
 fi
 ${kgetcred} -H HTTP/${server}@${R} ||
-    { echo "Trivial offline CA test failed (TGS)"; exit 2; }
+    { echo "Fetched TGT didn't work"; exit 2; }
 if which jq >/dev/null; then
     if ! ${klistjson} | jq -e '
             (reduce (.tickets[0]|(.Issued,.Expires)|
@@ -561,7 +663,7 @@ if ! (set -vx;
     exit 2
 fi
 ${kgetcred} -H HTTP/${server}@${R} ||
-    { echo "Trivial offline CA test failed (TGS)"; exit 2; }
+    { echo "Fetched TGT didn't work"; exit 2; }
 if which jq >/dev/null; then
     if ! ${klistjson} | jq -e '
             (reduce (.tickets[0]|(.Issued,.Expires)|
@@ -571,6 +673,153 @@ if which jq >/dev/null; then
         echo "Failed to get a TGT with /get-tgt end-point with addresses"
         exit 2
     fi
+fi
+
+echo "Fetch TGTs (batch, authz fail)"
+${kadmin} modify --max-ticket-life=10d krbtgt/${R}@${R}
+(set -vx; csr_grant pkinit bar@${R} foo@${R})
+${kdestroy}
+token=$(KRB5CCNAME=$cache2 $gsstoken HTTP@$server)
+if (set -vx;
+    curl -o "${cachefile}.json" -Lgsf                                   \
+         --resolve ${server}:${bx509port}:127.0.0.1                     \
+         -H "Authorization: Negotiate $token"                           \
+         "http://${server}:${bx509port}/get-tgts?cname=bar@${R}&cname=baz@${R}"); then
+    echo "Got TGTs with /get-tgts end-point that should have been denied"
+    exit 2
+fi
+
+echo "Fetch TGTs (batch, authz pass)"
+${kadmin} modify --max-ticket-life=10d krbtgt/${R}@${R}
+(csr_grant pkinit bar@${R} foo@${R})
+(csr_grant pkinit baz@${R} foo@${R})
+${kdestroy}
+token=$(KRB5CCNAME=$cache2 $gsstoken HTTP@$server)
+if ! (set -vx;
+    curl -vvvo "${cachefile}.json" -Lgsf                                \
+         --resolve ${server}:${bx509port}:127.0.0.1                     \
+         -H "Authorization: Negotiate $token"                           \
+         "http://${server}:${bx509port}/get-tgts?cname=bar@${R}&cname=baz@${R}"); then
+    echo "Failed to get TGTs batch"
+    exit 2
+fi
+if which jq >/dev/null; then
+    jq -e . "${cachefile}.json" > /dev/null ||
+        { echo "/get-tgts produced non-JSON"; exit 2; }
+
+    # Check bar@$R's tickets:
+    jq -r 'select(.name|startswith("bar@")).ccache' "${cachefile}.json" |
+        $rkbase64 -d -- - > "${cachefile}"
+    ${kgetcred} -H HTTP/${server}@${R} ||
+        { echo "Fetched TGT didn't work"; exit 2; }
+    ${klistjson} | jq -e --arg p bar@$R '.principal == $p' > /dev/null ||
+        { echo "/get-tgts produced wrong TGTs"; exit 2; }
+
+    # Check baz@$R's tickets:
+    jq -r 'select(.name|startswith("baz@")).ccache' "${cachefile}.json" |
+        $rkbase64 -d -- - > "${cachefile}"
+    ${kgetcred} -H HTTP/${server}@${R} ||
+        { echo "Fetched TGT didn't work"; exit 2; }
+    ${klistjson} | jq -e --arg p baz@$R '.principal == $p' > /dev/null ||
+        { echo "/get-tgts produced wrong TGTs"; exit 2; }
+fi
+
+echo "Fetch TGTs (batch, authz pass, one non-existent principal)"
+${kadmin} modify --max-ticket-life=10d krbtgt/${R}@${R}
+(csr_grant pkinit bar@${R} foo@${R})
+(csr_grant pkinit baz@${R} foo@${R})
+(csr_grant pkinit not@${R} foo@${R})
+${kdestroy}
+token=$(KRB5CCNAME=$cache2 $gsstoken HTTP@$server)
+if ! (set -vx;
+    curl -vvvo "${cachefile}.json" -Lgsf                                \
+         --resolve ${server}:${bx509port}:127.0.0.1                     \
+         -H "Authorization: Negotiate $token"                           \
+         "http://${server}:${bx509port}/get-tgts?cname=not@${R}&cname=bar@${R}&cname=baz@${R}"); then
+    echo "Failed to get TGTs batch including non-existent principal"
+    exit 2
+fi
+if which jq >/dev/null; then
+    set -vx
+    jq -e . "${cachefile}.json" > /dev/null ||
+        { echo "/get-tgts produced non-JSON"; exit 2; }
+    jq -es '.[]|select(.name|startswith("not@"))|(.error_code//empty)' "${cachefile}.json" > /dev/null ||
+        { echo "No error was reported for not@${R}!"; exit 2; }
+
+    # Check bar@$R's tickets:
+    jq -r 'select(.name|startswith("bar@")).ccache' "${cachefile}.json" |
+        $rkbase64 -d -- - > "${cachefile}"
+    ${kgetcred} -H HTTP/${server}@${R} ||
+        { echo "Fetched TGT didn't work"; exit 2; }
+    ${klistjson} | jq -e --arg p bar@$R '.principal == $p' > /dev/null ||
+        { echo "/get-tgts produced wrong TGTs"; exit 2; }
+
+    # Check baz@$R's tickets:
+    jq -r 'select(.name|startswith("baz@")).ccache' "${cachefile}.json" |
+        $rkbase64 -d -- - > "${cachefile}"
+    ${kgetcred} -H HTTP/${server}@${R} ||
+        { echo "Fetched TGT didn't work"; exit 2; }
+    ${klistjson} | jq -e --arg p baz@$R '.principal == $p' > /dev/null ||
+        { echo "/get-tgts produced wrong TGTs"; exit 2; }
+fi
+
+echo "killing bx509d (${bx509pid})"
+sh ${leaks_kill} bx509d $bx509pid || ec=1
+
+echo "Starting bx509d (csrf-protection-type=GET-with-token, POST-with-header)"
+${bx509d} --csrf-protection-type=GET-with-token \
+          --csrf-protection-type=POST-with-header --daemon || {
+    echo "bx509 failed to start"
+    exit 2
+}
+bx509pid=`getpid bx509d`
+
+${kinit} -kt $ukeytab foo@${R} || exit 1
+$klist || { echo "failed to kinit"; exit 2; }
+
+echo "Fetching a trivial user certificate (GET with CSRF token)"
+csr=$($rkbase64 -- ${objdir}/req | $rkvis -h --stdin)
+token=$(KRB5CCNAME=$cache $gsstoken HTTP@$server)
+if (set -vx; get_with_token get-cert '' -o "${objdir}/trivial.pem"); then
+    $hxtool print --content "FILE:${objdir}/trivial.pem"
+    if $hxtool acert --end-entity                                            \
+                    --expr="%{certificate.subject} == \"CN=foo,$DCs\""  \
+                    -P "foo@${R}" "FILE:${objdir}/trivial.pem"; then
+        echo 'Successfully obtained a trivial client certificate!'
+    else
+        echo 'FAIL: Obtained a trivial client certificate w/o expected PKINIT SAN)'
+        exit 1
+    fi
+    if $hxtool acert --expr="%{certificate.subject} == \"OU=Users,$DCs\""   \
+                     --has-private-key "FILE:${objdir}/trivial.pem"; then
+        echo 'Successfully obtained a trivial client certificate!'
+    fi
+else
+    echo 'Failed to get a certificate!'
+    exit 1
+fi
+
+echo "Fetching a trivial user certificate (POST with X-CSRF header, no token)"
+# Encode the CSR in base64, then URL-encode it
+csr=$($rkbase64 -- ${objdir}/req | $rkvis -h --stdin)
+token=$(KRB5CCNAME=$cache $gsstoken HTTP@$server)
+if (set -vx; get_cert '' -H 'X-CSRF: junk' -X POST -sf -o "${objdir}/trivial.pem"); then
+    $hxtool print --content "FILE:${objdir}/trivial.pem"
+    if $hxtool acert --end-entity                                            \
+                    --expr="%{certificate.subject} == \"CN=foo,$DCs\""  \
+                    -P "foo@${R}" "FILE:${objdir}/trivial.pem"; then
+        echo 'Successfully obtained a trivial client certificate!'
+    else
+        echo 'FAIL: Obtained a trivial client certificate w/o expected PKINIT SAN)'
+        exit 1
+    fi
+    if $hxtool acert --expr="%{certificate.subject} == \"OU=Users,$DCs\""   \
+                     --has-private-key "FILE:${objdir}/trivial.pem"; then
+        echo 'Successfully obtained a trivial client certificate!'
+    fi
+else
+    echo 'Failed to get a certificate!'
+    exit 1
 fi
 
 echo "Fetch negotiate token (pre-test)"
@@ -596,11 +845,9 @@ grep 'REQ.*wrongaddr=true' ${objdir}/messages.log |
 
 echo "Fetching a Negotiate token"
 token=$(KRB5CCNAME=$cache $gsstoken HTTP@$server)
+csr=
 if (set -vx;
-    curl -o negotiate-token -Lgsf                                       \
-         --resolve ${server}:${bx509port}:127.0.0.1                     \
-         -H "Authorization: Negotiate $token"                           \
-         "http://${server}:${bx509port}/bnegotiate?target=HTTP%40${server}"); then
+    get_with_token get-negotiate-token "target=HTTP%40${server}" -o "${objdir}/negotiate-token"); then
     # bx509 sends us a token w/o a newline for now; we add one because
     # gss-token expects it.
     test -s negotiate-token && echo >> negotiate-token

--- a/tests/kdc/check-httpkadmind.in
+++ b/tests/kdc/check-httpkadmind.in
@@ -697,7 +697,7 @@ ${hxtool} issue-certificate \
           --lifetime=7d \
           --certificate="FILE:pkinit-synthetic.crt" ||
          { echo "Failed to make PKINIT client cert"; exit 1; }
-KRB5CCNAME=$admincache ${kadmin} get -s $p >/dev/null &&
+KRB5CCNAME=$admincache ${kadmin} get -s $p >/dev/null 2>&1 &&
     { echo "Internal error -- $p exists too soon"; exit 1; }
 ${kinit2} -C "FILE:${objdir}/pkinit-synthetic.crt,${keyfile2}" ${p}@${R} || \
     { echo "Failed to kinit with PKINIT client cert"; exit 1; }
@@ -727,7 +727,7 @@ ${hxtool} issue-certificate \
           --lifetime=7d \
           --certificate="FILE:pkinit-synthetic.crt" ||
          { echo "Failed to make PKINIT client cert"; exit 1; }
-KRB5CCNAME=$admincache ${kadmin} get -s $p >/dev/null &&
+KRB5CCNAME=$admincache ${kadmin} get -s $p >/dev/null 2>&1 &&
     { echo "Internal error -- $p exists too soon"; exit 1; }
 ${kinit2} -C "FILE:${objdir}/pkinit-synthetic.crt,${keyfile2}" ${p}@${R} || \
     { echo "Failed to kinit with PKINIT client cert"; exit 1; }
@@ -757,7 +757,7 @@ ${hxtool} issue-certificate \
           --lifetime=7d \
           --certificate="FILE:pkinit-synthetic.crt" ||
          { echo "Failed to make PKINIT client cert"; exit 1; }
-KRB5CCNAME=$admincache ${kadmin} get -s $p >/dev/null &&
+KRB5CCNAME=$admincache ${kadmin} get -s $p >/dev/null 2>&1 &&
     { echo "Internal error -- $p exists too soon"; exit 1; }
 ${kinit2} -C "FILE:${objdir}/pkinit-synthetic.crt,${keyfile2}" ${p}@${R} || \
     { echo "Failed to kinit with PKINIT client cert"; exit 1; }
@@ -787,7 +787,7 @@ ${hxtool} issue-certificate \
           --lifetime=7d \
           --certificate="FILE:pkinit-synthetic.crt" ||
          { echo "Failed to make PKINIT client cert"; exit 1; }
-KRB5CCNAME=$admincache ${kadmin} get -s $p >/dev/null &&
+KRB5CCNAME=$admincache ${kadmin} get -s $p >/dev/null 2>&1 &&
     { echo "Internal error -- $p exists too soon"; exit 1; }
 ${kinit2} -C "FILE:${objdir}/pkinit-synthetic.crt,${keyfile2}" ${p}@${R} || \
     { echo "Failed to kinit with PKINIT client cert"; exit 1; }


### PR DESCRIPTION
This PR:

 - fixes usage of libmicrohttpd ("MHD"), specifically as to handling of POSTs with non-zero-length bodies, and cleanup of request context
 - adds a `/get-tgts` batch end-point to `kdc/bx509d.c`
 - updates the man pages `kdc/httpkadmind.8` and `kdc/bx509d.8`
 - adds commentary about how MHD is used

The `/get-tgt` end-point that's already in `master` is for getting a TGT given some other credential.

The `/get-tgts` end-point is the same, but for multiple principals at a time -- a batched version of `/get-tgt`.

These HTTPS services can now handle POST form data and multi-part too, where those are treated the same as URI q-param key/value pairs.  Internally, the main MHD request handler callback (`route()`) takes care of most everything, including authentication, CSRF protection, and processing of POST request bodies, prior to then calling the URI local-part's handler to process the request.  I.e., MHD does online handling of requests, but our handler turns it into non-online handling for convenience.