### PR TITLE
CVE-2022-37966 kdc: Use server keys to select a session key

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2205,7 +2205,7 @@ _kdc_as_rep(astgs_request_t r)
      * intersection of the client's requested enctypes and the server's (like a
      * root krbtgt, but not necessarily) etypes from its HDB entry.
      */
-    ret = _kdc_find_etype(r, (is_tgs ?  KFE_IS_TGS:0) | KFE_USE_CLIENT,
+    ret = _kdc_find_etype(r, (is_tgs ?  KFE_IS_TGS:0),
 			  b->etype.val, b->etype.len,
 			  &r->sessionetype, NULL, NULL);
     if (ret) {


### PR DESCRIPTION
To select a session key etype, we should look at the supported etypes of the server principal rather than the client principal.

Samba BUG: https://bugzilla.samba.org/show_bug.cgi?id=15237