### PR TITLE
lib/krb5: krb5_pac_parse mem leak if pac_header_size failure

### DIFF
--- a/lib/krb5/pac.c
+++ b/lib/krb5/pac.c
@@ -204,9 +204,8 @@ krb5_pac_parse(krb5_context context, const void *ptr, size_t len,
     }
 
     ret = pac_header_size(context, tmp, &header_end);
-    if (ret) {
-	return ret;
-    }
+    if (ret)
+	goto out;
 
     p->pac = calloc(1, header_end);
     if (p->pac == NULL) {


### PR DESCRIPTION
48 byte memory leak from krb5_pac_parse() each time pac_header_size() fails.