### PR TITLE
fallthrough logic breaks on macOS 14 SDK with clang 14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -505,16 +505,20 @@ rk_WIN32_EXPORT(BUILD_ROKEN_LIB, ROKEN_LIB)
 rk_WIN32_EXPORT(BUILD_GSSAPI_LIB, GSSAPI_LIB)
 rk_WIN32_EXPORT(BUILD_KDC_LIB, KDC_LIB)
 
-dnl Deal with switch FALLTHROUGH
+dnl Deal with switch fallthrough warnings
 AH_TOP([
-#if defined(__GNUC__)
-#if __GNUC__ >= 7
-# define fallthrough __attribute__((fallthrough))
+#if defined(DISPATCH_FALLTHROUGH)
+# define HEIM_FALLTHROUGH DISPATCH_FALLTHROUGH
 #else
-# define fallthrough do {} while (0) /* fallthrough */
-#endif
-#else
-# define fallthrough  do {} while (0) /* fallthrough */
+# if defined(__GNUC__)
+#  if __GNUC__ >= 7
+#   define HEIM_FALLTHROUGH __attribute__((fallthrough))
+#  else
+#   define HEIM_FALLTHROUGH do {} while (0) /* fallthrough */
+#  endif
+# else
+#  define HEIM_FALLTHROUGH do {} while (0) /* fallthrough */
+# endif
 #endif
 ])
 

--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -26,13 +26,13 @@
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  **********************************************************************/
 
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-#define fallthrough do {} while(0) /* fallthrough */
+#define HEIM_FALLTHROUGH do {} while(0) /* fallthrough */
 
 #ifndef RCSID
 #define RCSID(msg) \

--- a/kadmin/rpc.c
+++ b/kadmin/rpc.c
@@ -972,7 +972,7 @@ process_stream(krb5_context contextp,
 	    INSIST(gctx.ctx == NULL);
 
 	    gctx.inprogress = 1;
-	    fallthrough;
+	    HEIM_FALLTHROUGH;
 	case RPG_CONTINUE_INIT: {
 	    gss_name_t src_name = GSS_C_NO_NAME;
 	    krb5_data in;

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -1321,13 +1321,15 @@ renew_func(void *ptr)
 	ret = get_new_tickets(ctx->context, ctx->principal, ctx->ccache,
 			      ctx->ticket_life, 0, ctx->anonymous_pkinit);
     }
-    expire = ticket_lifetime(ctx->context, ctx->ccache, ctx->principal,
-			     server_str, &renew_expire);
+    if (ret == 0) {
+	expire = ticket_lifetime(ctx->context, ctx->ccache, ctx->principal,
+				 server_str, &renew_expire);
 
 #ifndef NO_AFS
-    if (ret == 0 && server_str == NULL && do_afslog && k_hasafs())
-	krb5_afslog(ctx->context, ctx->ccache, NULL, NULL);
+	if (server_str == NULL && do_afslog && k_hasafs())
+	    krb5_afslog(ctx->context, ctx->ccache, NULL, NULL);
 #endif
+    }
 
     update_siginfo_msg(expire, server_str);
 

--- a/lib/asn1/gen_copy.c
+++ b/lib/asn1/gen_copy.c
@@ -62,7 +62,7 @@ copy_type (const char *from, const char *to, const Type *t, int preserve)
 	    copy_primitive ("heim_integer", from, to);
 	    break;
 	}
-        fallthrough;
+        HEIM_FALLTHROUGH;
     case TBoolean:
     case TEnumerated :
 	fprintf(codefile, "*(%s) = *(%s);\n", to, from);

--- a/lib/asn1/gen_free.c
+++ b/lib/asn1/gen_free.c
@@ -56,7 +56,7 @@ free_type (const char *name, const Type *t, int preserve)
 	    free_primitive ("heim_integer", name);
 	    break;
 	}
-        /* fallthrough; */
+        /* HEIM_FALLTHROUGH; */
     case TBoolean:
     case TEnumerated :
     case TNull:

--- a/lib/gssapi/krb5/init_sec_context.c
+++ b/lib/gssapi/krb5/init_sec_context.c
@@ -932,7 +932,7 @@ OM_uint32 GSSAPI_CALLCONV _gsskrb5_init_sec_context
 			time_rec);
 	if (ret != GSS_S_COMPLETE)
 	    break;
-        fallthrough;
+        HEIM_FALLTHROUGH;
     case INITIATOR_RESTART:
 	ret = init_auth_restart(minor_status,
 				cred,

--- a/lib/hx509/cert.c
+++ b/lib/hx509/cert.c
@@ -2441,7 +2441,6 @@ hx509_verify_path(hx509_context context,
 		 * EE checking below.
 		 */
 		type = EE_CERT;
-                HEIM_FALLTHROUGH;
 	    }
 	}
         HEIM_FALLTHROUGH;

