### PR TITLE
Fix ctype.h misuse.

### DIFF
--- a/kdc/bx509d.c
+++ b/kdc/bx509d.c
@@ -1169,7 +1169,7 @@ princ_fs_encode(const char *in)
             s[k++] = c;
             break;
         default:
-            if (isalnum(c)) {
+            if (isalnum((unsigned char)c)) {
                 s[k++] = c;
             } else  {
                 s[k++] = '%';

--- a/kdc/ipc_csr_authorizer.c
+++ b/kdc/ipc_csr_authorizer.c
@@ -120,7 +120,7 @@ string_encode_sz(const char *in)
         case '/':
             continue;
         default:
-            if (isalnum(c))
+            if (isalnum((unsigned char)c))
                 continue;
             sz += 2;
         }

--- a/kdc/test_csr_authorizer.c
+++ b/kdc/test_csr_authorizer.c
@@ -523,7 +523,7 @@ string_encode_sz(const char *in)
                 sz += 2;
             break;
         default:
-            if (!isalnum(c))
+            if (!isalnum((unsigned char)c))
                 sz += 2;
         }
         first = 0;

--- a/lib/asn1/asn1_print.c
+++ b/lib/asn1/asn1_print.c
@@ -305,7 +305,7 @@ loop (unsigned char *buf, size_t len, int indent)
 		s = str.data;
 		printf("\"");
 		for (n = 0; n < str.length; n++) {
-		    if (isprint((int)s[n]))
+		    if (isprint(s[n]))
 			printf ("%c", s[n]);
 		    else
 			printf ("#%02x", s[n]);

--- a/lib/asn1/gen.c
+++ b/lib/asn1/gen.c
@@ -594,7 +594,7 @@ generate_constant (const Symbol *s)
 	gen_upper = strdup(s->gen_name);
 	len = strlen(gen_upper);
 	for (i = 0; i < len; i++)
-	    gen_upper[i] = toupper((int)s->gen_name[i]);
+	    gen_upper[i] = toupper((unsigned char)s->gen_name[i]);
 
 	fprintf (headerfile, "} */\n");
 	fprintf (headerfile,

--- a/lib/base/config_file.c
+++ b/lib/base/config_file.c
@@ -358,7 +358,7 @@ is_absolute_path(const char *path)
 
     /* A drive letter path might be absolute */
     if (len > 3
-         && isalpha(path[0])
+         && isalpha((unsigned char)path[0])
          && path[1] == ':'
          && ISPATHSEP(path[2]))
         return 1;
@@ -414,9 +414,9 @@ heim_config_parse_debug(struct fileptr *f,
             *err_message = "unmatched }";
             return 2048;
         } else if (strncmp(p, "include", sizeof("include") - 1) == 0 &&
-            isspace(p[sizeof("include") - 1])) {
+            isspace((unsigned char)p[sizeof("include") - 1])) {
             p += sizeof("include");
-            while (isspace(*p))
+            while (isspace((unsigned char)*p))
                 p++;
             if (!is_absolute_path(p)) {
                 heim_set_error_message(f->context, HEIM_ERR_CONFIG_BADFORMAT,
@@ -428,9 +428,9 @@ heim_config_parse_debug(struct fileptr *f,
             if (ret)
                 return ret;
         } else if (strncmp(p, "includedir", sizeof("includedir") - 1) == 0 &&
-            isspace(p[sizeof("includedir") - 1])) {
+            isspace((unsigned char)p[sizeof("includedir") - 1])) {
             p += sizeof("includedir");
-            while (isspace(*p))
+            while (isspace((unsigned char)*p))
                 p++;
             if (!is_absolute_path(p)) {
                 heim_set_error_message(f->context, HEIM_ERR_CONFIG_BADFORMAT,
@@ -508,7 +508,7 @@ heim_config_parse_dir_multi(heim_context context,
              * so we're safe.  Anyone changing this if condition here should
              * be aware.
              */
-            if (!isalnum(*p) && *p != '_' && *p != '-' &&
+            if (!isalnum((unsigned char)*p) && *p != '_' && *p != '-' &&
                 strcmp(p, ".conf") != 0) {
                 is_valid = 0;
                 break;

--- a/lib/gssapi/mech/gss_mech_switch.c
+++ b/lib/gssapi/mech/gss_mech_switch.c
@@ -542,7 +542,8 @@ gss_name_to_oid(const char *name)
 	gss_OID oid = GSS_C_NO_OID;
 	size_t namelen = strlen(name);
 
-	if (isdigit(name[0]) && _gss_string_to_oid(name, &oid) == 0)
+	if (isdigit((unsigned char)name[0]) &&
+	    _gss_string_to_oid(name, &oid) == 0)
 		return oid;
 
 	_gss_load_mech();

--- a/lib/gssapi/netlogon/import_name.c
+++ b/lib/gssapi/netlogon/import_name.c
@@ -71,8 +71,8 @@ OM_uint32 _netlogon_import_name
 
     /* normalise name to uppercase XXX UTF-8 OK? */
     for (i = 0; i < len; i++) {
-        ((char *)name->NetbiosName.value)[i] =
-            toupper(((char *)name->NetbiosName.value)[i]);
+        ((unsigned char *)name->NetbiosName.value)[i] =
+            toupper(((unsigned char *)name->NetbiosName.value)[i]);
     }
 
     if (dnsName != NULL && dnsName[0] != '\0') {

--- a/lib/hcrypto/test_dh.c
+++ b/lib/hcrypto/test_dh.c
@@ -260,9 +260,9 @@ str2val(const char *str, int base, size_t *len)
 
     i = 0;
     for (p = str; *p != '\0'; p++) {
-	if (isxdigit((int)*p))
+	if (isxdigit((unsigned char)*p))
 	    i++;
-	else if (isspace((int)*p))
+	else if (isspace((unsigned char)*p))
 	    ;
 	else
 	    return NULL;
@@ -277,7 +277,7 @@ str2val(const char *str, int base, size_t *len)
     i = 0;
     f = 0;
     for (rp = dst, p = str; *p != '\0'; p++) {
-	if (isxdigit((int)*p)) {
+	if (isxdigit((unsigned char)*p)) {
 	    if (!f) {
 		b[0] = *p;
 		f = 1;

--- a/lib/hdb/hdb.c
+++ b/lib/hdb/hdb.c
@@ -517,7 +517,7 @@ is_pathish(const char *s)
         strncmp(s, "../", sizeof("../") - 1) == 0)
         return 1;
 #ifdef WIN32
-    if (s[0] == '\\' || (isalpha(s[0]) && s[0] == ':') ||
+    if (s[0] == '\\' || (isalpha((unsigned char)s[0]) && s[0] == ':') ||
         strncmp(s, ".\\", sizeof(".\\") - 1) == 0 ||
         strncmp(s, "\\\\", sizeof("\\\\") - 1) == 0)
         return 1;

--- a/lib/hx509/file.c
+++ b/lib/hx509/file.c
@@ -239,7 +239,7 @@ hx509_pem_read(hx509_context context,
 	    p = strchr(buf, ':');
 	    if (p) {
 		*p++ = '\0';
-		while (isspace((int)*p))
+		while (isspace((unsigned char)*p))
 		    p++;
 		ret = hx509_pem_add_header(&headers, buf, p);
 		if (ret)

--- a/lib/kadm5/marshall.c
+++ b/lib/kadm5/marshall.c
@@ -572,7 +572,7 @@ eval_recipe1(krb5_storage *sp, const char *typ, const char *val)
             return EINVAL;
         if (consumed < 1)
             return EINVAL;
-        while (isspace(val[consumed]))
+        while (isspace((unsigned char)val[consumed]))
             consumed++;
         if (val[consumed] != '\0')
             return EINVAL;
@@ -592,7 +592,7 @@ eval_recipe1(krb5_storage *sp, const char *typ, const char *val)
         }
         if (consumed < 1)
             return EINVAL;
-        while (isspace(val[consumed]))
+        while (isspace((unsigned char)val[consumed]))
             consumed++;
         if (val[consumed] != '\0')
             return EINVAL;
@@ -697,7 +697,7 @@ eval_recipe(char *r, int spflags)
             }
         } while (nxt);
 
-        while (isspace(*p))
+        while (isspace((unsigned char)*p))
             p++;
         if (*p == '#') {
             p = nxt;
@@ -709,7 +709,7 @@ eval_recipe(char *r, int spflags)
         val = strpbrk(p, " \t");
         if (val) {
             *(val++) = '\0';
-            while (isspace(*val))
+            while (isspace((unsigned char)*val))
                 val++;
         }
         ret = eval_recipe1(sp, typ, val);

--- a/lib/krb5/cache.c
+++ b/lib/krb5/cache.c
@@ -1418,7 +1418,7 @@ cc_get_prefix_ops(krb5_context context,
 
 #ifdef _WIN32
     /* Is drive letter? */
-    if (isalpha(prefix[0]) && prefix[1] == ':')
+    if (isalpha((unsigned char)prefix[0]) && prefix[1] == ':')
 	return &krb5_fcc_ops;
 #endif
 

--- a/lib/krb5/principal.c
+++ b/lib/krb5/principal.c
@@ -1463,8 +1463,8 @@ krb5_sname_to_principal(krb5_context context,
 
 	/* Lower-case the hostname, because that's the convention */
 	for (cp = remote_host; *cp; cp++)
-	    if (isupper((int) (*cp)))
-		*cp = tolower((int) (*cp));
+	    if (isupper((unsigned char) (*cp)))
+		*cp = tolower((unsigned char) (*cp));
 
         /*
          * If there is only one name canon rule and it says to
@@ -1530,7 +1530,7 @@ static void
 tolower_str(char *s)
 {
     for (; *s != '\0'; s++) {
-        if (isupper(*s))
+        if (isupper((unsigned char)*s))
             *s = tolower_ascii(*s);
     }
 }

--- a/lib/roken/rtbl.c
+++ b/lib/roken/rtbl.c
@@ -473,7 +473,7 @@ rtbl_format_json(rtbl_t table)
 
 	    if (c->num_rows > j) {
 		char *header = c->header;
-		while (isspace((int)header[0])) /* trim off prefixed whitespace */
+		while (isspace((unsigned char)header[0])) /* trim off prefixed whitespace */
 		    header++;
 		p = rk_strpoolprintf(p, "%s\"%s\" : \"%s\"",
 				     comma ? "," : "", header,


### PR DESCRIPTION
Excluded: libtomath and libedit files, most of which appear to be testing or example code not involved in production, and which are derived from an upstream that should perhaps have patches submitted upstream instead.

fix https://github.com/heimdal/heimdal/issues/1111