### PR TITLE
Svace found an error in file kdc/digest.c. Return value of a function…

### DIFF
--- a/kdc/digest.c
+++ b/kdc/digest.c
@@ -518,7 +518,11 @@ _kdc_do_digest(krb5_context context,
 	    goto out;
 	}
 
-	krb5_store_stringz(sp, ireq.u.digestRequest.serverNonce);
+	ret = 	krb5_store_stringz(sp, ireq.u.digestRequest.serverNonce);
+	if (ret) {
+	    krb5_clear_error_message(context);
+	    goto out;
+	}
 
 	if (ireq.u.digestRequest.hostname) {
 	    ret = krb5_store_stringz(sp, *ireq.u.digestRequest.hostname);


### PR DESCRIPTION
… 'krb5_store_stringz' is not checked
**General error description**:
Return value of a function 'krb5_store_stringz' called at digest.c:519 is not checked, but it is usually checked for this function (26/27).
**Solution**: I added a check for the value that the function 'krb5_store_stringz' returns.
**P.S.** Svace is a static analyzer that detects over 50 classes of critical errors in source code. It supports C, C++, C#, Java; Kotlin and Go. https://www.ispras.ru/en/technologies/svace/