### PR TITLE
Avoid re-encode of TGS_REQ to allow year 9999 date for Windows 11 22H2 Compatability

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -356,7 +356,6 @@ _kdc_fast_unwrap_request(kdc_request_t r)
     krb5_keyblock armorkey;
     krb5_error_code ret;
     krb5_ap_req ap_req;
-    unsigned char *buf = NULL;
     KrbFastReq fastreq;
     size_t len, size;
     krb5_data data;
@@ -483,18 +482,10 @@ _kdc_fast_unwrap_request(kdc_request_t r)
     krb5_free_keyblock_contents(r->context, &armorkey);
 
     /* verify req-checksum of the outer body */
-
-    ASN1_MALLOC_ENCODE(KDC_REQ_BODY, buf, len, &r->req.req_body, &size, ret);
-    if (ret)
-	goto out;
-    if (size != len) {
-	ret = KRB5KDC_ERR_PREAUTH_FAILED;
-	goto out;
-    }
-
     ret = krb5_verify_checksum(r->context, r->armor_crypto,
 			       KRB5_KU_FAST_REQ_CHKSUM,
-			       buf, len, 
+			       r->req.req_body._save.data,
+			       r->req.req_body._save.length,
 			       &fxreq.u.armored_data.req_checksum);
     if (ret) {
 	kdc_log(r->context, r->config, 0,

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1078,9 +1078,6 @@ tgs_check_authenticator(krb5_context context,
 			krb5_keyblock *key)
 {
     krb5_authenticator auth;
-    size_t len = 0;
-    unsigned char *buf;
-    size_t buf_size;
     krb5_error_code ret;
     krb5_crypto crypto;
 
@@ -1106,25 +1103,9 @@ tgs_check_authenticator(krb5_context context,
 	goto out;
     }
 
-    /* XXX should not re-encode this */
-    ASN1_MALLOC_ENCODE(KDC_REQ_BODY, buf, buf_size, b, &len, ret);
-    if(ret){
-	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "Failed to encode KDC-REQ-BODY: %s", msg);
-	krb5_free_error_message(context, msg);
-	goto out;
-    }
-    if(buf_size != len) {
-	free(buf);
-	kdc_log(context, config, 0, "Internal error in ASN.1 encoder");
-	*e_text = "KDC internal error";
-	ret = KRB5KRB_ERR_GENERIC;
-	goto out;
-    }
     ret = krb5_crypto_init(context, key, 0, &crypto);
     if (ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	free(buf);
 	kdc_log(context, config, 0, "krb5_crypto_init failed: %s", msg);
 	krb5_free_error_message(context, msg);
 	goto out;
@@ -1132,10 +1113,9 @@ tgs_check_authenticator(krb5_context context,
     ret = krb5_verify_checksum(context,
 			       crypto,
 			       KRB5_KU_TGS_REQ_AUTH_CKSUM,
-			       buf,
-			       len,
+			       b->_save.data,
+			       b->_save.length,
 			       auth->cksum);
-    free(buf);
     krb5_crypto_destroy(context, crypto);
     if(ret){
 	const char *msg = krb5_get_error_message(context, ret);

--- a/kdc/pkinit.c
+++ b/kdc/pkinit.c
@@ -111,10 +111,7 @@ pk_check_pkauthenticator(krb5_context context,
 			 PKAuthenticator *a,
 			 const KDC_REQ *req)
 {
-    u_char *buf = NULL;
-    size_t buf_size;
     krb5_error_code ret;
-    size_t len = 0;
     krb5_timestamp now;
     Checksum checksum;
 
@@ -126,22 +123,13 @@ pk_check_pkauthenticator(krb5_context context,
 	return KRB5KRB_AP_ERR_SKEW;
     }
 
-    ASN1_MALLOC_ENCODE(KDC_REQ_BODY, buf, buf_size, &req->req_body, &len, ret);
-    if (ret) {
-	krb5_clear_error_message(context);
-	return ret;
-    }
-    if (buf_size != len)
-	krb5_abortx(context, "Internal error in ASN.1 encoder");
-
     ret = krb5_create_checksum(context,
 			       NULL,
 			       0,
 			       CKSUMTYPE_SHA1,
-			       buf,
-			       len,
+			       req->req_body._save.data,
+			       req->req_body._save.length,
 			       &checksum);
-    free(buf);
     if (ret) {
 	krb5_clear_error_message(context);
 	return ret;

--- a/lib/asn1/asn1parse.y
+++ b/lib/asn1/asn1parse.y
@@ -52,6 +52,7 @@ static Type *new_type (Typetype t);
 static struct constraint_spec *new_constraint_spec(enum ctype);
 static Type *new_tag(int tagclass, int tagvalue, int tagenv, Type *oldtype);
 void yyerror (const char *);
+#define yyerror yyerror
 static struct objid *new_objid(const char *label, int value);
 static void add_oid_to_tail(struct objid *, struct objid *);
 static void fix_labels(Symbol *s);

--- a/lib/asn1/krb5.opt
+++ b/lib/asn1/krb5.opt
@@ -4,3 +4,4 @@
 --sequence=METHOD-DATA
 --sequence=ETYPE-INFO
 --sequence=ETYPE-INFO2
+--preserve-binary=KDC-REQ-BODY

--- a/lib/com_err/parse.y
+++ b/lib/com_err/parse.y
@@ -35,7 +35,8 @@
 #include "compile_et.h"
 #include "lex.h"
 
-void yyerror (char *s);
+void yyerror (const char *s);
+#define yyerror yyerror
 static long name2number(const char *str);
 
 extern char *yytext;
@@ -168,7 +169,7 @@ name2number(const char *str)
 }
 
 void
-yyerror (char *s)
+yyerror (const char *s)
 {
      _lex_error_message ("%s\n", s);
 }

--- a/lib/hdb/hdb-mitdb.c
+++ b/lib/hdb/hdb-mitdb.c
@@ -1116,7 +1116,7 @@ krb5_error_code
 hdb_mitdb_create(krb5_context context, HDB **db,
 		 const char *filename)
 {
-    MITDB **mdb (MITDB **)db;
+    MITDB **mdb = (MITDB **)db;
     *mdb = calloc(1, sizeof(**mdb));
     if (*mdb == NULL) {
 	krb5_set_error_message(context, ENOMEM, "malloc: out of memory");

--- a/lib/roken/copyhostent.c
+++ b/lib/roken/copyhostent.c
@@ -40,7 +40,7 @@
  */
 
 ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-copyhostent (const struct hostent *h)
+rk_copyhostent(const struct hostent *h)
 {
     struct hostent *res;
     char **p;
@@ -96,4 +96,3 @@ copyhostent (const struct hostent *h)
     }
     return res;
 }
-

--- a/lib/roken/freeaddrinfo.c
+++ b/lib/roken/freeaddrinfo.c
@@ -40,7 +40,7 @@
  */
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
-freeaddrinfo(struct addrinfo *ai)
+rk_freeaddrinfo(struct addrinfo *ai)
 {
     struct addrinfo *tofree;
 

--- a/lib/roken/freehostent.c
+++ b/lib/roken/freehostent.c
@@ -40,7 +40,7 @@
  */
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
-freehostent (struct hostent *h)
+rk_freehostent(struct hostent *h)
 {
     char **p;
 

--- a/lib/roken/getaddrinfo.c
+++ b/lib/roken/getaddrinfo.c
@@ -366,10 +366,10 @@ get_nodes (const char *nodename,
  */
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-getaddrinfo(const char *nodename,
-	    const char *servname,
-	    const struct addrinfo *hints,
-	    struct addrinfo **res)
+rk_getaddrinfo(const char *nodename,
+	       const char *servname,
+	       const struct addrinfo *hints,
+	       struct addrinfo **res)
 {
     int ret;
     int port     = 0;
@@ -409,6 +409,6 @@ getaddrinfo(const char *nodename,
 	ret = get_null (hints, port, protocol, socktype, res);
     }
     if (ret)
-	freeaddrinfo (*res);
+	rk_freeaddrinfo(*res);
     return ret;
 }

--- a/lib/roken/getipnodebyaddr.c
+++ b/lib/roken/getipnodebyaddr.c
@@ -41,7 +41,7 @@
  */
 
 ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-getipnodebyaddr (const void *src, size_t len, int af, int *error_num)
+rk_getipnodebyaddr(const void *src, size_t len, int af, int *error_num)
 {
     struct hostent *tmp;
 

--- a/lib/roken/getipnodebyname.c
+++ b/lib/roken/getipnodebyname.c
@@ -45,7 +45,7 @@ static int h_errno = NO_RECOVERY;
  */
 
 ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-getipnodebyname (const char *name, int af, int flags, int *error_num)
+rk_getipnodebyname(const char *name, int af, int flags, int *error_num)
 {
     struct hostent *tmp;
 

--- a/lib/roken/getnameinfo.c
+++ b/lib/roken/getnameinfo.c
@@ -92,10 +92,10 @@ doit (int af,
  */
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-getnameinfo(const struct sockaddr *sa, socklen_t salen,
-	    char *host, size_t hostlen,
-	    char *serv, size_t servlen,
-	    int flags)
+rk_getnameinfo(const struct sockaddr *sa, socklen_t salen,
+	       char *host, size_t hostlen,
+	       char *serv, size_t servlen,
+	       int flags)
 {
     switch (sa->sa_family) {
 #ifdef HAVE_IPV6

--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -865,27 +865,27 @@ ROKEN_LIB_VARIABLE extern int opterr;
 
 #ifndef HAVE_GETIPNODEBYNAME
 #define getipnodebyname rk_getipnodebyname
-ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-getipnodebyname (const char *, int, int, int *);
 #endif
+ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
+rk_getipnodebyname(const char *, int, int, int *);
 
 #ifndef HAVE_GETIPNODEBYADDR
 #define getipnodebyaddr rk_getipnodebyaddr
-ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-getipnodebyaddr (const void *, size_t, int, int *);
 #endif
+ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
+rk_getipnodebyaddr(const void *, size_t, int, int *);
 
 #ifndef HAVE_FREEHOSTENT
 #define freehostent rk_freehostent
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
-freehostent (struct hostent *);
 #endif
+ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+rk_freehostent(struct hostent *);
 
 #ifndef HAVE_COPYHOSTENT
 #define copyhostent rk_copyhostent
-ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-copyhostent (const struct hostent *);
 #endif
+ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
+rk_copyhostent(const struct hostent *);
 
 #ifndef HAVE_SOCKLEN_T
 typedef int socklen_t;
@@ -951,27 +951,27 @@ struct addrinfo {
 
 #ifndef HAVE_GETADDRINFO
 #define getaddrinfo rk_getaddrinfo
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-getaddrinfo(const char *,
-	    const char *,
-	    const struct addrinfo *,
-	    struct addrinfo **);
 #endif
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+rk_getaddrinfo(const char *,
+	       const char *,
+	       const struct addrinfo *,
+	       struct addrinfo **);
 
 #ifndef HAVE_GETNAMEINFO
 #define getnameinfo rk_getnameinfo
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-getnameinfo(const struct sockaddr *, socklen_t,
-		char *, size_t,
-		char *, size_t,
-		int);
 #endif
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+rk_getnameinfo(const struct sockaddr *, socklen_t,
+	       char *, size_t,
+	       char *, size_t,
+	       int);
 
 #ifndef HAVE_FREEADDRINFO
 #define freeaddrinfo rk_freeaddrinfo
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
-freeaddrinfo(struct addrinfo *);
 #endif
+ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+rk_freeaddrinfo(struct addrinfo *);
 
 #ifndef HAVE_GAI_STRERROR
 #define gai_strerror rk_gai_strerror

--- a/lib/sl/slc-lex.l
+++ b/lib/sl/slc-lex.l
@@ -80,7 +80,7 @@ error_message (const char *format, ...)
 }
 
 void
-yyerror (char *s)
+yyerror (const char *s)
 {
     error_message("%s\n", s);
 }

--- a/lib/sl/slc.h
+++ b/lib/sl/slc.h
@@ -51,5 +51,6 @@ extern char *filename;
 extern int error_flag;
 void error_message (const char *format, ...);
 int yylex(void);
-void yyerror (char *s);
+void yyerror (const char *s);
+#define yyerror yyerror
 extern unsigned lineno;


### PR DESCRIPTION
This, as a courtesy, is a backport of ebfd48e40a1b61bf5a6b8d00fe5c581e24652b6e to Heimdal the 7.1 branch.

It passes the internal Heimdal 'make check' and it is the same as the tested patch published at https://bugzilla.samba.org/show_bug.cgi?id=15197 for Samba use, except that Samba's code is so old fast.c is not included.

The testing in Samba was as an AD DC being joined by Windows Server vNext build 25217.  The FAST and PKINIT codepaths were not manually tested.

Fixes: #1011 