### PR TITLE
Older MSVC does not provide __func__

### DIFF
--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -57,6 +57,10 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 #define MAXPATHLEN MaxPathLen
 #endif
 
+#if _MSC_VER < 1900
+# define __func__ __FUNCTION__
+#endif
+
 #ifdef BUILD_KRB5_LIB
 #ifndef KRB5_LIB
 #ifdef _WIN32

--- a/lib/krb5/krb5_locl.h
+++ b/lib/krb5/krb5_locl.h
@@ -202,10 +202,6 @@ extern const char _krb5_wellknown_lkdc[];
 #define ALLOC(X, N) (X) = calloc((N), sizeof(*(X)))
 #define ALLOC_SEQ(X, N) do { (X)->len = (N); ALLOC((X)->val, (N)); } while(0)
 
-#ifndef __func__
-#define __func__ "unknown-function"
-#endif
-
 #define krb5_einval(context, argnum) _krb5_einval((context), __func__, (argnum))
 
 #ifndef PATH_SEP


### PR DESCRIPTION
__func__ is a C99 standard variable but it is not available on MSVC _MSC_VER < 1900.  
Define __func__ as __FUNCTION__ on older MSVC so that the general define can be removed.