### PR TITLE
cf: Honour OpenSSL library and include paths

### DIFF
--- a/cf/crypto.m4
+++ b/cf/crypto.m4
@@ -112,6 +112,22 @@ if test "$with_openssl" != "no"; then
         LDFLAGS="${LIB_openssl_crypto} ${LDFLAGS}"
         AC_CHECK_LIB([crypto], [OPENSSL_init],
                      [LIB_openssl_crypto="${LIB_openssl_crypto} -lcrypto"; openssl=yes], [openssl=no], [])
+        if test "$openssl" = "yes"; then
+            AC_CHECK_LIB([crypto],
+                         [OSSL_EC_curve_nid2name],
+                         [AC_DEFINE_UNQUOTED([HAVE_OPENSSL_30], 1,
+                                             [whether OpenSSL is 3.0 or higher])]
+                         )
+            AC_CHECK_HEADERS([openssl/fips.h],
+                             [AC_DEFINE_UNQUOTED([HAVE_OPENSSL_FIPS_H], 1,
+                                                 [whether openssl/fips.h is available])]
+                             )
+            AC_CHECK_LIB([crypto],
+                         [FIPS_mode_set],
+                         [AC_DEFINE_UNQUOTED([HAVE_OPENSSL_FIPS_MODE_SET_API], 1,
+                                             [whether FIPS_mode_set API is available])]
+                         )
+        fi
         # These cases are just for static linking on older OSes,
         # presumably.
         if test "$openssl" = "no"; then
@@ -132,23 +148,6 @@ if test "$with_openssl" != "no"; then
         fi
         CFLAGS="${saved_CFLAGS}"
         LDFLAGS="${saved_LDFLAGS}"
-fi
-
-if test "$openssl" = "yes"; then
-    AC_CHECK_LIB([crypto],
-                 [OSSL_EC_curve_nid2name],
-                 [AC_DEFINE_UNQUOTED([HAVE_OPENSSL_30], 1,
-                                     [whether OpenSSL is 3.0 or higher])]
-                 )
-    AC_CHECK_HEADERS([openssl/fips.h],
-                     [AC_DEFINE_UNQUOTED([HAVE_OPENSSL_FIPS_H], 1,
-                                         [whether openssl/fips.h is available])]
-                     )
-    AC_CHECK_LIB([crypto],
-                 [FIPS_mode_set],
-                 [AC_DEFINE_UNQUOTED([HAVE_OPENSSL_FIPS_MODE_SET_API], 1,
-                                     [whether FIPS_mode_set API is available])]
-                 )
 fi
 
 LIB_hcrypto='$(top_builddir)/lib/hcrypto/libhcrypto.la'


### PR DESCRIPTION
Check for OpenSSL features while LDFLAGS and CFLAGS are set with the paths provided in the configure command line. This allows detecting a non-default OpenSSL's version correctly, such as on FreeBSD with one of the OpenSSL 3.0 ports.