### PR TITLE
kdc: Pass ticket into PAC verification function

### DIFF
--- a/kdc/kdc-plugin.c
+++ b/kdc/kdc-plugin.c
@@ -145,6 +145,7 @@ struct verify_uc {
     hdb_entry *client;
     hdb_entry *server;
     hdb_entry *krbtgt;
+    EncTicketPart *ticket;
     krb5_pac *pac;
 };
 
@@ -162,7 +163,8 @@ verify(krb5_context context, const void *plug, void *plugctx, void *userctx)
 			 uc->r,
 			 uc->client_principal,
 			 uc->delegated_proxy_principal,
-			 uc->client, uc->server, uc->krbtgt, uc->pac);
+			 uc->client, uc->server, uc->krbtgt,
+			 uc->ticket, uc->pac);
     return ret;
 }
 
@@ -173,6 +175,7 @@ _kdc_pac_verify(astgs_request_t r,
 		hdb_entry *client,
 		hdb_entry *server,
 		hdb_entry *krbtgt,
+		EncTicketPart *ticket,
 		krb5_pac *pac)
 {
     struct verify_uc uc;
@@ -186,6 +189,7 @@ _kdc_pac_verify(astgs_request_t r,
     uc.client = client;
     uc.server = server;
     uc.krbtgt = krbtgt;
+    uc.ticket = ticket,
     uc.pac = pac;
 
     return _krb5_plugin_run_f(r->context, &kdc_plugin_data,

--- a/kdc/kdc-plugin.h
+++ b/kdc/kdc-plugin.h
@@ -69,6 +69,7 @@ typedef krb5_error_code
 					   hdb_entry *,/* client */
 					   hdb_entry *,/* server */
 					   hdb_entry *,/* krbtgt */
+					   EncTicketPart *, /* ticket */
 					   krb5_pac *);
 
 /*

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -125,7 +125,7 @@ _kdc_check_pac(astgs_request_t r,
     /* Verify the KDC signatures. */
     ret = _kdc_pac_verify(r,
 			  client_principal, delegated_proxy_principal,
-			  client, server, krbtgt, &pac);
+			  client, server, krbtgt, tkt, &pac);
     if (ret == 0) {
 	if (pac_canon_name) {
 	    ret = _krb5_pac_get_canon_principal(context, pac, pac_canon_name);


### PR DESCRIPTION
The plugin may want to verify the ticket is actually a TGT, and not a kpasswd ticket. To do this, it needs access to the ticket to check that its remaining lifetime is greater than two minutes.