### PR TITLE
Update krb5.conf

### DIFF
--- a/krb5.conf
+++ b/krb5.conf
@@ -1,3 +1,8 @@
+# The krb5.conf file can include other files using either of the following directives at the beginning of the line
+# see also krb5.conf(5)
+# include /etc/krb5-sssd.conf
+# includedir /etc/krb5.conf.d
+
 [libdefaults]
 	default_realm = MY.REALM
 	clockskew = 300


### PR DESCRIPTION
I would like to introduce a comment which mentions the ability including either configuration files or directory's. The situation in some Linux distributions are somewhat unclear, in terms of having a default include directory or not in krb5.conf e.g. /etc/krb5.conf.d/ 
Having a comment like this, gives the package maintainers the ability to define a default include or handover the situation to the specific software, which expects this folder. Thanks!
 