### PR TITLE
Pass -d to yacc(1) so it generates the header file.

### DIFF
--- a/lib/asn1/Makefile.am
+++ b/lib/asn1/Makefile.am
@@ -4,7 +4,7 @@ include $(top_srcdir)/Makefile.am.common
 
 WFLAGS += $(WFLAGS_ENUM_CONV)
 
-YFLAGS = -o asn1parse.c -t
+YFLAGS = -d -o asn1parse.c -t
 
 AM_CPPFLAGS += $(ROKEN_RENAME) -I$(top_builddir)/include -I$(top_srcdir)/lib/base
 

--- a/lib/hx509/Makefile.am
+++ b/lib/hx509/Makefile.am
@@ -11,7 +11,7 @@ BUILT_SOURCES =				\
 	hx509_err.c			\
 	hx509_err.h
 
-AM_YFLAGS = -o sel-gram.c
+AM_YFLAGS = -d -o sel-gram.c
 
 dist_libhx509_la_SOURCES = \
 	ca.c \


### PR DESCRIPTION
Bison must generate this unsolicited, but BSD yacc does not.

The makefiles for lib/com_err and lib/sl already did this; this change just adds it to lib/asn1 and lib/hx509 too.

fix https://github.com/heimdal/heimdal/issues/1100