### PR TITLE
gss: use mechglue instead of gsskrb5 encoders

### DIFF
--- a/lib/gssapi/krb5/8003.c
+++ b/lib/gssapi/krb5/8003.c
@@ -33,48 +33,6 @@
 
 #include "gsskrb5_locl.h"
 
-krb5_error_code
-_gsskrb5_encode_om_uint32(OM_uint32 n, u_char *p)
-{
-  p[0] = (n >> 0)  & 0xFF;
-  p[1] = (n >> 8)  & 0xFF;
-  p[2] = (n >> 16) & 0xFF;
-  p[3] = (n >> 24) & 0xFF;
-  return 0;
-}
-
-krb5_error_code
-_gsskrb5_encode_be_om_uint32(OM_uint32 n, u_char *p)
-{
-  p[0] = (n >> 24) & 0xFF;
-  p[1] = (n >> 16) & 0xFF;
-  p[2] = (n >> 8)  & 0xFF;
-  p[3] = (n >> 0)  & 0xFF;
-  return 0;
-}
-
-krb5_error_code
-_gsskrb5_decode_om_uint32(const void *ptr, OM_uint32 *n)
-{
-    const u_char *p = ptr;
-    *n = ((uint32_t)p[0])
-       | ((uint32_t)p[1] << 8)
-       | ((uint32_t)p[2] << 16)
-       | ((uint32_t)p[3] << 24);
-    return 0;
-}
-
-krb5_error_code
-_gsskrb5_decode_be_om_uint32(const void *ptr, OM_uint32 *n)
-{
-    const u_char *p = ptr;
-    *n = ((uint32_t)p[0] <<24)
-       | ((uint32_t)p[1] << 16)
-       | ((uint32_t)p[2] << 8)
-       | ((uint32_t)p[3]);
-    return 0;
-}
-
 static krb5_error_code
 hash_input_chan_bindings (const gss_channel_bindings_t b,
 			  u_char *p)
