### PR TITLE
roken/parse_bytes: fix test for >= terabyte units on 32 bit systems

### DIFF
--- a/kcm/config.c
+++ b/kcm/config.c
@@ -36,6 +36,8 @@
 #include <getarg.h>
 #include <parse_bytes.h>
 
+#define MAX_REQUEST_MAX 67108864ll /* 64MB, the maximum accepted value of max_request */
+
 static const char *config_file;	/* location of kcm config file */
 
 size_t max_request = 0;		/* maximal size of a request */
@@ -360,13 +362,16 @@ kcm_configure(int argc, char **argv)
     }
 
     if (max_request_str) {
-        ssize_t bytes;
+        int64_t bytes;
 
         if ((bytes = parse_bytes(max_request_str, NULL)) < 0)
             krb5_errx(kcm_context, 1,
                       "--max-request size must be non-negative");
+        if (bytes > MAX_REQUEST_MAX)
+            krb5_errx(kcm_context, 1, "--max-request size is too big "
+                      "(must be smaller than %lld)", MAX_REQUEST_MAX);
 
-	max_request = bytes;
+        max_request = bytes;
     }
 
     if(max_request == 0){
@@ -376,11 +381,15 @@ kcm_configure(int argc, char **argv)
 				    "max-request",
 				    NULL);
         if (p) {
-            ssize_t bytes;
+            int64_t bytes;
 
             if ((bytes = parse_bytes(max_request_str, NULL)) < 0)
                 krb5_errx(kcm_context, 1,
                           "[kcm] max-request size must be non-negative");
+            if (bytes > MAX_REQUEST_MAX)
+                krb5_errx(kcm_context, 1, "[kcm] max-request size is too big "
+                          "(must be smaller than %lld)", MAX_REQUEST_MAX);
+
             max_request = bytes;
         }
     }

--- a/lib/asn1/check-gen.c
+++ b/lib/asn1/check-gen.c
@@ -2162,9 +2162,9 @@ test_default(void)
     };
 
     TESTDefault values[] = {
-	{ "Heimdal", 8, 9223372036854775807, 1 },
+	{ "Heimdal", 8, 9223372036854775807LL, 1 },
 	{ "heimdal", 7, 2147483647, 0 },
-	{ "Heimdal", 7, 9223372036854775807, 0 },
+	{ "Heimdal", 7, 9223372036854775807LL, 0 },
 	{ "heimdal", 8, 2147483647, 1 },
     };
     int i, ret;

--- a/lib/asn1/check-gen.c
+++ b/lib/asn1/check-gen.c
@@ -54,6 +54,12 @@
 static int my_copy_vers_called;
 static int my_free_vers_called;
 