--- a/lib/hx509/cert.c
+++ b/lib/hx509/cert.c
@@ -2441,10 +2441,10 @@ hx509_verify_path(hx509_context context,
 		 * EE checking below.
 		 */
 		type = EE_CERT;
-                fallthrough;
+                HEIM_FALLTHROUGH;
 	    }
 	}
-        fallthrough;
+        HEIM_FALLTHROUGH;
 	case EE_CERT:
 	    /*
 	     * If there where any proxy certificates in the chain

--- a/lib/hx509/cms.c
+++ b/lib/hx509/cms.c
@@ -182,7 +182,7 @@ fill_CMSIdentifier(const hx509_cert cert,
 						   &id->u.subjectKeyIdentifier);
 	if (ret == 0)
 	    break;
-        fallthrough;
+        HEIM_FALLTHROUGH;
     case CMS_ID_NAME: {
 	hx509_name name;
 

--- a/lib/hx509/file.c
+++ b/lib/hx509/file.c
@@ -230,7 +230,7 @@ hx509_pem_read(hx509_context context,
 		where = INDATA;
 		goto indata;
 	    }
-            fallthrough;
+            HEIM_FALLTHROUGH;
 	case INHEADER:
 	    if (buf[0] == '\0') {
 		where = INDATA;

--- a/lib/hx509/req.c
+++ b/lib/hx509/req.c
@@ -1046,7 +1046,7 @@ authorize_feat(hx509_request req, abitstring a, size_t n, int idx)
     switch (ret) {
     case 0:
         req->nauthorized++;
-        fallthrough;
+        HEIM_FALLTHROUGH;
     case -1:
         return 0;
     default:
@@ -1063,7 +1063,7 @@ reject_feat(hx509_request req, abitstring a, size_t n, int idx)
     switch (ret) {
     case 0:
         req->nauthorized--;
-        fallthrough;
+        HEIM_FALLTHROUGH;
     case -1:
         return 0;
     default:
@@ -1245,7 +1245,7 @@ san_map_type(GeneralName *san)
             if (der_heim_oid_cmp(&san->u.otherName.type_id, map[i].oid) == 0)
                 return map[i].type;
     }
-        fallthrough;
+        HEIM_FALLTHROUGH;
     default:                               return HX509_SAN_TYPE_UNSUPPORTED;
     }
 }
@@ -1360,7 +1360,7 @@ hx509_request_get_san(hx509_request req,
     case HX509_SAN_TYPE_REGISTERED_ID:
         return der_print_heim_oid(&san->u.registeredID, '.', out);
     case HX509_SAN_TYPE_XMPP:
-        fallthrough;
+        HEIM_FALLTHROUGH;
     case HX509_SAN_TYPE_MS_UPN: {
         int ret;
 

--- a/lib/ipc/server.c
+++ b/lib/ipc/server.c
@@ -122,26 +122,19 @@ mach_complete_sync(heim_sipc_call ctx, int returnvalue, heim_idata *reply)
 {
     struct mach_call_ctx *s = (struct mach_call_ctx *)ctx;
     heim_ipc_message_inband_t replyin;
-    mach_msg_type_number_t replyinCnt;
-    heim_ipc_message_outband_t replyout;
-    mach_msg_type_number_t replyoutCnt;
-    kern_return_t kr;
+    mach_msg_type_number_t replyinCnt = 0;
+    heim_ipc_message_outband_t replyout = 0;
+    mach_msg_type_number_t replyoutCnt = 0;
 
     if (returnvalue) {
 	/* on error, no reply */
