### PR TITLE
Found an error in file lib/krb5/send_to_kdc.c.

### DIFF
--- a/lib/krb5/send_to_kdc.c
+++ b/lib/krb5/send_to_kdc.c
@@ -757,7 +757,7 @@ eval_host_state(krb5_context context,
     if (host->state == CONNECTING && writeable)
 	host_connected(context, ctx, host);
 
-    if (readable) {
+    if (host->state != DEAD && readable) {
 
 	debug_host(context, 5, host, "reading packet");
 


### PR DESCRIPTION
**General error description**:
Variable 'host->fd', which may receive negative value at send_to_kdc.c:499 by calling function 'host_connected' at send_to_kdc.c:758, is used at send_to_kdc.c:403 by calling function 'host_dead' at send_to_kdc.c:772.
**Solution**:
I modified the test conditions on line 760 - I added the expression host->state != DEAD to the condition via the && operation.