### PR TITLE
roken: getaddrinfo get_null return EAI_MEMORY errors

### DIFF
--- a/lib/roken/getaddrinfo.c
+++ b/lib/roken/getaddrinfo.c
@@ -216,7 +216,7 @@ get_null (const struct addrinfo *hints,
 		       &current, const_v4, &v4_addr, NULL);
     }
     *res = first;
-    return 0;
+    return ret;
 }
 
 static int


### PR DESCRIPTION
The only error that get_null() can return is an EAI_MEMORY error
if a memory allocation fails.   The error should be returned to
the caller instead of swallowed.

Fixes #1007
Reported-by: opless