### PR TITLE
only announce enabled pa types

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1997,7 +1997,10 @@ add_enc_pa_rep(astgs_request_t r)
 			  KRB5_PADATA_REQ_ENC_PA_REP, cdata.data, cdata.length);
     if (ret)
 	return ret;
-    
+
+    if (!r->config->enable_fast)
+	return 0;
+
     return krb5_padata_add(r->context, r->ek.encrypted_pa_data,
 			   KRB5_PADATA_FX_FAST, NULL, 0);
 }
@@ -2305,6 +2308,8 @@ _kdc_as_rep(astgs_request_t r)
 		if (!r->armor_crypto && !r->config->enable_unarmored_pa_enc_timestamp)
 		    continue;
 	    }
+	    if (pat[n].type == KRB5_PADATA_FX_FAST && !r->config->enable_fast)
+		continue;
 
 	    ret = krb5_padata_add(r->context, r->rep.padata,
 				  pat[n].type, NULL, 0);

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2302,6 +2302,8 @@ _kdc_as_rep(astgs_request_t r)
 
 	    if (!r->armor_crypto && (pat[n].flags & PA_REQ_FAST))
 		continue;
+	    if (pat[n].type == KRB5_PADATA_PKINIT_KX && !r->config->allow_anonymous)
+		continue;
 	    if (pat[n].type == KRB5_PADATA_ENC_TIMESTAMP) {
 		if (r->armor_crypto && !r->config->enable_armored_pa_enc_timestamp)
 		    continue;

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2312,6 +2312,8 @@ _kdc_as_rep(astgs_request_t r)
 	    }
 	    if (pat[n].type == KRB5_PADATA_FX_FAST && !r->config->enable_fast)
 		continue;
+	    if (pat[n].type == KRB5_PADATA_GSS && !r->config->enable_gss_preauth)
+		continue;
 
 	    ret = krb5_padata_add(r->context, r->rep.padata,
 				  pat[n].type, NULL, 0);


### PR DESCRIPTION
It confuses clients if the kdc announces support for a pa-type, e.g. KRB5_PADATA_FX_FAST and later ignore/reject it