### PR TITLE
Fix for 1011 from Samba

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1078,9 +1078,6 @@ tgs_check_authenticator(krb5_context context,
 			krb5_keyblock *key)
 {
     krb5_authenticator auth;
-    size_t len = 0;
-    unsigned char *buf;
-    size_t buf_size;
     krb5_error_code ret;
     krb5_crypto crypto;
 
@@ -1106,25 +1103,9 @@ tgs_check_authenticator(krb5_context context,
 	goto out;
     }
 
-    /* XXX should not re-encode this */
-    ASN1_MALLOC_ENCODE(KDC_REQ_BODY, buf, buf_size, b, &len, ret);
-    if(ret){
-	const char *msg = krb5_get_error_message(context, ret);
-	kdc_log(context, config, 0, "Failed to encode KDC-REQ-BODY: %s", msg);
-	krb5_free_error_message(context, msg);
-	goto out;
-    }
-    if(buf_size != len) {
-	free(buf);
-	kdc_log(context, config, 0, "Internal error in ASN.1 encoder");
-	*e_text = "KDC internal error";
-	ret = KRB5KRB_ERR_GENERIC;
-	goto out;
-    }
     ret = krb5_crypto_init(context, key, 0, &crypto);
     if (ret) {
 	const char *msg = krb5_get_error_message(context, ret);
-	free(buf);
 	kdc_log(context, config, 0, "krb5_crypto_init failed: %s", msg);
 	krb5_free_error_message(context, msg);
 	goto out;
@@ -1132,10 +1113,9 @@ tgs_check_authenticator(krb5_context context,
     ret = krb5_verify_checksum(context,
 			       crypto,
 			       KRB5_KU_TGS_REQ_AUTH_CKSUM,
-			       buf,
-			       len,
+			       b->_save.data,
+			       b->_save.length,
 			       auth->cksum);
-    free(buf);
     krb5_crypto_destroy(context, crypto);
     if(ret){
 	const char *msg = krb5_get_error_message(context, ret);

--- a/kdc/pkinit.c
+++ b/kdc/pkinit.c
@@ -111,10 +111,7 @@ pk_check_pkauthenticator(krb5_context context,
 			 PKAuthenticator *a,
 			 const KDC_REQ *req)
 {
-    u_char *buf = NULL;
-    size_t buf_size;
     krb5_error_code ret;
-    size_t len = 0;
     krb5_timestamp now;
     Checksum checksum;
 
@@ -126,22 +123,13 @@ pk_check_pkauthenticator(krb5_context context,
 	return KRB5KRB_AP_ERR_SKEW;
     }
 
-    ASN1_MALLOC_ENCODE(KDC_REQ_BODY, buf, buf_size, &req->req_body, &len, ret);
-    if (ret) {
-	krb5_clear_error_message(context);
-	return ret;
-    }
-    if (buf_size != len)
-	krb5_abortx(context, "Internal error in ASN.1 encoder");
-
     ret = krb5_create_checksum(context,
 			       NULL,
 			       0,
 			       CKSUMTYPE_SHA1,
-			       buf,
-			       len,
+			       req->req_body._save.data,
+			       req->req_body._save.length,
 			       &checksum);
-    free(buf);
     if (ret) {
 	krb5_clear_error_message(context);
 	return ret;

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -976,10 +976,12 @@ renew_func(void *ptr)
     expire = ticket_lifetime(ctx->context, ctx->ccache, ctx->principal,
 			     server_str, &renew_expire);
 
+    if (ret == 0 && server_str == NULL) {
 #ifndef NO_AFS
-    if (ret == 0 && server_str == NULL && do_afslog && k_hasafs())
-	krb5_afslog(ctx->context, ctx->ccache, NULL, NULL);
+	if (do_afslog && k_hasafs())
+	    krb5_afslog(ctx->context, ctx->ccache, NULL, NULL);
 #endif
+    }
 
     update_siginfo_msg(expire, server_str);
 

--- a/lib/asn1/krb5.opt
+++ b/lib/asn1/krb5.opt
@@ -4,3 +4,4 @@
 --sequence=METHOD-DATA
 --sequence=ETYPE-INFO
 --sequence=ETYPE-INFO2
+--preserve-binary=KDC-REQ-BODY

--- a/lib/ipc/server.c
+++ b/lib/ipc/server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 Kungliga Tekniska Högskolan
+ * Copyright (c) 2009 Kungliga Tekniska Hï¿½gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *
@@ -125,23 +125,21 @@ mach_complete_sync(heim_sipc_call ctx, int returnvalue, heim_idata *reply)
     mach_msg_type_number_t replyinCnt;
     heim_ipc_message_outband_t replyout;
     mach_msg_type_number_t replyoutCnt;
-    kern_return_t kr;
+
 
     if (returnvalue) {
 	/* on error, no reply */
 	replyinCnt = 0;
 	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else if (reply->length < 2048) {
 	replyinCnt = reply->length;
 	memcpy(replyin, reply->data, replyinCnt);
 	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else {
 	replyinCnt = 0;
-	kr = vm_read(mach_task_self(),
-		     (vm_address_t)reply->data, reply->length,
-		     (vm_address_t *)&replyout, &replyoutCnt);
+	vm_read(mach_task_self(),
+		(vm_address_t)reply->data, reply->length,
+		(vm_address_t *)&replyout, &replyoutCnt);
     }
 
     mheim_ripc_call_reply(s->reply_port, returnvalue,
@@ -162,28 +160,25 @@ mach_complete_async(heim_sipc_call ctx, int returnvalue, heim_idata *reply)
     mach_msg_type_number_t replyinCnt;
     heim_ipc_message_outband_t replyout;
     mach_msg_type_number_t replyoutCnt;
-    kern_return_t kr;
 
     if (returnvalue) {
 	/* on error, no reply */
 	replyinCnt = 0;
 	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else if (reply->length < 2048) {
 	replyinCnt = reply->length;
 	memcpy(replyin, reply->data, replyinCnt);
 	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else {
 	replyinCnt = 0;
-	kr = vm_read(mach_task_self(),
-		     (vm_address_t)reply->data, reply->length,
-		     (vm_address_t *)&replyout, &replyoutCnt);
+	vm_read(mach_task_self(),
+		(vm_address_t)reply->data, reply->length,
+		(vm_address_t *)&replyout, &replyoutCnt);
     }
 
-    kr = mheim_aipc_acall_reply(s->reply_port, returnvalue,
-				replyin, replyinCnt,
-				replyout, replyoutCnt);
+    mheim_aipc_acall_reply(s->reply_port, returnvalue,
+			   replyin, replyinCnt,
+			   replyout, replyoutCnt);
     heim_ipc_free_cred(s->cred);
     free(s->req.data);
     free(s);
@@ -1189,4 +1184,3 @@ heim_ipc_main(void)
     process_loop();
 #endif
 }
-


### PR DESCRIPTION
Use --preserve-binary=KDC-REQ-BODY option to ASN.1 compiler to avoid re-encoding KDC-REQ-BODYs for verification in GSS preauth, TGS and PKINIT.

[abartlet@samba.org adapted from Heimdal commit
 ebfd48e40a1b61bf5a6b8d00fe5c581e24652b6e
 by removing references to FAST and GSS-pre-auth.

 This fixes the Windows 11 22H2 issue with TGS-REQ
 as seen at https:github.com/heimdal/heimdal/issues/1011 and so
 removes the knownfail file for this test]

FIXES: 1011

Signed-off-by: Andrew Bartlett <abartlet@samba.org>