### PR TITLE
[7.8.0] lib/krb5: fix _krb5_get_int64 on 32-bit systems

### DIFF
--- a/lib/krb5/store-int.c
+++ b/lib/krb5/store-int.c
@@ -49,7 +49,7 @@ KRB5_LIB_FUNCTION krb5_ssize_t KRB5_LIB_CALL
 _krb5_get_int64(void *buffer, uint64_t *value, size_t size)
 {
     unsigned char *p = buffer;
-    unsigned long v = 0;
+    uint64_t v = 0;
     size_t i;
     for (i = 0; i < size; i++)
 	v = (v << 8) + p[i];


### PR DESCRIPTION
On systems where 'unsigned long' is 32-bits and the 'size' parameter is set to 8 and the bytes are:

0x78 0x00 0x00 0x00 0x00 0x00 0x00 0x00

When 'i' becomes 4 'v' will be 0 again. As 'unsigned long' is only able to hold 4 bytes.

Change the type of 'v' from 'unsigned long' to 'uint64_t' which matches the type of the output parameter 'value'.

(cherry picked from commit https://github.com/heimdal/heimdal/commit/9d1bfab9882d0aa14ae0981e6667c93db93ffc5d)

Signed-off-by: Stefan Metzmacher [metze@samba.org](mailto:metze@samba.org)
Reviewed-by: Ralph Boehme [slow@samba.org](mailto:slow@samba.org)
CVE: CVE-2022-42898
Samba-BUG: https://bugzilla.samba.org/show_bug.cgi?id=15203