### PR TITLE
hdb: Add armor principal flag

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -835,10 +835,9 @@ _kdc_free_fast_state(KDCFastState *state)
 }
 
 krb5_error_code
-_kdc_fast_check_armor_pac(astgs_request_t r)
+_kdc_fast_check_armor_pac(astgs_request_t r, int flags)
 {
     krb5_error_code ret;
-    int flags;
     krb5_boolean ad_kdc_issued = FALSE;
     krb5_pac mspac = NULL;
     krb5_principal armor_client_principal = NULL;
@@ -846,7 +845,6 @@ _kdc_fast_check_armor_pac(astgs_request_t r)
     hdb_entry *armor_client = NULL;
     char *armor_client_principal_name = NULL;
 
-    flags = HDB_F_FOR_TGS_REQ;
     if (_kdc_synthetic_princ_used_p(r->context, r->armor_ticket))
 	flags |= HDB_F_SYNTHETIC_OK;
     if (r->req.req_body.kdc_options.canonicalize)

--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -845,6 +845,7 @@ _kdc_fast_check_armor_pac(astgs_request_t r, int flags)
     hdb_entry *armor_client = NULL;
     char *armor_client_principal_name = NULL;
 
+    flags |= HDB_F_ARMOR_PRINCIPAL;
     if (_kdc_synthetic_princ_used_p(r->context, r->armor_ticket))
 	flags |= HDB_F_SYNTHETIC_OK;
     if (r->req.req_body.kdc_options.canonicalize)

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -2017,7 +2017,7 @@ server_lookup:
 
 	/* Validate armor TGT before potentially including device claims */
 	if (priv->armor_ticket) {
-	    ret = _kdc_fast_check_armor_pac(priv);
+	    ret = _kdc_fast_check_armor_pac(priv, HDB_F_FOR_TGS_REQ);
 	    if (ret)
 		goto out;
 	}

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -77,6 +77,7 @@ enum hdb_lockop{ HDB_RLOCK, HDB_WLOCK };
 #define HDB_F_DELAY_NEW_KEYS	0x08000	/* apply [hdb] new_service_key_delay */
 #define HDB_F_SYNTHETIC_OK	0x10000	/* synthetic principal for PKINIT or GSS preauth OK */
 #define HDB_F_GET_FAST_COOKIE	0x20000	/* fetch the FX-COOKIE key (not a normal principal) */
+#define HDB_F_ARMOR_PRINCIPAL	0x40000	/* fetch is for the client of an armor ticket */
 
 /* hdb_capability_flags */
 #define HDB_CAP_F_HANDLE_ENTERPRISE_PRINCIPAL 1


### PR DESCRIPTION
This is useful to be able to tell whether a principal is being looked up just to verify a FAST armor ticket, which lets the HDB plugin avoid some unnecessary work.