-	replyinCnt = 0;
-	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else if (reply->length < 2048) {
 	replyinCnt = reply->length;
 	memcpy(replyin, reply->data, replyinCnt);
-	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else {
-	replyinCnt = 0;
-	kr = vm_read(mach_task_self(),
-		     (vm_address_t)reply->data, reply->length,
-		     (vm_address_t *)&replyout, &replyoutCnt);
+	vm_read(mach_task_self(),
+		(vm_address_t)reply->data, reply->length,
+		(vm_address_t *)&replyout, &replyoutCnt);
     }
 
     mheim_ripc_call_reply(s->reply_port, returnvalue,
@@ -159,31 +152,24 @@ mach_complete_async(heim_sipc_call ctx, int returnvalue, heim_idata *reply)
 {
     struct mach_call_ctx *s = (struct mach_call_ctx *)ctx;
     heim_ipc_message_inband_t replyin;
-    mach_msg_type_number_t replyinCnt;
-    heim_ipc_message_outband_t replyout;
-    mach_msg_type_number_t replyoutCnt;
-    kern_return_t kr;
+    mach_msg_type_number_t replyinCnt = 0;
+    heim_ipc_message_outband_t replyout = 0;
+    mach_msg_type_number_t replyoutCnt = 0;
 
     if (returnvalue) {
 	/* on error, no reply */
-	replyinCnt = 0;
-	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else if (reply->length < 2048) {
 	replyinCnt = reply->length;
 	memcpy(replyin, reply->data, replyinCnt);
-	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else {
-	replyinCnt = 0;
-	kr = vm_read(mach_task_self(),
-		     (vm_address_t)reply->data, reply->length,
-		     (vm_address_t *)&replyout, &replyoutCnt);
+	vm_read(mach_task_self(),
+		(vm_address_t)reply->data, reply->length,
+		(vm_address_t *)&replyout, &replyoutCnt);
     }
 
-    kr = mheim_aipc_acall_reply(s->reply_port, returnvalue,
-				replyin, replyinCnt,
-				replyout, replyoutCnt);
+    mheim_aipc_acall_reply(s->reply_port, returnvalue,
+			   replyin, replyinCnt,
+			   replyout, replyoutCnt);
     heim_ipc_free_cred(s->cred);
     free(s->req.data);
     free(s);
@@ -1383,4 +1369,3 @@ heim_ipc_main(void)
     process_loop();
 #endif
 }
-

--- a/lib/kafs/rxkad_kdf.c
+++ b/lib/kafs/rxkad_kdf.c
@@ -209,7 +209,7 @@ _kafs_derive_des_key(krb5_enctype enctype, void *keydata, size_t keylen,
 	ret = compress_parity_bits(keydata, &keylen);
 	if (ret)
 	    return ret;
-        fallthrough;
+        HEIM_FALLTHROUGH;
     default:
 	if (enctype < 0)
 	    return KRB5_PROG_ETYPE_NOSUPP;

--- a/lib/krb5/send_to_kdc.c
+++ b/lib/krb5/send_to_kdc.c
@@ -1192,7 +1192,7 @@ krb5_sendto_context(krb5_context context,
 		break;
 	    }
 	    action = KRB5_SENDTO_KRBHST;
-            fallthrough;
+            HEIM_FALLTHROUGH;
 	case KRB5_SENDTO_KRBHST:
 	    if (ctx->krbhst == NULL) {
 		ret = krb5_krbhst_init_flags(context, realm, type,
@@ -1214,7 +1214,7 @@ krb5_sendto_context(krb5_context context,
 		handle = heim_retain(ctx->krbhst);
 	    }
 	    action = KRB5_SENDTO_TIMEOUT;
-            fallthrough;
+            HEIM_FALLTHROUGH;
 	case KRB5_SENDTO_TIMEOUT:
 
 	    /*

--- a/lib/ntlm/digest.c
+++ b/lib/ntlm/digest.c
@@ -471,7 +471,7 @@ heim_digest_generate_challenge(heim_digest_t context)
 	    break;
 	case HEIM_DIGEST_TYPE_AUTO:
 	    context->type = HEIM_DIGEST_TYPE_RFC2831;
-            fallthrough;
+            HEIM_FALLTHROUGH;
 	case HEIM_DIGEST_TYPE_RFC2831:
 	    asprintf(&challenge, "realm=\"%s\",nonce=\"%s\",qop=\"%s\",algorithm=md5-sess,charset=utf-8,maxbuf=%s",
 		     context->serverRealm, context->serverNonce, context->serverQOP, context->serverMaxbuf);

--- a/lib/roken/base32.c
+++ b/lib/roken/base32.c
@@ -100,10 +100,10 @@ rk_base32_encode(const void *data, int size, char **str, enum rk_base32_flags fl
 	p[6] = chars[(c & 0x0000000000000003e0ULL) >> 5];
 	p[7] = chars[(c & 0x00000000000000001fULL) >> 0];
         switch (i - size) {
-        case 4: p[2] = p[3] = '=';  fallthrough;
-        case 3: p[4] = '=';         fallthrough;
-        case 2: p[5] = p[6] = '=';  fallthrough;
-        case 1: p[7] = '=';         fallthrough;
+        case 4: p[2] = p[3] = '=';  HEIM_FALLTHROUGH;
+        case 3: p[4] = '=';         HEIM_FALLTHROUGH;
+        case 2: p[5] = p[6] = '=';  HEIM_FALLTHROUGH;
+        case 1: p[7] = '=';         HEIM_FALLTHROUGH;
         default:                    break;
         }
 	p += 8;

--- a/lib/roken/dirent-test.c
+++ b/lib/roken/dirent-test.c
@@ -148,7 +148,7 @@ int teardown_test(void)
 
         strcmp(dirname + len + 1 - sizeof(TESTDIR)/sizeof(char), TESTDIR) == 0) {
 
-        fallthrough;
+        HEIM_FALLTHROUGH;
 
     } else {
         /* did we create the directory? */
@@ -162,7 +162,7 @@ int teardown_test(void)
                     fprintf(stderr, "Can't change to test directory. Aborting cleanup.\n");
                     return -1;
                 } else {
-                    fallthrough;
+                    HEIM_FALLTHROUGH;
                 }
             } else {
                 return -1;

--- a/lib/roken/fnmatch.c
+++ b/lib/roken/fnmatch.c
@@ -129,7 +129,7 @@ rk_fnmatch(const char *pattern, const char *string, int flags)
 					--pattern;
 				}
 			}
-                        fallthrough;
+                        HEIM_FALLTHROUGH;
 		default:
 			if (c != *string++)
 				return (FNM_NOMATCH);

--- a/lib/roken/getaddrinfo.c
+++ b/lib/roken/getaddrinfo.c
@@ -188,7 +188,7 @@ get_null (const struct addrinfo *hints,
     struct addrinfo *first = NULL;
     struct addrinfo **current = &first;
     int family = PF_UNSPEC;
-    int ret;
+    int ret = EAI_FAMILY;
 
     if (hints != NULL)
 	family = hints->ai_family;
@@ -216,7 +216,7 @@ get_null (const struct addrinfo *hints,
 		       &current, const_v4, &v4_addr, NULL);
     }
     *res = first;
-    return 0;
+    return ret;
 }
 
 static int

--- a/lib/roken/getuserinfo.c
+++ b/lib/roken/getuserinfo.c
@@ -136,7 +136,7 @@ roken_get_homedir(char *home, size_t homesz)
         }
         return home;
     }
-    fallthrough;
+    HEIM_FALLTHROUGH;
 #else
 #ifdef HAVE_GETPWNAM_R
     size_t buflen = 2048;

--- a/lib/roken/snprintf.c
+++ b/lib/roken/snprintf.c
@@ -515,7 +515,7 @@ xyzprintf (struct snprintf_state *state, const char *char_format, va_list ap)
 	    }
 	    case '\0' :
 		--format;