+#include <limits.h>
+#if UINT_MAX == 0xffffffff
+// 32 bit
+#define DISABLE_TEST_64
+#endif
+
 int
 my_copy_vers(const my_vers *from, my_vers *to)
 {
@@ -2143,17 +2149,21 @@ static int
 test_default(void)
 {
     struct test_case tests[] = {
+#ifndef DISABLE_TEST_64
 	{ NULL, 2, "\x30\x00", NULL },
+#endif
 	{ NULL, 25,
           "\x30\x17\x0c\x07\x68\x65\x69\x6d\x64\x61"
           "\x6c\xa0\x03\x02\x01\x07\x02\x04\x7f\xff"
           "\xff\xff\x01\x01\x00",
 	  NULL
 	},
+#ifndef DISABLE_TEST_64
 	{ NULL, 10,
           "\x30\x08\xa0\x03\x02\x01\x07\x01\x01\x00",
 	  NULL
 	},
+#endif
 	{ NULL, 17,
           "\x30\x0f\x0c\x07\x68\x65\x69\x6d\x64\x61\x6c\x02\x04"
           "\x7f\xff\xff\xff",
@@ -2162,9 +2172,13 @@ test_default(void)
     };
 
     TESTDefault values[] = {
+#ifndef DISABLE_TEST_64
 	{ "Heimdal", 8, 9223372036854775807LL, 1 },
+#endif
 	{ "heimdal", 7, 2147483647, 0 },
+#ifndef DISABLE_TEST_64
 	{ "Heimdal", 7, 9223372036854775807LL, 0 },
+#endif
 	{ "heimdal", 8, 2147483647, 1 },
     };
     int i, ret;

--- a/lib/hx509/hxtool.c
+++ b/lib/hx509/hxtool.c
@@ -33,6 +33,7 @@
 
 #include "hx_locl.h"
 
+#include <stdint.h>
 #include <hxtool-commands.h>
 #include <sl.h>
 #include <rtbl.h>
@@ -1661,13 +1662,15 @@ random_data(void *opt, int argc, char **argv)
 {
     void *ptr;
     ssize_t len;
+    int64_t bytes;
     int ret;
 
-    len = parse_bytes(argv[0], "byte");
-    if (len <= 0) {
+    bytes = parse_bytes(argv[0], "byte");
+    if (bytes <= 0 || bytes > SSIZE_MAX) {
 	fprintf(stderr, "bad argument to random-data\n");
 	return 1;
     }
+    len = bytes;
 
     ptr = malloc(len);
     if (ptr == NULL) {

--- a/lib/roken/parse_bytes-test.c
+++ b/lib/roken/parse_bytes-test.c
@@ -38,7 +38,7 @@
 
 static struct testcase {
     int canonicalp;
-    ssize_t val;
+    int64_t val;
     const char *def_unit;
     const char *str;
 } tests[] = {
@@ -52,7 +52,7 @@ static struct testcase {
     {1, 1024 * 1024, NULL, "1 megabyte"},
     {0, 1025, NULL, "1 kilobyte 1"},
     {1, 1025, NULL, "1 kilobyte 1 byte"},
-    {1, 1024UL * 1024 * 1024 * 1024, NULL, "1 terabyte"},
+    {1, 1024ULL * 1024 * 1024 * 1024, NULL, "1 terabyte"},
 };
 
 int
@@ -63,7 +63,7 @@ main(int argc, char **argv)
 
     for (i = 0; i < sizeof(tests)/sizeof(tests[0]); ++i) {
 	char buf[256];
-	ssize_t val = parse_bytes (tests[i].str, tests[i].def_unit);
+	int64_t val = parse_bytes (tests[i].str, tests[i].def_unit);
 
 	if (val != tests[i].val) {
 	    printf ("parse_bytes (%s, %s) = %lld != %lld\n",

--- a/lib/roken/parse_bytes.c
+++ b/lib/roken/parse_bytes.c
@@ -37,10 +37,10 @@
 #include "parse_bytes.h"
 
 static struct units bytes_units[] = {
-    { "petabyte", 1024UL * 1024 * 1024 * 1024 * 1024 },
-    { "PB", 1024UL * 1024 * 1024 * 1024 * 1024 },
-    { "terabyte", 1024UL * 1024 * 1024 * 1024 },
-    { "TB", 1024UL * 1024 * 1024 * 1024 },
+    { "petabyte", 1024ULL * 1024 * 1024 * 1024 * 1024 },
+    { "PB", 1024ULL * 1024 * 1024 * 1024 * 1024 },
+    { "terabyte", 1024ULL * 1024 * 1024 * 1024 },
+    { "TB", 1024ULL * 1024 * 1024 * 1024 },
     { "gigabyte", 1024 * 1024 * 1024 },
     { "gbyte", 1024 * 1024 * 1024 },
     { "GB", 1024 * 1024 * 1024 },
@@ -54,28 +54,28 @@ static struct units bytes_units[] = {
 };
 
 static struct units bytes_short_units[] = {
-    { "PB", 1024UL * 1024 * 1024 * 1024 * 1024 },
-    { "TB", 1024UL * 1024 * 1024 * 1024 },
+    { "PB", 1024ULL * 1024 * 1024 * 1024 * 1024 },
+    { "TB", 1024ULL * 1024 * 1024 * 1024 },
     { "GB", 1024 * 1024 * 1024 },
     { "MB", 1024 * 1024 },
     { "KB", 1024 },
     { NULL, 0 }
 };
 
-ROKEN_LIB_FUNCTION ssize_t ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION int64_t ROKEN_LIB_CALL
 parse_bytes(const char *s, const char *def_unit)
 {
     return parse_units (s, bytes_units, def_unit);
 }
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_bytes(ssize_t t, char *s, size_t len)
+unparse_bytes(int64_t t, char *s, size_t len)
 {
     return unparse_units (t, bytes_units, s, len);
 }
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_bytes_short (ssize_t t, char *s, size_t len)
+unparse_bytes_short (int64_t t, char *s, size_t len)
 {
     return unparse_units_approx (t, bytes_short_units, s, len);
 }

--- a/lib/roken/parse_bytes.h
+++ b/lib/roken/parse_bytes.h
@@ -38,13 +38,13 @@
 
 #include <roken.h>
 
-ROKEN_LIB_FUNCTION ssize_t ROKEN_LIB_CALL
+ROKEN_LIB_FUNCTION int64_t ROKEN_LIB_CALL
 parse_bytes(const char *s, const char *def_unit);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_bytes(ssize_t t, char *s, size_t len);
+unparse_bytes(int64_t t, char *s, size_t len);
 
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL
-unparse_bytes_short(ssize_t t, char *s, size_t len);
+unparse_bytes_short(int64_t t, char *s, size_t len);
 
 #endif /* __PARSE_BYTES_H__ */


### PR DESCRIPTION
On 32 bit systems, sizeof(ssize_t) and sizeof(unsigned long aka UL) is 32 bits which is not able to hold the value of a terabyte.