### PR TITLE
Implement `gss_get_mic_iov` and `gss_verify_mic_iov`

### DIFF
--- a/lib/gssapi/gssapi/gssapi.h
+++ b/lib/gssapi/gssapi/gssapi.h
@@ -956,6 +956,14 @@ GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
 gss_get_mic_iov(OM_uint32 *, gss_const_ctx_id_t, gss_iov_buffer_desc *, int);
 
 GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
+gss_verify_mic_iov(
+	OM_uint32 *,
+	gss_const_ctx_id_t,
+	gss_iov_buffer_desc *,
+	int,
+	const gss_buffer_t);
+
+GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
 gss_wrap_iov(OM_uint32 *, gss_ctx_id_t, int, gss_qop_t, int *,
 	     gss_iov_buffer_desc *, int);
 

--- a/lib/gssapi/gssapi/gssapi.h
+++ b/lib/gssapi/gssapi/gssapi.h
@@ -953,6 +953,9 @@ gss_decapsulate_token(gss_const_buffer_t /* input_token */,
  */
 
 GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
+gss_get_mic_iov(OM_uint32 *, gss_const_ctx_id_t, gss_iov_buffer_desc *, int);
+
+GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
 gss_wrap_iov(OM_uint32 *, gss_ctx_id_t, int, gss_qop_t, int *,
 	     gss_iov_buffer_desc *, int);
 

--- a/lib/gssapi/gssapi_mech.h
+++ b/lib/gssapi/gssapi_mech.h
@@ -124,6 +124,14 @@ typedef OM_uint32 GSSAPI_CALLCONV _gss_verify_mic_t
 	       gss_qop_t *             /* qop_state */
 	      );
 
