### PR TITLE
lib/base: Avoid compiler warning about use-after-free on Fedora 36

### DIFF
--- a/lib/base/json.c
+++ b/lib/base/json.c
@@ -962,7 +962,12 @@ parse_string(struct parse_ctx *ctx)
 
     /* NUL-terminate for rk_base64_decode() and plain paranoia */
     if (p0 != NULL && p == pend) {
-        char *tmp = realloc(p0, 1 + pend - p);
+        /*
+	 * Work out how far p is into p0 to re-esablish p after
+	 * the realloc()
+	 */
+        size_t p0_to_pend_len = (pend - p0);
+        char *tmp = realloc(p0, 1 + p0_to_pend_len);
 
         if (tmp == NULL) {
             ctx->error = heim_error_create_enomem();


### PR DESCRIPTION
While the local stack pointers could be thought of as "only" numbers that are not invalidated by the memory they point at being freed, any use of the pointer after the free is undefined and so warned about (at best).

gcc version 12.2.1 20220819 (Red Hat 12.2.1-1) (GCC)

Signed-off-by: Andrew Bartlett <abartlet@samba.org>