@@ -85,23 +43,23 @@ hash_input_chan_bindings (const gss_channel_bindings_t b,
   ctx = EVP_MD_CTX_create();
   EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
 
-  _gsskrb5_encode_om_uint32 (b->initiator_addrtype, num);
+  _gss_mg_encode_le_uint32 (b->initiator_addrtype, num);
   EVP_DigestUpdate(ctx, num, sizeof(num));
-  _gsskrb5_encode_om_uint32 (b->initiator_address.length, num);
+  _gss_mg_encode_le_uint32 (b->initiator_address.length, num);
   EVP_DigestUpdate(ctx, num, sizeof(num));
   if (b->initiator_address.length)
       EVP_DigestUpdate(ctx,
 		       b->initiator_address.value,
 		       b->initiator_address.length);
-  _gsskrb5_encode_om_uint32 (b->acceptor_addrtype, num);
+  _gss_mg_encode_le_uint32 (b->acceptor_addrtype, num);
   EVP_DigestUpdate(ctx, num, sizeof(num));
-  _gsskrb5_encode_om_uint32 (b->acceptor_address.length, num);
+  _gss_mg_encode_le_uint32 (b->acceptor_address.length, num);
   EVP_DigestUpdate(ctx, num, sizeof(num));
   if (b->acceptor_address.length)
       EVP_DigestUpdate(ctx,
 		       b->acceptor_address.value,
 		       b->acceptor_address.length);
-  _gsskrb5_encode_om_uint32 (b->application_data.length, num);
+  _gss_mg_encode_le_uint32 (b->application_data.length, num);
   EVP_DigestUpdate(ctx, num, sizeof(num));
   if (b->application_data.length)
       EVP_DigestUpdate(ctx,
@@ -144,7 +102,7 @@ _gsskrb5_create_8003_checksum (
     }
 
     p = result->checksum.data;
-    _gsskrb5_encode_om_uint32 (16, p);
+    _gss_mg_encode_le_uint32 (16, p);
     p += 4;
     if (input_chan_bindings == GSS_C_NO_CHANNEL_BINDINGS) {
 	memset (p, 0, 16);
@@ -152,7 +110,7 @@ _gsskrb5_create_8003_checksum (
 	hash_input_chan_bindings (input_chan_bindings, p);
     }
     p += 16;
-    _gsskrb5_encode_om_uint32 (flags, p);
+    _gss_mg_encode_le_uint32 (flags, p);
     p += 4;
 
     if (fwd_data->length > 0 && (flags & GSS_C_DELEG_FLAG)) {
@@ -244,7 +202,7 @@ _gsskrb5_verify_8003_checksum(
     }
 
     p = cksum->checksum.data;
-    _gsskrb5_decode_om_uint32(p, &length);
+    _gss_mg_decode_le_uint32(p, &length);
     if(length != sizeof(hash)) {
 	*minor_status = 0;
 	return GSS_S_BAD_BINDINGS;
@@ -273,7 +231,7 @@ _gsskrb5_verify_8003_checksum(
 
     p += sizeof(hash);
 
-    _gsskrb5_decode_om_uint32(p, flags);
+    _gss_mg_decode_le_uint32(p, flags);
     p += 4;
 
     if (cksum->checksum.length > 24 && (*flags & GSS_C_DELEG_FLAG)) {

--- a/lib/gssapi/krb5/arcfour.c
+++ b/lib/gssapi/krb5/arcfour.c
@@ -293,7 +293,7 @@ _gssapi_get_mic_arcfour(OM_uint32 * minor_status,
 				     context_handle->auth_context,
 				     &seq_number);
     p = p0 + 8; /* SND_SEQ */
-    _gsskrb5_encode_be_om_uint32(seq_number, p);
+    _gss_mg_encode_be_uint32(seq_number, p);
 
     krb5_auth_con_setlocalseqnumber (context,
 				     context_handle->auth_context,
@@ -385,7 +385,7 @@ _gssapi_verify_mic_arcfour(OM_uint32 * minor_status,
 	memset(k6_data, 0, sizeof(k6_data));
     }
 
-    _gsskrb5_decode_be_om_uint32(SND_SEQ, &seq_number);
+    _gss_mg_decode_be_uint32(SND_SEQ, &seq_number);
 
     if (context_handle->more_flags & LOCAL)
 	cmp = (ct_memcmp(&SND_SEQ[4], "\xff\xff\xff\xff", 4) != 0);
@@ -473,7 +473,7 @@ _gssapi_wrap_arcfour(OM_uint32 * minor_status,
 				     context_handle->auth_context,
 				     &seq_number);
 
-    _gsskrb5_encode_be_om_uint32(seq_number, p0 + 8);
+    _gss_mg_encode_be_uint32(seq_number, p0 + 8);
 
     krb5_auth_con_setlocalseqnumber (context,
 				     context_handle->auth_context,
@@ -656,7 +656,7 @@ OM_uint32 _gssapi_unwrap_arcfour(OM_uint32 *minor_status,
 	memset_s(k6_data, sizeof(k6_data), 0, sizeof(k6_data));
     }
 
-    _gsskrb5_decode_be_om_uint32(SND_SEQ, &seq_number);
+    _gss_mg_decode_be_uint32(SND_SEQ, &seq_number);
 
     if (context_handle->more_flags & LOCAL)
 	cmp = (ct_memcmp(&SND_SEQ[4], "\xff\xff\xff\xff", 4) != 0);
@@ -1042,7 +1042,7 @@ _gssapi_wrap_iov_arcfour(OM_uint32 *minor_status,
     krb5_auth_con_getlocalseqnumber(context,
 				    ctx->auth_context,
 				    &seq_number);
-    _gsskrb5_encode_be_om_uint32(seq_number, p0 + 8);
+    _gss_mg_encode_be_uint32(seq_number, p0 + 8);
 
     krb5_auth_con_setlocalseqnumber(context,
 				    ctx->auth_context,
@@ -1279,7 +1279,7 @@ _gssapi_unwrap_iov_arcfour(OM_uint32 *minor_status,
 	memset(k6_data, 0, sizeof(k6_data));
     }
 
-    _gsskrb5_decode_be_om_uint32(snd_seq, &seq_number);
+    _gss_mg_decode_be_uint32(snd_seq, &seq_number);
 
     if (ctx->more_flags & LOCAL) {
 	cmp = (ct_memcmp(&snd_seq[4], "\xff\xff\xff\xff", 4) != 0);

--- a/lib/gssapi/krb5/cfx.c
+++ b/lib/gssapi/krb5/cfx.c
@@ -505,8 +505,8 @@ _gssapi_wrap_cfx_iov(OM_uint32 *minor_status,
     krb5_auth_con_getlocalseqnumber(context,
 				    ctx->auth_context,
 				    &seq_number);
-    _gsskrb5_encode_be_om_uint32(0,          &token->SND_SEQ[0]);
-    _gsskrb5_encode_be_om_uint32(seq_number, &token->SND_SEQ[4]);
+    _gss_mg_encode_be_uint32(0,          &token->SND_SEQ[0]);
+    _gss_mg_encode_be_uint32(seq_number, &token->SND_SEQ[4]);
     krb5_auth_con_setlocalseqnumber(context,
 				    ctx->auth_context,
 				    ++seq_number);
@@ -817,8 +817,8 @@ _gssapi_unwrap_cfx_iov(OM_uint32 *minor_status,
     /*
      * Check sequence number
      */
-    _gsskrb5_decode_be_om_uint32(&token->SND_SEQ[0], &seq_number_hi);
-    _gsskrb5_decode_be_om_uint32(&token->SND_SEQ[4], &seq_number_lo);
+    _gss_mg_decode_be_uint32(&token->SND_SEQ[0], &seq_number_hi);
+    _gss_mg_decode_be_uint32(&token->SND_SEQ[4], &seq_number_lo);
     if (seq_number_hi) {
 	/* no support for 64-bit sequence numbers */
 	*minor_status = ERANGE;
@@ -1271,8 +1271,8 @@ OM_uint32 _gssapi_wrap_cfx(OM_uint32 *minor_status,
     krb5_auth_con_getlocalseqnumber(context,
 				    ctx->auth_context,
 				    &seq_number);
-    _gsskrb5_encode_be_om_uint32(0,          &token->SND_SEQ[0]);
-    _gsskrb5_encode_be_om_uint32(seq_number, &token->SND_SEQ[4]);
+    _gss_mg_encode_be_uint32(0,          &token->SND_SEQ[0]);
+    _gss_mg_encode_be_uint32(seq_number, &token->SND_SEQ[4]);
     krb5_auth_con_setlocalseqnumber(context,
 				    ctx->auth_context,
 				    ++seq_number);
@@ -1458,8 +1458,8 @@ OM_uint32 _gssapi_unwrap_cfx(OM_uint32 *minor_status,
     /*
      * Check sequence number
      */
-    _gsskrb5_decode_be_om_uint32(&token->SND_SEQ[0], &seq_number_hi);
-    _gsskrb5_decode_be_om_uint32(&token->SND_SEQ[4], &seq_number_lo);
+    _gss_mg_decode_be_uint32(&token->SND_SEQ[0], &seq_number_hi);
+    _gss_mg_decode_be_uint32(&token->SND_SEQ[4], &seq_number_lo);
     if (seq_number_hi) {
 	/* no support for 64-bit sequence numbers */
 	*minor_status = ERANGE;
@@ -1642,8 +1642,8 @@ OM_uint32 _gssapi_mic_cfx(OM_uint32 *minor_status,
     krb5_auth_con_getlocalseqnumber(context,
 				    ctx->auth_context,
 				    &seq_number);
-    _gsskrb5_encode_be_om_uint32(0,          &token->SND_SEQ[0]);
-    _gsskrb5_encode_be_om_uint32(seq_number, &token->SND_SEQ[4]);
+    _gss_mg_encode_be_uint32(0,          &token->SND_SEQ[0]);
+    _gss_mg_encode_be_uint32(seq_number, &token->SND_SEQ[4]);
     krb5_auth_con_setlocalseqnumber(context,
 				    ctx->auth_context,
 				    ++seq_number);
@@ -1736,8 +1736,8 @@ OM_uint32 _gssapi_verify_mic_cfx(OM_uint32 *minor_status,
     /*
      * Check sequence number
      */
-    _gsskrb5_decode_be_om_uint32(&token->SND_SEQ[0], &seq_number_hi);
-    _gsskrb5_decode_be_om_uint32(&token->SND_SEQ[4], &seq_number_lo);
+    _gss_mg_decode_be_uint32(&token->SND_SEQ[0], &seq_number_hi);
+    _gss_mg_decode_be_uint32(&token->SND_SEQ[4], &seq_number_lo);
     if (seq_number_hi) {
 	*minor_status = ERANGE;
 	return GSS_S_UNSEQ_TOKEN;

--- a/lib/gssapi/krb5/inquire_sec_context_by_oid.c
+++ b/lib/gssapi/krb5/inquire_sec_context_by_oid.c
@@ -90,7 +90,7 @@ static OM_uint32 inquire_sec_context_tkt_flags
     tkt_flags = TicketFlags2int(context_handle->ticket->ticket.flags);
     HEIMDAL_MUTEX_unlock(&context_handle->ctx_id_mutex);
 
-    _gsskrb5_encode_om_uint32(tkt_flags, buf);
+    _gss_mg_encode_le_uint32(tkt_flags, buf);
     value.length = sizeof(buf);
     value.value = buf;
 
@@ -445,7 +445,7 @@ get_authtime(OM_uint32 *minor_status,
 
     HEIMDAL_MUTEX_unlock(&ctx->ctx_id_mutex);
 
-    _gsskrb5_encode_om_uint32(authtime, buf);
+    _gss_mg_encode_le_uint32(authtime, buf);
     value.length = sizeof(buf);
     value.value = buf;
 

--- a/lib/gssapi/krb5/inquire_sec_context_by_oid.c
+++ b/lib/gssapi/krb5/inquire_sec_context_by_oid.c
@@ -430,8 +430,8 @@ get_authtime(OM_uint32 *minor_status,
 
 {
     gss_buffer_desc value;
-    unsigned char buf[4];
-    OM_uint32 authtime;
+    unsigned char buf[SIZEOF_TIME_T];
+    time_t authtime;
 
     HEIMDAL_MUTEX_lock(&ctx->ctx_id_mutex);
     if (ctx->ticket == NULL) {
@@ -445,7 +445,13 @@ get_authtime(OM_uint32 *minor_status,
 
     HEIMDAL_MUTEX_unlock(&ctx->ctx_id_mutex);
 
+#if SIZEOF_TIME_T == 8
+    _gss_mg_encode_le_uint64(authtime, buf);
+#elif SIZEOF_TIME_T == 4
     _gss_mg_encode_le_uint32(authtime, buf);
+#else
+#error set SIZEOF_TIME_T for your platform
+#endif
     value.length = sizeof(buf);
     value.value = buf;
 

--- a/lib/gssapi/krb5/prf.c
+++ b/lib/gssapi/krb5/prf.c
@@ -119,7 +119,7 @@ _gsskrb5_pseudo_random(OM_uint32 *minor_status,
     while(dol > 0) {
 	size_t tsize;
 
-	_gsskrb5_encode_be_om_uint32(num, input.data);
+	_gss_mg_encode_be_uint32(num, input.data);
 
 	ret = krb5_crypto_prf(context, crypto, &input, &output);
 	if (ret) {

--- a/lib/gssapi/krb5/unwrap.c
+++ b/lib/gssapi/krb5/unwrap.c
@@ -163,7 +163,7 @@ unwrap_des
   memset (&schedule, 0, sizeof(schedule));
 
   seq = p;
-  _gsskrb5_decode_om_uint32(seq, &seq_number);
+  _gss_mg_decode_be_uint32(seq, &seq_number);
 
   if (context_handle->more_flags & LOCAL)
       cmp = ct_memcmp(&seq[4], "\xff\xff\xff\xff", 4);
@@ -335,7 +335,7 @@ unwrap_des3
   }
 
   seq = seq_data.data;
-  _gsskrb5_decode_om_uint32(seq, &seq_number);
+  _gss_mg_decode_be_uint32(seq, &seq_number);
 
   if (context_handle->more_flags & LOCAL)
       cmp = ct_memcmp(&seq[4], "\xff\xff\xff\xff", 4);

--- a/lib/gssapi/krb5/verify_mic.c
+++ b/lib/gssapi/krb5/verify_mic.c
@@ -109,7 +109,7 @@ verify_mic_des
   memset_s(&schedule, sizeof(schedule), 0, sizeof(schedule));
 
   seq = p;
-  _gsskrb5_decode_om_uint32(seq, &seq_number);
+  _gss_mg_decode_be_uint32(seq, &seq_number);
 
   if (context_handle->more_flags & LOCAL)
       cmp = ct_memcmp(&seq[4], "\xff\xff\xff\xff", 4);
@@ -211,7 +211,7 @@ retry:
   HEIMDAL_MUTEX_lock(&context_handle->ctx_id_mutex);
 
   seq = seq_data.data;
-  _gsskrb5_decode_om_uint32(seq, &seq_number);
+  _gss_mg_decode_be_uint32(seq, &seq_number);
 
   if (context_handle->more_flags & LOCAL)
       cmp = ct_memcmp(&seq[4], "\xff\xff\xff\xff", 4);

--- a/lib/gssapi/mech/gss_krb5.c
+++ b/lib/gssapi/mech/gss_krb5.c
@@ -538,6 +538,7 @@ gsskrb5_extract_authtime_from_sec_context(OM_uint32 *minor_status,
 {
     gss_buffer_set_t data_set = GSS_C_NO_BUFFER_SET;
     OM_uint32 maj_stat;
+    uint32_t tmp;
 
     if (context_handle == GSS_C_NO_CONTEXT) {
 	*minor_status = EINVAL;
@@ -570,12 +571,8 @@ gsskrb5_extract_authtime_from_sec_context(OM_uint32 *minor_status,
 	return GSS_S_FAILURE;
     }
 
-    {
-	unsigned char *buf = data_set->elements[0].value;
-	*authtime = ((unsigned long)buf[3] <<24) | (buf[2] << 16) |
-	    (buf[1] << 8) | (buf[0] << 0);
-    }
-
+    _gss_mg_decode_le_uint32(data_set->elements[0].value, &tmp);
+    *authtime = (time_t)tmp;
     gss_release_buffer_set(minor_status, &data_set);
 
     *minor_status = 0;
@@ -844,10 +841,7 @@ gss_krb5_get_tkt_flags(OM_uint32 *minor_status,
 	return GSS_S_FAILURE;
     }
 
-    {
-	const u_char *p = data_set->elements[0].value;
-	*tkt_flags = (p[0] << 0) | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
-    }
+    _gss_mg_decode_le_uint32(data_set->elements[0].value, tkt_flags);
 
     gss_release_buffer_set(minor_status, &data_set);
     return GSS_S_COMPLETE;

--- a/lib/gssapi/mech/gss_utils.c
+++ b/lib/gssapi/mech/gss_utils.c
@@ -178,6 +178,60 @@ _gss_secure_release_buffer_set(OM_uint32 *minor_status,
 }
 
 void
+_gss_mg_encode_le_uint64(uint64_t n, uint8_t *p)
+{
+    p[0] = (n >> 0 ) & 0xFF;
+    p[1] = (n >> 8 ) & 0xFF;
+    p[2] = (n >> 16) & 0xFF;
+    p[3] = (n >> 24) & 0xFF;
+    p[4] = (n >> 32) & 0xFF;
+    p[5] = (n >> 40) & 0xFF;
+    p[6] = (n >> 48) & 0xFF;
+    p[7] = (n >> 56) & 0xFF;
+}
+
+void
+_gss_mg_decode_le_uint64(const void *ptr, uint64_t *n)
+{
+    const uint8_t *p = ptr;
+    *n = ((uint64_t)p[0] << 0)
+       | ((uint64_t)p[1] << 8)
+       | ((uint64_t)p[2] << 16)
+       | ((uint64_t)p[3] << 24)
+       | ((uint64_t)p[4] << 32)
+       | ((uint64_t)p[5] << 40)
+       | ((uint64_t)p[6] << 48)
+       | ((uint64_t)p[7] << 56);
+}
+
+void
+_gss_mg_encode_be_uint64(uint64_t n, uint8_t *p)
+{
+    p[0] = (n >> 56) & 0xFF;
+    p[1] = (n >> 48) & 0xFF;
+    p[2] = (n >> 40) & 0xFF;
+    p[3] = (n >> 32) & 0xFF;
+    p[4] = (n >> 24) & 0xFF;
+    p[5] = (n >> 16) & 0xFF;
+    p[6] = (n >> 8 ) & 0xFF;
+    p[7] = (n >> 0 ) & 0xFF;
+}
+
+void
+_gss_mg_decode_be_uint64(const void *ptr, uint64_t *n)
+{
+    const uint8_t *p = ptr;
+    *n = ((uint64_t)p[0] << 56)
+       | ((uint64_t)p[1] << 48)
+       | ((uint64_t)p[2] << 40)
+       | ((uint64_t)p[3] << 32)
+       | ((uint64_t)p[4] << 24)
+       | ((uint64_t)p[5] << 16)
+       | ((uint64_t)p[6] << 8)
+       | ((uint64_t)p[7] << 0);
+}
+
+void
 _gss_mg_encode_le_uint32(uint32_t n, uint8_t *p)
 {
     p[0] = (n >> 0 ) & 0xFF;

--- a/lib/gssapi/mech/utils.h
+++ b/lib/gssapi/mech/utils.h
@@ -36,6 +36,11 @@ OM_uint32 _gss_secure_release_buffer(OM_uint32 *minor_status,
 OM_uint32 _gss_secure_release_buffer_set(OM_uint32 *minor_status,
 					 gss_buffer_set_t *buffer_set);
 
+void _gss_mg_encode_le_uint64(uint64_t n, uint8_t *p);
+void _gss_mg_decode_le_uint64(const void *ptr, uint64_t *n);
+void _gss_mg_encode_be_uint64(uint64_t n, uint8_t *p);
+void _gss_mg_decode_be_uint64(const void *ptr, uint64_t *n);
+
 void _gss_mg_encode_le_uint32(uint32_t n, uint8_t *p);
 void _gss_mg_decode_le_uint32(const void *ptr, uint32_t *n);
 void _gss_mg_encode_be_uint32(uint32_t n, uint8_t *p);


### PR DESCRIPTION
Replace calls to `_gsskrb5_{en,de}code...()` with mechglue equivalents.