+typedef OM_uint32 GSSAPI_CALLCONV _gss_verify_mic_iov_t
+	      (OM_uint32 *minor_status,
+	        gss_const_ctx_id_t context_handle,
+	        gss_iov_buffer_desc *iov, /* message iov */
+	        int iov_count,
+	        const gss_buffer_t token_buffer
+	      );
+
 typedef OM_uint32 GSSAPI_CALLCONV _gss_wrap_t
 	      (OM_uint32 *,            /* minor_status */
 	       gss_const_ctx_id_t,     /* context_handle */
@@ -588,6 +596,7 @@ typedef struct gssapi_mech_interface_desc {
 	_gss_get_mic_t			*gm_get_mic;
 	_gss_get_mic_iov_t		*gm_get_mic_iov;
 	_gss_verify_mic_t		*gm_verify_mic;
+	_gss_verify_mic_iov_t	*gm_verify_mic_iov;
 	_gss_wrap_t			*gm_wrap;
 	_gss_unwrap_t			*gm_unwrap;
 	_gss_display_status_t		*gm_display_status;

--- a/lib/gssapi/gssapi_mech.h
+++ b/lib/gssapi/gssapi_mech.h
@@ -109,6 +109,13 @@ typedef OM_uint32 GSSAPI_CALLCONV _gss_get_mic_t
 	       gss_buffer_t            /* message_token */
 	      );
 
+typedef OM_uint32 GSSAPI_CALLCONV _gss_get_mic_iov_t
+	      (OM_uint32 *minor_status,
+	        gss_const_ctx_id_t context_handle,
+	        gss_iov_buffer_desc *iov, /* iov buffers */
+	        int iov_count
+	      );
+
 typedef OM_uint32 GSSAPI_CALLCONV _gss_verify_mic_t
 	      (OM_uint32 *,            /* minor_status */
 	       gss_const_ctx_id_t,     /* context_handle */
@@ -579,6 +586,7 @@ typedef struct gssapi_mech_interface_desc {
 	_gss_delete_sec_context_t	*gm_delete_sec_context;
 	_gss_context_time_t		*gm_context_time;
 	_gss_get_mic_t			*gm_get_mic;
+	_gss_get_mic_iov_t		*gm_get_mic_iov;
 	_gss_verify_mic_t		*gm_verify_mic;
 	_gss_wrap_t			*gm_wrap;
 	_gss_unwrap_t			*gm_unwrap;

--- a/lib/gssapi/krb5/external.c
+++ b/lib/gssapi/krb5/external.c
@@ -346,6 +346,7 @@ static gssapi_mech_interface_desc krb5_mech = {
     _gsskrb5_delete_sec_context,
     _gsskrb5_context_time,
     _gsskrb5_get_mic,
+    _gsskrb5_get_mic_iov,
     _gsskrb5_verify_mic,
     _gsskrb5_wrap,
     _gsskrb5_unwrap,

--- a/lib/gssapi/krb5/external.c
+++ b/lib/gssapi/krb5/external.c
@@ -348,6 +348,7 @@ static gssapi_mech_interface_desc krb5_mech = {
     _gsskrb5_get_mic,
     _gsskrb5_get_mic_iov,
     _gsskrb5_verify_mic,
+    _gsskrb5_verify_mic_iov,
     _gsskrb5_wrap,
     _gsskrb5_unwrap,
     _gsskrb5_display_status,

--- a/lib/gssapi/krb5/get_mic.c
+++ b/lib/gssapi/krb5/get_mic.c
@@ -328,3 +328,23 @@ OM_uint32 GSSAPI_CALLCONV _gsskrb5_get_mic
   krb5_free_keyblock (context, key);
   return ret;
 }
+
+OM_uint32 GSSAPI_CALLCONV
+_gsskrb5_get_mic_iov(
+	OM_uint32 *minor_status,
+	gss_const_ctx_id_t context_handle,
+	gss_iov_buffer_desc *iov,
+	int iov_count)
+{
+	krb5_context context;
+	const gsskrb5_ctx ctx = (const gsskrb5_ctx)context_handle;
+
+	GSSAPI_KRB5_INIT(&context);
+
+	if (ctx->more_flags & IS_CFX) {
+		return _gssapi_get_mic_iov(minor_status, ctx, context, iov, iov_count);
+	} else {
+		*minor_status = 0;
+		return GSS_S_FAILURE;
+	}
+}

--- a/lib/gssapi/krb5/verify_mic.c
+++ b/lib/gssapi/krb5/verify_mic.c
@@ -358,3 +358,25 @@ _gsskrb5_verify_mic
 
     return ret;
 }
+
+OM_uint32 GSSAPI_CALLCONV
+_gsskrb5_verify_mic_iov(
+	OM_uint32 * minor_status,
+	gss_const_ctx_id_t context_handle,
+	gss_iov_buffer_desc *iov,
+	int iov_count,
+	const gss_buffer_t token_buffer)
+{
+	krb5_context context;
+	const gsskrb5_ctx ctx = (const gsskrb5_ctx)context_handle;
+
+	GSSAPI_KRB5_INIT(&context);
+
+	if (ctx->more_flags & IS_CFX) {
+		return _gssapi_verify_mic_iov(
+			minor_status, ctx, context, iov, iov_count, token_buffer);
+	} else {
+		*minor_status = 0;
+		return GSS_S_FAILURE;
+	}
+}

--- a/lib/gssapi/libgssapi-exports.def
+++ b/lib/gssapi/libgssapi-exports.def
@@ -43,6 +43,7 @@ EXPORTS
 	gss_export_name_composite
 	gss_export_sec_context
 	gss_get_mic
+	gss_get_mic_iov
 	gss_get_neg_mechs
 	gss_get_name_attribute
         gss_import_cred

--- a/lib/gssapi/libgssapi-exports.def
+++ b/lib/gssapi/libgssapi-exports.def
@@ -108,6 +108,7 @@ EXPORTS
 	gss_userok
 	gss_verify
 	gss_verify_mic
+	gss_verify_mic_iov
 	gss_wrap
 	gss_wrap_aead
 	gss_wrap_iov

--- a/lib/gssapi/mech/gss_get_mic.c
+++ b/lib/gssapi/mech/gss_get_mic.c
@@ -49,3 +49,32 @@ gss_get_mic(OM_uint32 *minor_status,
 	return (m->gm_get_mic(minor_status, ctx->gc_ctx, qop_req,
 		    message_buffer, message_token));
 }
+
+GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
+gss_get_mic_iov(
+	OM_uint32 *minor_status,
+	gss_const_ctx_id_t context_handle,
+	gss_iov_buffer_desc *iov,
+	int iov_count)
+{
+	struct _gss_context *ctx = (struct _gss_context *)context_handle;
+	gssapi_mech_interface m;
+
+	if (minor_status) {
+		*minor_status = 0;
+	}
+	if (ctx == NULL) {
+		return GSS_S_NO_CONTEXT;
+	}
+	if (iov == NULL && iov_count != 0) {
+		return GSS_S_CALL_INACCESSIBLE_READ;
+	}
+
+	m = ctx->gc_mech;
+
+	if (m->gm_get_mic_iov == NULL) {
+		return GSS_S_UNAVAILABLE;
+	}
+
+	return (m->gm_get_mic_iov)(minor_status, ctx->gc_ctx, iov, iov_count);
+}

--- a/lib/gssapi/mech/gss_verify_mic.c
+++ b/lib/gssapi/mech/gss_verify_mic.c
@@ -50,3 +50,29 @@ gss_verify_mic(OM_uint32 *minor_status,
 	return (m->gm_verify_mic(minor_status, ctx->gc_ctx,
 		    message_buffer, token_buffer, qop_state));
 }
+
+GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
+gss_verify_mic_iov(
+	OM_uint32 *minor_status,
+	gss_const_ctx_id_t context_handle,
+	gss_iov_buffer_desc *iov,
+	int iov_count,
+	const gss_buffer_t token_buffer)
+{
+	struct _gss_context *ctx = (struct _gss_context *) context_handle;
+	gssapi_mech_interface m;
+
+	if (ctx == NULL) {
+		*minor_status = 0;
+		return GSS_S_NO_CONTEXT;
+	}
+
+	m = ctx->gc_mech;
+
+	if (m->gm_verify_mic_iov == NULL) {
+		return GSS_S_UNAVAILABLE;
+	}
+
+	return (m->gm_verify_mic_iov(
+		minor_status, ctx->gc_ctx, iov, iov_count, token_buffer));
+}

--- a/lib/gssapi/netlogon/external.c
+++ b/lib/gssapi/netlogon/external.c
@@ -48,6 +48,7 @@ static gssapi_mech_interface_desc netlogon_mech = {
     _netlogon_delete_sec_context,
     _netlogon_context_time,
     _netlogon_get_mic,
+    NULL, /* gm_get_mic_iov */
     _netlogon_verify_mic,
     NULL,
     NULL,

--- a/lib/gssapi/netlogon/external.c
+++ b/lib/gssapi/netlogon/external.c
@@ -50,6 +50,7 @@ static gssapi_mech_interface_desc netlogon_mech = {
     _netlogon_get_mic,
     NULL, /* gm_get_mic_iov */
     _netlogon_verify_mic,
+    NULL, /* gm_verify_mic_iov */
     NULL,
     NULL,
     _netlogon_display_status,

--- a/lib/gssapi/ntlm/external.c
+++ b/lib/gssapi/ntlm/external.c
@@ -73,6 +73,7 @@ static gssapi_mech_interface_desc ntlm_mech = {
     _gss_ntlm_delete_sec_context,
     _gss_ntlm_context_time,
     _gss_ntlm_get_mic,
+    NULL, /* gm_get_mic_iov */
     _gss_ntlm_verify_mic,
     _gss_ntlm_wrap,
     _gss_ntlm_unwrap,

--- a/lib/gssapi/ntlm/external.c
+++ b/lib/gssapi/ntlm/external.c
@@ -75,6 +75,7 @@ static gssapi_mech_interface_desc ntlm_mech = {
     _gss_ntlm_get_mic,
     NULL, /* gm_get_mic_iov */
     _gss_ntlm_verify_mic,
+    NULL, /* gm_verify_mic_iov */
     _gss_ntlm_wrap,
     _gss_ntlm_unwrap,
     _gss_ntlm_display_status,

--- a/lib/gssapi/sanon/external.c
+++ b/lib/gssapi/sanon/external.c
@@ -205,6 +205,7 @@ static gssapi_mech_interface_desc sanon_mech = {
     _gss_sanon_get_mic,
     NULL, /* gm_get_mic_iov */
     _gss_sanon_verify_mic,
+    NULL, /* gm_verify_mic_iov */
     _gss_sanon_wrap,
     _gss_sanon_unwrap,
     _gss_sanon_display_status,

--- a/lib/gssapi/sanon/external.c
+++ b/lib/gssapi/sanon/external.c
@@ -203,6 +203,7 @@ static gssapi_mech_interface_desc sanon_mech = {
     _gss_sanon_delete_sec_context,
     _gss_sanon_context_time,
     _gss_sanon_get_mic,
+    NULL, /* gm_get_mic_iov */
     _gss_sanon_verify_mic,
     _gss_sanon_wrap,
     _gss_sanon_unwrap,

--- a/lib/gssapi/spnego/external.c
+++ b/lib/gssapi/spnego/external.c
@@ -97,6 +97,7 @@ static gssapi_mech_interface_desc spnego_mech = {
     _gss_spnego_delete_sec_context,
     _gss_spnego_context_time,
     _gss_spnego_get_mic,
+    NULL, /* gm_get_mic_iov */
     _gss_spnego_verify_mic,
     _gss_spnego_wrap,
     _gss_spnego_unwrap,

--- a/lib/gssapi/spnego/external.c
+++ b/lib/gssapi/spnego/external.c
@@ -99,6 +99,7 @@ static gssapi_mech_interface_desc spnego_mech = {
     _gss_spnego_get_mic,
     NULL, /* gm_get_mic_iov */
     _gss_spnego_verify_mic,
+    NULL, /* gm_verify_mic_iov */
     _gss_spnego_wrap,
     _gss_spnego_unwrap,
     NULL, /* gm_display_status */

--- a/lib/gssapi/version-script.map
+++ b/lib/gssapi/version-script.map
@@ -102,6 +102,7 @@ HEIMDAL_GSS_2.0 {
 		gss_userok;
 		gss_verify;
 		gss_verify_mic;
+		gss_verify_mic_iov;
 		gss_wrap;
 		gss_wrap_aead;
 		gss_wrap_iov;

--- a/lib/gssapi/version-script.map
+++ b/lib/gssapi/version-script.map
@@ -46,6 +46,7 @@ HEIMDAL_GSS_2.0 {
 		gss_export_name_composite;
 		gss_export_sec_context;
 		gss_get_mic;
+		gss_get_mic_iov;
 		gss_get_neg_mechs;
 		gss_get_name_attribute;
 		gss_import_cred;

--- a/lib/libedit/config.h.in
+++ b/lib/libedit/config.h.in
@@ -48,8 +48,8 @@
 /* Define to 1 if you have the <limits.h> header file. */
 #undef HAVE_LIMITS_H
 
-/* Define to 1 if you have the <minix/config.h> header file. */
-#undef HAVE_MINIX_CONFIG_H
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
 
 /* Define to 1 if you have the <ncurses.h> header file. */
 #undef HAVE_NCURSES_H
@@ -66,9 +66,6 @@
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
-
-/* Define to 1 if you have the <stdio.h> header file. */
-#undef HAVE_STDIO_H
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #undef HAVE_STDLIB_H
@@ -123,9 +120,6 @@
 /* Define to 1 if you have the <vfork.h> header file. */
 #undef HAVE_VFORK_H
 
-/* Define to 1 if you have the <wchar.h> header file. */
-#undef HAVE_WCHAR_H
-
 /* Define to 1 if you have the `wcsdup' function. */
 #undef HAVE_WCSDUP
 
@@ -166,106 +160,48 @@
 /* Define as the return type of signal handlers (`int' or `void'). */
 #undef RETSIGTYPE
 
-/* Define to 1 if all of the C90 standard headers exist (not just the ones
-   required in a freestanding environment). This macro is provided for
-   backward compatibility; new code need not use it. */
+/* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 
 /* Enable extensions on AIX 3, Interix.  */
 #ifndef _ALL_SOURCE
 # undef _ALL_SOURCE
 #endif
-/* Enable general extensions on macOS.  */
-#ifndef _DARWIN_C_SOURCE
-# undef _DARWIN_C_SOURCE
-#endif
-/* Enable general extensions on Solaris.  */
-#ifndef __EXTENSIONS__
-# undef __EXTENSIONS__
-#endif
 /* Enable GNU extensions on systems that have them.  */
 #ifndef _GNU_SOURCE
 # undef _GNU_SOURCE
 #endif
-/* Enable X/Open compliant socket functions that do not require linking
-   with -lxnet on HP-UX 11.11.  */
-#ifndef _HPUX_ALT_XOPEN_SOCKET_API
-# undef _HPUX_ALT_XOPEN_SOCKET_API
-#endif
-/* Identify the host operating system as Minix.
-   This macro does not affect the system headers' behavior.
-   A future release of Autoconf may stop defining this macro.  */
-#ifndef _MINIX
-# undef _MINIX
-#endif
-/* Enable general extensions on NetBSD.
-   Enable NetBSD compatibility extensions on Minix.  */
-#ifndef _NETBSD_SOURCE
-# undef _NETBSD_SOURCE
-#endif
-/* Enable OpenBSD compatibility extensions on NetBSD.
-   Oddly enough, this does nothing on OpenBSD.  */
-#ifndef _OPENBSD_SOURCE
-# undef _OPENBSD_SOURCE
-#endif
-/* Define to 1 if needed for POSIX-compatible behavior.  */
-#ifndef _POSIX_SOURCE
-# undef _POSIX_SOURCE
-#endif
-/* Define to 2 if needed for POSIX-compatible behavior.  */
-#ifndef _POSIX_1_SOURCE
-# undef _POSIX_1_SOURCE
-#endif
-/* Enable POSIX-compatible threading on Solaris.  */
+/* Enable threading extensions on Solaris.  */
 #ifndef _POSIX_PTHREAD_SEMANTICS
 # undef _POSIX_PTHREAD_SEMANTICS
-#endif
-/* Enable extensions specified by ISO/IEC TS 18661-5:2014.  */
-#ifndef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
-# undef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
-#endif
-/* Enable extensions specified by ISO/IEC TS 18661-1:2014.  */
-#ifndef __STDC_WANT_IEC_60559_BFP_EXT__
-# undef __STDC_WANT_IEC_60559_BFP_EXT__
-#endif
-/* Enable extensions specified by ISO/IEC TS 18661-2:2015.  */
-#ifndef __STDC_WANT_IEC_60559_DFP_EXT__
-# undef __STDC_WANT_IEC_60559_DFP_EXT__
-#endif
-/* Enable extensions specified by ISO/IEC TS 18661-4:2015.  */
-#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
-# undef __STDC_WANT_IEC_60559_FUNCS_EXT__
-#endif
-/* Enable extensions specified by ISO/IEC TS 18661-3:2015.  */
-#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
-# undef __STDC_WANT_IEC_60559_TYPES_EXT__
-#endif
-/* Enable extensions specified by ISO/IEC TR 24731-2:2010.  */
-#ifndef __STDC_WANT_LIB_EXT2__
-# undef __STDC_WANT_LIB_EXT2__
-#endif
-/* Enable extensions specified by ISO/IEC 24747:2009.  */
-#ifndef __STDC_WANT_MATH_SPEC_FUNCS__
-# undef __STDC_WANT_MATH_SPEC_FUNCS__
 #endif
 /* Enable extensions on HP NonStop.  */
 #ifndef _TANDEM_SOURCE
 # undef _TANDEM_SOURCE
 #endif
-/* Enable X/Open extensions.  Define to 500 only if necessary
-   to make mbstate_t available.  */
-#ifndef _XOPEN_SOURCE
-# undef _XOPEN_SOURCE
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# undef __EXTENSIONS__
 #endif
 
 
 /* Version number of package */
 #undef VERSION
 
+/* Define to 1 if on MINIX. */
+#undef _MINIX
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+#undef _POSIX_1_SOURCE
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+#undef _POSIX_SOURCE
+
 /* Define to empty if `const' does not conform to ANSI C. */
 #undef const
 
-/* Define as a signed integer type capable of holding a process identifier. */
+/* Define to `int' if <sys/types.h> does not define. */
 #undef pid_t
 
 /* Define to `unsigned int' if <sys/types.h> does not define. */


### PR DESCRIPTION
With some limitations:
- I couldn't for the life of me get the test fixture working at all. It's failing lots of stuff on master for me even without my changes. It's tested out our test environment and it's working fine but that's probably not very helpful for you. I'll include an example test that I want to include at the bottom.
- Only works for krb5 mechanism; errors for others.
- Only works for non-DCE style messages, if that's a thing for get/verify MIC. I assume it errors with DCE but didn't try b/c we don't use that in our environment.
- Probably only is actually zero copy for SHA1 -- this is also true of wrap/unwrap IOV variants today (SHA1 appears zero-copy, others do not). But should work for all checksum flavors.
- Defined the IOV interface myself to match our use case: `get` takes a `header`, `padding`, and `trailer` and returns a checksum in the `data` body. Verify takes a `data` body and errors if the verification fails. This might not match what other GSS libraries do for these methods with IOV parameters.
- Could probably share more code but I kept it isolated to make it easy to apply to various versions of the library.

Here's the start of a test I would write in your framework if I could get it working:
```
static void
getverifymic_iov(gss_ctx_id_t cctx, gss_ctx_id_t sctx, gss_OID mechoid)
{
	OM_uint32 min_stat, maj_stat;
	gss_iov_buffer_desc iov[4];
	int iov_len;

	char message_data[16] = "0123456789abcdef";

	memset(iov, 0, sizeof(iov));
	memset(&iov, 0, sizeof(iov));
	iov_len = sizeof(iov)/sizeof(iov[0]);

	iov[0].type = GSS_IOV_BUFFER_TYPE_HEADER | GSS_IOV_BUFFER_FLAG_ALLOCATE;
	iov[1].type = GSS_IOV_BUFFER_TYPE_PADDING | GSS_IOV_BUFFER_FLAG_ALLOCATE;
	iov[2].type = GSS_IOV_BUFFER_TYPE_TRAILER | GSS_IOV_BUFFER_FLAG_ALLOCATE;

	iov[3].type = GSS_IOV_BUFFER_TYPE_DATA;
	iov[3].buffer.value = message_data;
	iov[3].buffer.length = 16;

	maj_stat = gss_get_mic_iov(&min_stat, cctx, iov, iov_len);
	if (maj_stat != GSS_S_COMPLETE) {
		errx(1, "gss_get_mic_iov failed: %s", gssapi_err(maj_stat, min_stat, mechoid));
	}

	// XXX Steven: verify and assert, using both IOV and non-iov.
}
```