### PR TITLE
roken: do not override system network address functions

### DIFF
--- a/lib/roken/copyhostent.c
+++ b/lib/roken/copyhostent.c
@@ -40,7 +40,7 @@
  */
 
 ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-copyhostent (const struct hostent *h)
+rk_copyhostent(const struct hostent *h)
 {
     struct hostent *res;
     char **p;
@@ -96,4 +96,3 @@ copyhostent (const struct hostent *h)
     }
     return res;
 }
-

--- a/lib/roken/freeaddrinfo.c
+++ b/lib/roken/freeaddrinfo.c
@@ -40,7 +40,7 @@
  */
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
-freeaddrinfo(struct addrinfo *ai)
+rk_freeaddrinfo(struct addrinfo *ai)
 {
     struct addrinfo *tofree;
 

--- a/lib/roken/freehostent.c
+++ b/lib/roken/freehostent.c
@@ -40,7 +40,7 @@
  */
 
 ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
-freehostent (struct hostent *h)
+rk_freehostent(struct hostent *h)
 {
     char **p;
 

--- a/lib/roken/getaddrinfo.c
+++ b/lib/roken/getaddrinfo.c
@@ -368,10 +368,10 @@ get_nodes (const char *nodename,
  */
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-getaddrinfo(const char *nodename,
-	    const char *servname,
-	    const struct addrinfo *hints,
-	    struct addrinfo **res)
+rk_getaddrinfo(const char *nodename,
+	       const char *servname,
+	       const struct addrinfo *hints,
+	       struct addrinfo **res)
 {
     int ret;
     int port     = 0;
@@ -411,6 +411,6 @@ getaddrinfo(const char *nodename,
 	ret = get_null (hints, port, protocol, socktype, res);
     }
     if (ret)
-	freeaddrinfo (*res);
+	rk_freeaddrinfo(*res);
     return ret;
 }

--- a/lib/roken/getipnodebyaddr.c
+++ b/lib/roken/getipnodebyaddr.c
@@ -41,7 +41,7 @@
  */
 
 ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-getipnodebyaddr (const void *src, size_t len, int af, int *error_num)
+rk_getipnodebyaddr(const void *src, size_t len, int af, int *error_num)
 {
     struct hostent *tmp;
 

--- a/lib/roken/getipnodebyname.c
+++ b/lib/roken/getipnodebyname.c
@@ -45,7 +45,7 @@ static int h_errno = NO_RECOVERY;
  */
 
 ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-getipnodebyname (const char *name, int af, int flags, int *error_num)
+rk_getipnodebyname(const char *name, int af, int flags, int *error_num)
 {
     struct hostent *tmp;
 

--- a/lib/roken/getnameinfo.c
+++ b/lib/roken/getnameinfo.c
@@ -92,10 +92,10 @@ doit (int af,
  */
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-getnameinfo(const struct sockaddr *sa, socklen_t salen,
-	    char *host, size_t hostlen,
-	    char *serv, size_t servlen,
-	    int flags)
+rk_getnameinfo(const struct sockaddr *sa, socklen_t salen,
+	       char *host, size_t hostlen,
+	       char *serv, size_t servlen,
+	       int flags)
 {
     switch (sa->sa_family) {
 #ifdef HAVE_IPV6

--- a/lib/roken/roken.h.in
+++ b/lib/roken/roken.h.in
@@ -870,27 +870,27 @@ ROKEN_LIB_VARIABLE extern int opterr;
 
 #ifndef HAVE_GETIPNODEBYNAME
 #define getipnodebyname rk_getipnodebyname
-ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-getipnodebyname (const char *, int, int, int *);
 #endif
+ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
+rk_getipnodebyname(const char *, int, int, int *);
 
 #ifndef HAVE_GETIPNODEBYADDR
 #define getipnodebyaddr rk_getipnodebyaddr
-ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-getipnodebyaddr (const void *, size_t, int, int *);
 #endif
+ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
+rk_getipnodebyaddr(const void *, size_t, int, int *);
 
 #ifndef HAVE_FREEHOSTENT
 #define freehostent rk_freehostent
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
-freehostent (struct hostent *);
 #endif
+ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+rk_freehostent(struct hostent *);
 
 #ifndef HAVE_COPYHOSTENT
 #define copyhostent rk_copyhostent
-ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
-copyhostent (const struct hostent *);
 #endif
+ROKEN_LIB_FUNCTION struct hostent * ROKEN_LIB_CALL
+rk_copyhostent(const struct hostent *);
 
 #ifndef HAVE_SOCKLEN_T
 typedef int socklen_t;
@@ -956,27 +956,27 @@ struct addrinfo {
 
 #ifndef HAVE_GETADDRINFO
 #define getaddrinfo rk_getaddrinfo
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-getaddrinfo(const char *,
-	    const char *,
-	    const struct addrinfo *,
-	    struct addrinfo **);
 #endif
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+rk_getaddrinfo(const char *,
+	       const char *,
+	       const struct addrinfo *,
+	       struct addrinfo **);
 
 #ifndef HAVE_GETNAMEINFO
 #define getnameinfo rk_getnameinfo
-ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-getnameinfo(const struct sockaddr *, socklen_t,
-		char *, size_t,
-		char *, size_t,
-		int);
 #endif
+ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
+rk_getnameinfo(const struct sockaddr *, socklen_t,
+	       char *, size_t,
+	       char *, size_t,
+	       int);
 
 #ifndef HAVE_FREEADDRINFO
 #define freeaddrinfo rk_freeaddrinfo
-ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
-freeaddrinfo(struct addrinfo *);
 #endif
+ROKEN_LIB_FUNCTION void ROKEN_LIB_CALL
+rk_freeaddrinfo(struct addrinfo *);
 
 #ifndef HAVE_GAI_STRERROR
 #define gai_strerror rk_gai_strerror


### PR DESCRIPTION
Roken functions rk_copyhostent(), rk_freeaddrinfo(), rk_freehostent() rk_getaddrinfo(), rk_getipnodebyaddr(),  rk_getipnodebyname(), and rk_getnameinfo() should never be built without the "rk_" prefix.  Doing so overrides the system provided functions of the same name when they exist.

(cherry picked from commit 7b3a99323632677d4255532049cc5a1031d8f706)