### PR TITLE
Switch from ubuntu-18.04 to ubuntu-latest for Github Actions

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -16,7 +16,7 @@ jobs:
                 name: [linux-clang]
                 include:
                     - name: linux-clang
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: clang
         steps:
             - name: Clone repository

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,11 +57,11 @@ jobs:
                 name: [linux-clang, linux-gcc]
                 include:
                     - name: linux-clang
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: clang
                       cflags: ''
                     - name: linux-gcc
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: gcc
                       cflags: '-Wnonnull'
         steps:

--- a/.github/workflows/scanbuild.yml
+++ b/.github/workflows/scanbuild.yml
@@ -20,7 +20,7 @@ jobs:
                 name: [linux-clang]
                 include:
                     - name: linux-clang
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: clang
         steps:
             - name: Clone repository

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -57,12 +57,12 @@ jobs:
                 name: [linux-clang, linux-gcc]
                 include:
                     - name: linux-clang
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: clang
                       cflags: '-fsanitize=undefined'
                       ldflags: ''
                     - name: linux-gcc
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: gcc
                       cflags: '-Wnonnull -fsanitize=undefined'
                       ldflags: ''

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,7 +20,7 @@ jobs:
                 name: [linux-clang]
                 include:
                     - name: linux-clang
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: clang
         steps:
             - name: Clone repository


### PR DESCRIPTION
[Reference](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

Ubuntu 18.04 on Github Action has been deprecated.