### PR TITLE
roken/mkdtemp.c: fix incorrect indexing

### DIFF
--- a/lib/roken/mkdtemp.c
+++ b/lib/roken/mkdtemp.c
@@ -59,9 +59,8 @@ mkdtemp(char *template)
     pid_t val = getpid();
 
     for (i = 0; i < len && i < 7 && template[len - i] == 'X'; i++) {
-	template[len] = '0' + val % 10;
+	template[len - i] = '0' + val % 10;
 	val /= 10;
-	len--;
         if (!val)
             val = getpid();
     }


### PR DESCRIPTION
Both the len and the index was decremented, which made the exit condition (template[len - i] == 'X') trigger before it should. Fixes solaris10 where mkdtemp is not available.