### PR TITLE
CVE-2022-42898: lib/krb5: fix _krb5_get_int64 on systems where 'unsigned long' is just 32-bit

### DIFF
--- a/lib/krb5/store-int.c
+++ b/lib/krb5/store-int.c
@@ -49,7 +49,7 @@ KRB5_LIB_FUNCTION krb5_ssize_t KRB5_LIB_CALL
 _krb5_get_int64(void *buffer, uint64_t *value, size_t size)
 {
     unsigned char *p = buffer;
-    unsigned long v = 0;
+    uint64_t v = 0;
     size_t i;
     for (i = 0; i < size; i++)
 	v = (v << 8) + p[i];


### PR DESCRIPTION
See: https://bugzilla.samba.org/show_bug.cgi?id=15203

