### PR TITLE
Heimdal aix atomics

### DIFF
--- a/lib/base/heimbase-atomics.h
+++ b/lib/base/heimbase-atomics.h
@@ -103,10 +103,10 @@
 
 #define heim_base_atomic_barrier()	__isync()
 
-#define heim_base_atomic_inc(x)		(fetch_and_add((atomic_p)(x)) + 1)
-#define heim_base_atomic_dec(x)		(fetch_and_add((atomic_p)(x)) - 1)
-#define heim_base_atomic_integer_type	unsigned int
-#define heim_base_atomic_integer_max	UINT_MAX
+#define heim_base_atomic_inc(x)		(fetch_and_add((atomic_p)(x),  1) + 1)
+#define heim_base_atomic_dec(x)		(fetch_and_add((atomic_p)(x), -1) - 1)
+#define heim_base_atomic_integer_type	int
+#define heim_base_atomic_integer_max	INT_MAX
 
 static inline void *
 heim_base_exchange_pointer(void *p, void *newval)

--- a/lib/base/heimbase-atomics.h
+++ b/lib/base/heimbase-atomics.h
@@ -103,10 +103,10 @@
 
 #define heim_base_atomic_barrier()	__isync()
 
-#define heim_base_atomic_inc(x)		(fetch_and_add((atomic_p)(x),  1) + 1)
-#define heim_base_atomic_dec(x)		(fetch_and_add((atomic_p)(x), -1) - 1)
-#define heim_base_atomic_integer_type	int
-#define heim_base_atomic_integer_max	INT_MAX
+#define heim_base_atomic_inc(x)		(fetch_and_addlp((atomic_l)(x),  1) + 1)
+#define heim_base_atomic_dec(x)		(fetch_and_addlp((atomic_l)(x), -1) - 1)
+#define heim_base_atomic_integer_type	long
+#define heim_base_atomic_integer_max	LONG_MAX
 
 static inline void *
 heim_base_exchange_pointer(void *p, void *newval)


### PR DESCRIPTION

commit acad7be65ec3dd504470f8f8a4d6f353718e93bc
Author: Luke Howard <lukeh@padl.com>
Date:   Wed Dec 9 11:00:11 2015 +1100

    base: Solaris and AIX atomic increment/exchange
    
    Implement heim_base_atomic_XXX and heim_base_exchange_pointer
    for Solaris and AIX. (AIX not tested.)

introduced untested support for aix, untested code is broken code...

So this is tested on AIX 7 now.