### PR TITLE
Some portability fixes

### DIFF
--- a/lib/asn1/template.c
+++ b/lib/asn1/template.c
@@ -3015,7 +3015,7 @@ _asn1_copy(const struct asn1_template *t, const void *from, void *to)
 	    unsigned int i;
 
 	    tel->val = calloc(fel->len, ellen);
-	    if (tel->val == NULL)
+	    if (tel->val == NULL && fel->len > 0)
 		return ENOMEM;
 
 	    tel->len = fel->len;

--- a/lib/base/heimbase-atomics.h
+++ b/lib/base/heimbase-atomics.h
@@ -357,7 +357,7 @@ heim_base_cas_64(heim_base_atomic(uint64_t) *target, uint64_t expected,uint64_t 
 #endif
 
 #ifndef heim_base_atomic_barrier
-#define heim_base_atomic_barrier()
+static inline void heim_base_atomic_barrier(void) { return; }
 #endif
 
 #ifndef heim_base_atomic_load

--- a/lib/gssapi/spnego/context_storage.c
+++ b/lib/gssapi/spnego/context_storage.c
@@ -55,6 +55,10 @@ ret_negoex_auth_mech(krb5_storage *sp, struct negoex_auth_mech **mechp);
 static krb5_error_code
 store_negoex_auth_mech(krb5_storage *sp, struct negoex_auth_mech *mech);
 
+#ifdef sc_flags
+#undef sc_flags
+#endif
+
 static uint16_t
 spnego_flags_to_int(struct spnego_flags flags);
 static struct spnego_flags


### PR DESCRIPTION
roken: provide a getline implementation from libedit if needed
spnego/context_storage: undef sc_flags (for hpux)
heimdal/asn1: do not throw error when trying to allocate 0 bytes of memory
heimbase-atomics.h: replace heim_base_atomic_barrier with syntax valid noop