-                fallthrough;
+                HEIM_FALLTHROUGH;
 	    case '%' :
 		(*state->append_char)(state, c);
 		++len;

--- a/lib/roken/strftime.c
+++ b/lib/roken/strftime.c
@@ -377,7 +377,7 @@ strftime (char *buf, size_t maxsize, const char *format,
 		break;
 	    case '\0' :
 		--format;
-                fallthrough;
+                HEIM_FALLTHROUGH;
 	    case '%' :
 		ret = snprintf (buf, maxsize - n,
 				"%%");

--- a/lib/roken/strptime.c
+++ b/lib/roken/strptime.c
@@ -424,7 +424,7 @@ strptime (const char *buf, const char *format, struct tm *timeptr)
 		abort ();
 	    case '\0' :
 		--format;
-                fallthrough;
+                HEIM_FALLTHROUGH;
 	    case '%' :
 		if (*buf == '%')
 		    ++buf;

--- a/lib/wind/utf8.c
+++ b/lib/wind/utf8.c
@@ -205,18 +205,18 @@ wind_ucs4utf8(const uint32_t *in, size_t in_len, char *out, size_t *out_len)
 	    case 4:
 		out[3] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                fallthrough;
+                HEIM_FALLTHROUGH;
 	    case 3:
 		out[2] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                fallthrough;
+                HEIM_FALLTHROUGH;
 	    case 2:
 		out[1] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                fallthrough;
+                HEIM_FALLTHROUGH;
 	    case 1:
 		out[0] = ch | first_char[len - 1];
-                fallthrough;
+                HEIM_FALLTHROUGH;
             default:
                 break;
 	    }
@@ -486,14 +486,14 @@ wind_ucs2utf8(const uint16_t *in, size_t in_len, char *out, size_t *out_len)
 	    case 3:
 		out[2] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                fallthrough;
+                HEIM_FALLTHROUGH;
 	    case 2:
 		out[1] = (ch | 0x80) & 0xbf;
 		ch = ch >> 6;
-                fallthrough;
+                HEIM_FALLTHROUGH;
 	    case 1:
 		out[0] = ch | first_char[len - 1];
-                fallthrough;
+                HEIM_FALLTHROUGH;
             default:
                 break;
 	    }


### PR DESCRIPTION
Apple clang version 14.0.0 (clang-1400.0.17.3.1) fails the build because stds.h defines `fallthrough` as a macro which is then expanded when base.h evaluates

  # if __has_attribute(fallthrough) && __clang_major__ >= 5

The macOS SDK defines `DISPATCH_FALLTHROUGH` as the macro instead of `fallthrough`.

This change replaces the use of `fallthrough` in the tree with `HEIM_FALLTHROUGH` and updates the declaration in configure logic to define `HEIM_FALLTHROUGH` based upon existing definitions (if any) of `fallthrough` or `DISPATCH_FALLTHROUGH`.