### PR TITLE
Sprinkle const throughout libkrb5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -764,16 +764,16 @@ if test -d "$srcdir/.git"; then
 #ifndef VERSION_HIDDEN
 #define VERSION_HIDDEN
 #endif
-VERSION_HIDDEN const char *heimdal_long_version = "@([#])\$Version: $PACKAGE_STRING by @USER@ on @HOST@ @BRANCH@ @TAG@ ($host) @COMMIT@ @DATE@ \$";
-VERSION_HIDDEN const char *heimdal_version = "AC_PACKAGE_STRING";
+VERSION_HIDDEN const char *const heimdal_long_version = "@([#])\$Version: $PACKAGE_STRING by @USER@ on @HOST@ @BRANCH@ @TAG@ ($host) @COMMIT@ @DATE@ \$";
+VERSION_HIDDEN const char *const heimdal_version = "AC_PACKAGE_STRING";
 EOF
 else
     cat > include/newversion.h.in <<EOF
 #ifndef VERSION_HIDDEN
 #define VERSION_HIDDEN
 #endif
-VERSION_HIDDEN const char *heimdal_long_version = "@([#])\$Version: $PACKAGE_STRING by @USER@ on @HOST@ ($host) @DATE@ \$";
-VERSION_HIDDEN const char *heimdal_version = "AC_PACKAGE_STRING";
+VERSION_HIDDEN const char *const heimdal_long_version = "@([#])\$Version: $PACKAGE_STRING by @USER@ on @HOST@ ($host) @DATE@ \$";
+VERSION_HIDDEN const char *const heimdal_version = "AC_PACKAGE_STRING";
 EOF
 fi
 

--- a/include/NTMakefile
+++ b/include/NTMakefile
@@ -111,8 +111,8 @@ while(<>) {
 
 $(INCDIR)\version.h: ..\windows\NTMakefile.version NTMakefile
 	$(CP) << $@
-const char *heimdal_long_version = "@(#)$$Version: $(VER_PACKAGE_NAME) $(VER_PACKAGE_VERSION) by $(USERNAME) on $(COMPUTERNAME) ($(CPU)-pc-windows) $$";
-const char *heimdal_version = "$(VER_PACKAGE_NAME) $(VER_PACKAGE_VERSION)";
+const char *const heimdal_long_version = "@(#)$$Version: $(VER_PACKAGE_NAME) $(VER_PACKAGE_VERSION) by $(USERNAME) on $(COMPUTERNAME) ($(CPU)-pc-windows) $$";
+const char *const heimdal_version = "$(VER_PACKAGE_NAME) $(VER_PACKAGE_VERSION)";
 <<
 
 all:: $(INCFILES)

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1336,8 +1336,8 @@ get_pa_etype_info(krb5_context context,
  *
  */
 
-extern int _krb5_AES_SHA1_string_to_default_iterator;
-extern int _krb5_AES_SHA2_string_to_default_iterator;
+extern const int _krb5_AES_SHA1_string_to_default_iterator;
+extern const int _krb5_AES_SHA2_string_to_default_iterator;
 
 static krb5_error_code
 make_s2kparams(int value, size_t len, krb5_data **ps2kparams)

--- a/lib/base/common_plugin.h
+++ b/lib/base/common_plugin.h
@@ -75,6 +75,7 @@ struct heim_plugin_common_ftable_desc {
 };
 typedef struct heim_plugin_common_ftable_desc heim_plugin_common_ftable;
 typedef struct heim_plugin_common_ftable_desc *heim_plugin_common_ftable_p;
+typedef const struct heim_plugin_common_ftable_desc *heim_plugin_common_ftable_const_p;
 typedef struct heim_plugin_common_ftable_desc * const heim_plugin_common_ftable_cp;
 
 typedef int

--- a/lib/base/heimbase.c
+++ b/lib/base/heimbase.c
@@ -40,7 +40,7 @@
 static heim_base_atomic(uint32_t) tidglobal = HEIM_TID_USER;
 
 struct heim_base {
-    heim_type_t isa;
+    heim_const_type_t isa;
     heim_base_atomic(uint32_t) ref_cnt;
     HEIM_TAILQ_ENTRY(heim_base) autorel;
     heim_auto_release_t autorelpool;
@@ -49,7 +49,7 @@ struct heim_base {
 
 /* specialized version of base */
 struct heim_base_mem {
-    heim_type_t isa;
+    heim_const_type_t isa;
     heim_base_atomic(uint32_t) ref_cnt;
     HEIM_TAILQ_ENTRY(heim_base) autorel;
     heim_auto_release_t autorelpool;
@@ -182,7 +182,7 @@ static heim_type_t tagged_isa[9] = {
     NULL
 };
 
-heim_type_t
+heim_const_type_t
 _heim_get_isa(heim_object_t ptr)
 {
     struct heim_base *p;
@@ -206,7 +206,7 @@ _heim_get_isa(heim_object_t ptr)
 heim_tid_t
 heim_get_tid(heim_object_t ptr)
 {
-    heim_type_t isa = _heim_get_isa(ptr);
+    heim_const_type_t isa = _heim_get_isa(ptr);
     return isa->tid;
 }
 
@@ -221,7 +221,7 @@ heim_get_tid(heim_object_t ptr)
 uintptr_t
 heim_get_hash(heim_object_t ptr)
 {
-    heim_type_t isa = _heim_get_isa(ptr);
+    heim_const_type_t isa = _heim_get_isa(ptr);
     if (isa->hash)
 	return isa->hash(ptr);
     return (uintptr_t)ptr;
@@ -241,7 +241,7 @@ int
 heim_cmp(heim_object_t a, heim_object_t b)
 {
     heim_tid_t ta, tb;
-    heim_type_t isa;
+    heim_const_type_t isa;
 
     ta = heim_get_tid(a);
     tb = heim_get_tid(b);
@@ -272,7 +272,7 @@ memory_dealloc(void *ptr)
     }
 }
 
-struct heim_type_data memory_object = {
+static const struct heim_type_data memory_object = {
     HEIM_TID_MEMORY,
     "memory-object",
     NULL,
@@ -338,7 +338,7 @@ _heim_create_type(const char *name,
 }
 
 heim_object_t
-_heim_alloc_object(heim_type_t type, size_t size)
+_heim_alloc_object(heim_const_type_t type, size_t size)
 {
     /* XXX should use posix_memalign */
     struct heim_base *p = calloc(1, size + sizeof(*p));

--- a/lib/base/heimbase.h
+++ b/lib/base/heimbase.h
@@ -102,7 +102,7 @@ struct heim_plugin_data {
     const char *module;
     const char *name;
     int min_version;
-    const char **deps;
+    const char *const *deps;
     heim_get_instance_func_t get_instance;
 };
 

--- a/lib/base/heimbasepriv.h
+++ b/lib/base/heimbasepriv.h
@@ -46,6 +46,7 @@ typedef uintptr_t (*heim_type_hash)(void *);
 typedef heim_string_t (*heim_type_description)(void *);
 
 typedef struct heim_type_data *heim_type_t;
+typedef const struct heim_type_data *heim_const_type_t;
 
 struct heim_type_data {
     heim_tid_t tid;
@@ -58,7 +59,7 @@ struct heim_type_data {
     heim_type_description desc;
 };
 
-heim_type_t _heim_get_isa(heim_object_t);
+heim_const_type_t _heim_get_isa(heim_object_t);
 
 heim_type_t
 _heim_create_type(const char *name,
@@ -70,7 +71,7 @@ _heim_create_type(const char *name,
 		  heim_type_description desc);
 
 heim_object_t
-_heim_alloc_object(heim_type_t type, size_t size);
+_heim_alloc_object(heim_const_type_t type, size_t size);
 
 void *
 _heim_get_isaextra(heim_object_t o, size_t idx);

--- a/lib/base/plugin.c
+++ b/lib/base/plugin.c
@@ -152,7 +152,7 @@ copy_internal_dso(const char *name)
 }
 
 struct heim_plugin {
-    heim_plugin_common_ftable_p ftable;
+    heim_plugin_common_ftable_const_p ftable;
     void *ctx;
 };
 
@@ -166,7 +166,7 @@ plugin_free(void *ptr)
 }
 
 struct heim_plugin_register_ctx {
-    void *symbol;
+    const void *symbol;
     int is_dup;
 };
 
@@ -199,7 +199,7 @@ heim_plugin_register(heim_context context,
                      heim_pcontext pcontext,
                      const char *module,
                      const char *name,
-                     void *ftable)
+                     const void *ftable)
 {
     heim_error_code ret;
     heim_array_t plugins;
@@ -480,7 +480,7 @@ struct iter_ctx {
     heim_context context;
     heim_pcontext pcontext;
     heim_string_t n;
-    struct heim_plugin_data *caller;
+    const struct heim_plugin_data *caller;
     int flags;
     heim_array_t result;
     int32_t (HEIM_LIB_CALL *func)(void *, const void *, void *, void *);
@@ -540,7 +540,7 @@ add_dso_plugin_struct(heim_context context,
 
 static int
 validate_plugin_deps(heim_context context,
-                     struct heim_plugin_data *caller,
+                     const struct heim_plugin_data *caller,
                      const char *dsopath,
                      heim_get_instance_func_t get_instance)
 {
@@ -583,7 +583,7 @@ validate_plugin_deps(heim_context context,
 static heim_array_t
 add_dso_plugins_load_fn(heim_context context,
                         heim_pcontext pcontext,
-                        struct heim_plugin_data *caller,
+                        const struct heim_plugin_data *caller,
                         const char *dsopath,
                         void *dsohandle)
 {
@@ -635,7 +635,7 @@ add_dso_plugins_load_fn(heim_context context,
             heim_warn(context, ret, "plugin %s[%zu] failed to initialize",
                       dsopath, i);
         } else {
-            pl->ftable = rk_UNCONST(cpm);
+            pl->ftable = cpm;
             heim_array_append_value(plugins, pl);
         }
         heim_release(pl);
@@ -738,7 +738,7 @@ eval_results(heim_object_t value, void *ctx, int *stop)
 heim_error_code
 heim_plugin_run_f(heim_context context,
                   heim_pcontext pcontext,
-                  struct heim_plugin_data *caller,
+                  const struct heim_plugin_data *caller,
                   int flags,
                   int32_t nohandle,
                   void *userctx,

--- a/lib/com_err/com_err.c
+++ b/lib/com_err/com_err.c
@@ -63,7 +63,7 @@ error_message (long code)
 }
 
 KRB5_LIB_FUNCTION int KRB5_LIB_CALL
-init_error_table(const char **msgs, long base, int count)
+init_error_table(const char *const *msgs, long base, int count)
 {
     initialize_error_table_r(&_et_list, msgs, count, base);
     return 0;

--- a/lib/com_err/com_err.h
+++ b/lib/com_err/com_err.h
@@ -51,7 +51,7 @@ KRB5_LIB_FUNCTION const char * KRB5_LIB_CALL
 error_message (long);
 
 KRB5_LIB_FUNCTION int KRB5_LIB_CALL
-init_error_table (const char**, long, int);
+init_error_table (const char *const *, long, int);
 
 KRB5_LIB_FUNCTION void KRB5_LIB_CALL
 com_err_va (const char *, long, const char *, va_list)

--- a/lib/com_err/com_right.h
+++ b/lib/com_err/com_right.h
@@ -79,7 +79,7 @@ KRB5_LIB_FUNCTION const char * KRB5_LIB_CALL
 com_right_r (struct et_list *list, long code, char *, size_t);
 
 KRB5_LIB_FUNCTION void KRB5_LIB_CALL
-initialize_error_table_r (struct et_list **, const char **, int, long);
+initialize_error_table_r (struct et_list **, const char *const *, int, long);
 
 KRB5_LIB_FUNCTION void KRB5_LIB_CALL
 free_error_table (struct et_list *);

--- a/lib/com_err/compile_et.c
+++ b/lib/com_err/compile_et.c
@@ -87,7 +87,7 @@ generate_c(void)
     fprintf(c_file, "#define N_(x) (x)\n");
     fprintf(c_file, "\n");
 
-    fprintf(c_file, "static const char *%s_error_strings[] = {\n", name);
+    fprintf(c_file, "static const char *const %s_error_strings[] = {\n", name);
 
     for(ec = codes, n = 0; ec; ec = ec->next, n++) {
 	while(n < ec->number) {

--- a/lib/com_err/error.c
+++ b/lib/com_err/error.c
@@ -81,7 +81,7 @@ struct foobar {
 
 KRB5_LIB_FUNCTION void KRB5_LIB_CALL
 initialize_error_table_r(struct et_list **list,
-			 const char **messages,
+			 const char *const *messages,
 			 int num_errors,
 			 long base)
 {

--- a/lib/ipc/client.c
+++ b/lib/ipc/client.c
@@ -520,7 +520,7 @@ struct hipc_ops {
 		 void (*)(void *, int, heim_idata *, heim_icred));
 };
 
-struct hipc_ops ipcs[] = {
+static const struct hipc_ops ipcs[] = {
 #if defined(__APPLE__) && defined(HAVE_GCD)
     { "MACH", mach_init, mach_release, mach_ipc, mach_async },
 #endif
@@ -531,7 +531,7 @@ struct hipc_ops ipcs[] = {
 };
 
 struct heim_ipc {
-    struct hipc_ops *ops;
+    const struct hipc_ops *ops;
     void *ctx;
 };
 

--- a/lib/krb5/addr_families.c
+++ b/lib/krb5/addr_families.c
@@ -734,7 +734,7 @@ addrport_print_addr (const krb5_address *addr, char *str, size_t len)
     return ret_len;
 }
 
-static struct addr_operations at[] = {
+static const struct addr_operations at[] = {
     {
 	AF_INET,	KRB5_ADDRESS_INET, sizeof(struct sockaddr_in),
 	ipv4_sockaddr2addr,
@@ -810,7 +810,7 @@ static struct addr_operations at[] = {
     }
 };
 
-static size_t num_addrs = sizeof(at) / sizeof(at[0]);
+static const size_t num_addrs = sizeof(at) / sizeof(at[0]);
 
 static size_t max_sockaddr_size = 0;
 
@@ -818,7 +818,7 @@ static size_t max_sockaddr_size = 0;
  * generic functions
  */
 
-static struct addr_operations *
+static const struct addr_operations *
 find_af(int af)
 {
     size_t i;
@@ -830,7 +830,7 @@ find_af(int af)
     return NULL;
 }
 
-static struct addr_operations *
+static const struct addr_operations *
 find_atype(krb5_address_type atype)
 {
     size_t i;
@@ -859,7 +859,7 @@ KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_sockaddr2address (krb5_context context,
 		       const struct sockaddr *sa, krb5_address *addr)
 {
-    struct addr_operations *a = find_af(sa->sa_family);
+    const struct addr_operations *a = find_af(sa->sa_family);
     if (a == NULL) {
 	krb5_set_error_message (context, KRB5_PROG_ATYPE_NOSUPP,
 				N_("Address family %d not supported", ""),
@@ -887,7 +887,7 @@ KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_sockaddr2port (krb5_context context,
 		    const struct sockaddr *sa, int16_t *port)
 {
-    struct addr_operations *a = find_af(sa->sa_family);
+    const struct addr_operations *a = find_af(sa->sa_family);
     if (a == NULL) {
 	krb5_set_error_message (context, KRB5_PROG_ATYPE_NOSUPP,
 				N_("Address family %d not supported", ""),
@@ -925,7 +925,7 @@ krb5_addr2sockaddr (krb5_context context,
 		    krb5_socklen_t *sa_size,
 		    int port)
 {
-    struct addr_operations *a = find_atype(addr->addr_type);
+    const struct addr_operations *a = find_atype(addr->addr_type);
 
     if (a == NULL) {
 	krb5_set_error_message (context, KRB5_PROG_ATYPE_NOSUPP,
@@ -981,7 +981,7 @@ krb5_max_sockaddr_size (void)
 KRB5_LIB_FUNCTION krb5_boolean KRB5_LIB_CALL
 krb5_sockaddr_uninteresting(const struct sockaddr *sa)
 {
-    struct addr_operations *a = find_af(sa->sa_family);
+    const struct addr_operations *a = find_af(sa->sa_family);
     if (a == NULL || a->uninteresting == NULL)
 	return TRUE;
     return (*a->uninteresting)(sa);
@@ -990,7 +990,7 @@ krb5_sockaddr_uninteresting(const struct sockaddr *sa)
 KRB5_LIB_FUNCTION krb5_boolean KRB5_LIB_CALL
 krb5_sockaddr_is_loopback(const struct sockaddr *sa)
 {
-    struct addr_operations *a = find_af(sa->sa_family);
+    const struct addr_operations *a = find_af(sa->sa_family);
     if (a == NULL || a->is_loopback == NULL)
 	return TRUE;
     return (*a->is_loopback)(sa);
@@ -1022,7 +1022,7 @@ krb5_h_addr2sockaddr (krb5_context context,
 		      krb5_socklen_t *sa_size,
 		      int port)
 {
-    struct addr_operations *a = find_af(af);
+    const struct addr_operations *a = find_af(af);
     if (a == NULL) {
 	krb5_set_error_message (context, KRB5_PROG_ATYPE_NOSUPP,
 				"Address family %d not supported", af);
@@ -1051,7 +1051,7 @@ krb5_h_addr2addr (krb5_context context,
 		  int af,
 		  const char *haddr, krb5_address *addr)
 {
-    struct addr_operations *a = find_af(af);
+    const struct addr_operations *a = find_af(af);
     if (a == NULL) {
 	krb5_set_error_message (context, KRB5_PROG_ATYPE_NOSUPP,
 				N_("Address family %d not supported", ""), af);
@@ -1084,7 +1084,7 @@ krb5_anyaddr (krb5_context context,
 	      krb5_socklen_t *sa_size,
 	      int port)
 {
-    struct addr_operations *a = find_af (af);
+    const struct addr_operations *a = find_af (af);
 
     if (a == NULL) {
 	krb5_set_error_message (context, KRB5_PROG_ATYPE_NOSUPP,
@@ -1116,7 +1116,7 @@ KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_print_address (const krb5_address *addr,
 		    char *str, size_t len, size_t *ret_len)
 {
-    struct addr_operations *a = find_atype(addr->addr_type);
+    const struct addr_operations *a = find_atype(addr->addr_type);
     int ret;
 
     if (a == NULL || a->print_addr == NULL) {
@@ -1267,7 +1267,7 @@ krb5_address_order(krb5_context context,
 {
     /* this sucks; what if both addresses have order functions, which
        should we call? this works for now, though */
-    struct addr_operations *a;
+    const struct addr_operations *a;
     a = find_atype(addr1->addr_type);
     if(a == NULL) {
 	krb5_set_error_message (context, KRB5_PROG_ATYPE_NOSUPP,
@@ -1359,7 +1359,7 @@ KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_free_address(krb5_context context,
 		  krb5_address *address)
 {
-    struct addr_operations *a = find_atype (address->addr_type);
+    const struct addr_operations *a = find_atype (address->addr_type);
     if(a != NULL && a->free_addr != NULL)
 	return (*a->free_addr)(context, address);
     krb5_data_free (&address->address);
@@ -1405,7 +1405,7 @@ krb5_copy_address(krb5_context context,
 		  const krb5_address *inaddr,
 		  krb5_address *outaddr)
 {
-    struct addr_operations *a = find_af (inaddr->addr_type);
+    const struct addr_operations *a = find_af (inaddr->addr_type);
     if(a != NULL && a->copy_addr != NULL)
 	return (*a->copy_addr)(context, inaddr, outaddr);
     return copy_HostAddress(inaddr, outaddr);
@@ -1563,7 +1563,7 @@ krb5_address_prefixlen_boundary(krb5_context context,
 				krb5_address *low,
 				krb5_address *high)
 {
-    struct addr_operations *a = find_atype (inaddr->addr_type);
+    const struct addr_operations *a = find_atype (inaddr->addr_type);
     if(a != NULL && a->mask_boundary != NULL)
 	return (*a->mask_boundary)(context, inaddr, prefixlen, low, high);
     krb5_set_error_message(context, KRB5_PROG_ATYPE_NOSUPP,

--- a/lib/krb5/aname_to_localname.c
+++ b/lib/krb5/aname_to_localname.c
@@ -44,7 +44,7 @@ static krb5_error_code KRB5_LIB_CALL an2ln_def_plug_an2ln(void *, krb5_context, 
 					    krb5_const_principal, set_result_f,
 					    void *);
 
-static krb5plugin_an2ln_ftable an2ln_def_plug = {
+static const krb5plugin_an2ln_ftable an2ln_def_plug = {
     0,
     an2ln_def_plug_init,
     an2ln_def_plug_fini,
@@ -81,9 +81,9 @@ plcallback(krb5_context context,
     return locate->an2ln(plugctx, context, plctx->rule, plctx->aname, set_res, plctx);
 }
 
-static const char *an2ln_plugin_deps[] = { "krb5", NULL };
+static const char *const an2ln_plugin_deps[] = { "krb5", NULL };
 
-static struct heim_plugin_data
+static const struct heim_plugin_data
 an2ln_plugin_data = {
     "krb5",
     KRB5_PLUGIN_AN2LN,

--- a/lib/krb5/changepw.c
+++ b/lib/krb5/changepw.c
@@ -478,7 +478,7 @@ typedef krb5_error_code (*kpwd_process_reply) (krb5_context,
 					       krb5_data *,
 					       const char *);
 
-static struct kpwd_proc {
+static const struct kpwd_proc {
     const char *name;
     int flags;
 #define SUPPORT_TCP	1
@@ -513,7 +513,7 @@ change_password_loop (krb5_context	context,
 		      int		*result_code,
 		      krb5_data		*result_code_string,
 		      krb5_data		*result_string,
-		      struct kpwd_proc	*proc)
+		      const struct kpwd_proc	*proc)
 {
     krb5_error_code ret;
     krb5_auth_context auth_context = NULL;
@@ -662,10 +662,10 @@ change_password_loop (krb5_context	context,
 
 #ifndef HEIMDAL_SMALLER
 
-static struct kpwd_proc *
+static const struct kpwd_proc *
 find_chpw_proto(const char *name)
 {
-    struct kpwd_proc *p;
+    const struct kpwd_proc *p;
     for (p = procs; p->name != NULL; p++) {
 	if (strcmp(p->name, name) == 0)
 	    return p;
@@ -697,7 +697,7 @@ krb5_change_password (krb5_context	context,
 		      krb5_data		*result_string)
     KRB5_DEPRECATED_FUNCTION("Use X instead")
 {
-    struct kpwd_proc *p = find_chpw_proto("change password");
+    const struct kpwd_proc *p = find_chpw_proto("change password");
 
     *result_code = KRB5_KPASSWD_MALFORMED;
     result_code_string->data = result_string->data = NULL;

--- a/lib/krb5/constants.c
+++ b/lib/krb5/constants.c
@@ -35,7 +35,7 @@
 
 #include "krb5_locl.h"
 
-KRB5_LIB_VARIABLE const char *krb5_config_file =
+KRB5_LIB_VARIABLE const char *const krb5_config_file =
 #ifdef KRB5_DEFAULT_CONFIG_FILE
 KRB5_DEFAULT_CONFIG_FILE
 #else
@@ -56,12 +56,12 @@ SYSCONFDIR "/krb5.conf" PATH_SEP
 #endif /* KRB5_DEFAULT_CONFIG_FILE */
 ;
 
-KRB5_LIB_VARIABLE const char *krb5_defkeyname = KEYTAB_DEFAULT;
+KRB5_LIB_VARIABLE const char *const krb5_defkeyname = KEYTAB_DEFAULT;
 
-KRB5_LIB_VARIABLE const char *krb5_cc_type_api = "API";
-KRB5_LIB_VARIABLE const char *krb5_cc_type_file = "FILE";
-KRB5_LIB_VARIABLE const char *krb5_cc_type_memory = "MEMORY";
-KRB5_LIB_VARIABLE const char *krb5_cc_type_kcm = "KCM";
-KRB5_LIB_VARIABLE const char *krb5_cc_type_scc = "SCC";
-KRB5_LIB_VARIABLE const char *krb5_cc_type_dcc = "DIR";
-KRB5_LIB_VARIABLE const char *krb5_cc_type_keyring = "KEYRING";
+KRB5_LIB_VARIABLE const char *const krb5_cc_type_api = "API";
+KRB5_LIB_VARIABLE const char *const krb5_cc_type_file = "FILE";
+KRB5_LIB_VARIABLE const char *const krb5_cc_type_memory = "MEMORY";
+KRB5_LIB_VARIABLE const char *const krb5_cc_type_kcm = "KCM";
+KRB5_LIB_VARIABLE const char *const krb5_cc_type_scc = "SCC";
+KRB5_LIB_VARIABLE const char *const krb5_cc_type_dcc = "DIR";
+KRB5_LIB_VARIABLE const char *const krb5_cc_type_keyring = "KEYRING";

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -372,7 +372,7 @@ kt_ops_copy(krb5_context context, const krb5_context src_context)
     return 0;
 }
 
-static const char *sysplugin_dirs[] =  {
+static const char *const sysplugin_dirs[] =  {
 #ifdef _WIN32
     "$ORIGIN",
 #else

--- a/lib/krb5/crypto.c
+++ b/lib/krb5/crypto.c
@@ -1922,13 +1922,13 @@ krb5_decrypt_iov_ivec(krb5_context context,
 	    goto cleanup;
     } else {
 	krb5_data ivec_data;
-	static unsigned char zero_ivec[EVP_MAX_IV_LENGTH];
+	static const unsigned char zero_ivec[EVP_MAX_IV_LENGTH];
 
 	heim_assert(et->blocksize <= sizeof(zero_ivec),
 		    "blocksize too big for ivec buffer");
 
 	ivec_data.length = et->blocksize;
-	ivec_data.data = ivec ? ivec : zero_ivec;
+	ivec_data.data = ivec ? ivec : rk_UNCONST(zero_ivec);
 
 	ret = iov_coalesce(context, &ivec_data, data, num_data, TRUE, &sign_data);
 	if(ret)

--- a/lib/krb5/db_plugin.c
+++ b/lib/krb5/db_plugin.c
@@ -14,9 +14,9 @@ db_plugins_plcallback(krb5_context context, const void *plug, void *plugctx,
     return 0;
 }
 
-static const char *db_plugin_deps[] = { "krb5", NULL };
+static const char *const db_plugin_deps[] = { "krb5", NULL };
 
-static struct heim_plugin_data
+static const struct heim_plugin_data
 db_plugin_data = {
     "krb5",
     KRB5_PLUGIN_DB,

--- a/lib/krb5/get_host_realm.c
+++ b/lib/krb5/get_host_realm.c
@@ -109,17 +109,17 @@ dns_find_realm(krb5_context context,
 	       const char *domain,
 	       krb5_realm **realms)
 {
-    static const char *default_labels[] = { "_kerberos", NULL };
+    static const char *const default_labels[] = { "_kerberos", NULL };
     char dom[MAXHOSTNAMELEN];
     struct rk_dns_reply *r;
-    const char **labels;
+    const char *const *labels;
     char **config_labels;
     int i, ret = 0;
 
     config_labels = krb5_config_get_strings(context, NULL, "libdefaults",
 					    "dns_lookup_realm_labels", NULL);
     if(config_labels != NULL)
-	labels = (const char **)config_labels;
+	labels = (const char *const *)config_labels;
     else
 	labels = default_labels;
     if(*domain == '.')

--- a/lib/krb5/get_in_tkt.c
+++ b/lib/krb5/get_in_tkt.c
@@ -319,7 +319,9 @@ set_ptypes(krb5_context context,
 	   krb5_preauthdata **preauth)
 {
     static krb5_preauthdata preauth2;
-    static krb5_preauthtype ptypes2[] = { KRB5_PADATA_ENC_TIMESTAMP, KRB5_PADATA_NONE };
+    static const krb5_preauthtype ptypes2[] = {
+	    KRB5_PADATA_ENC_TIMESTAMP, KRB5_PADATA_NONE
+    };
 
     if(error->e_data) {
 	METHOD_DATA md;

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -61,7 +61,7 @@ struct krb5_gss_init_ctx_data {
 struct krb5_get_init_creds_ctx {
     KDCOptions flags;
     krb5_creds cred;
-    krb5_addresses *addrs;
+    const krb5_addresses *addrs;
     krb5_enctype *etypes;
     krb5_preauthtype *pre_auth_types;
     char *in_tkt_service;
@@ -447,7 +447,7 @@ krb5_init_creds_warn_user(krb5_context context,
     return 0;
 }
 
-static krb5_addresses no_addrs = { 0, NULL };
+static const krb5_addresses no_addrs = { 0, NULL };
 
 static krb5_error_code
 get_init_creds_common(krb5_context context,
@@ -1939,9 +1939,9 @@ typedef krb5_error_code (*pa_restart_f)(krb5_context, krb5_init_creds_context, v
 typedef krb5_error_code (*pa_step_f)(krb5_context, krb5_init_creds_context, void *, PA_DATA *, const AS_REQ *, const AS_REP *, METHOD_DATA *, METHOD_DATA *);
 typedef void            (*pa_release_f)(void *);
 
-struct patype {
+static const struct patype {
     int type;
-    char *name;
+    const char *name;
     int flags;
 #define PA_F_ANNOUNCE		1
 #define PA_F_CONFIG		2
@@ -2083,7 +2083,7 @@ get_pa_type_name(int type)
  */
 
 struct pa_auth_mech {
-    struct patype *patype;
+    const struct patype *patype;
     struct pa_auth_mech *next; /* when doing authentication sets */
     char pactx[1];
 };
@@ -2153,7 +2153,7 @@ mech_dealloc(void *ctx)
 	pa_mech->patype->release((void *)&pa_mech->pactx[0]);
 }
 
-struct heim_type_data pa_auth_mech_object = {
+static const struct heim_type_data pa_auth_mech_object = {
     HEIM_TID_PA_AUTH_MECH,
     "heim-pa-mech-context",
     NULL,
@@ -2168,7 +2168,7 @@ static struct pa_auth_mech *
 pa_mech_create(krb5_context context, krb5_init_creds_context ctx, int pa_type)
 {
     struct pa_auth_mech *pa_mech;
-    struct patype *patype = NULL;
+    const struct patype *patype = NULL;
     size_t n;
 
     for (n = 0; patype == NULL && n < sizeof(patypes)/sizeof(patypes[0]); n++) {

--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -697,7 +697,7 @@ typedef struct {
     KRB_ERROR error;
 } krb5_kdc_rep;
 
-extern const char *heimdal_version, *heimdal_long_version;
+extern const char *const heimdal_version, *const heimdal_long_version;
 
 typedef void (KRB5_CALLCONV * krb5_log_log_func_t)(krb5_context,
 						   const char*,

--- a/lib/krb5/krb5.h
+++ b/lib/krb5/krb5.h
@@ -1018,8 +1018,8 @@ typedef struct krb5_kx509_req_ctx_data *krb5_kx509_req_ctx;
 
 /* variables */
 
-extern KRB5_LIB_VARIABLE const char *krb5_config_file;
-extern KRB5_LIB_VARIABLE const char *krb5_defkeyname;
+extern KRB5_LIB_VARIABLE const char *const krb5_config_file;
+extern KRB5_LIB_VARIABLE const char *const krb5_defkeyname;
 
 
 extern KRB5_LIB_VARIABLE const krb5_cc_ops krb5_acc_ops;
@@ -1038,13 +1038,13 @@ extern KRB5_LIB_VARIABLE const krb5_kt_ops krb5_mkt_ops;
 extern KRB5_LIB_VARIABLE const krb5_kt_ops krb5_akf_ops;
 extern KRB5_LIB_VARIABLE const krb5_kt_ops krb5_any_ops;
 
-extern KRB5_LIB_VARIABLE const char *krb5_cc_type_api;
-extern KRB5_LIB_VARIABLE const char *krb5_cc_type_file;
-extern KRB5_LIB_VARIABLE const char *krb5_cc_type_memory;
-extern KRB5_LIB_VARIABLE const char *krb5_cc_type_kcm;
-extern KRB5_LIB_VARIABLE const char *krb5_cc_type_scc;
-extern KRB5_LIB_VARIABLE const char *krb5_cc_type_dcc;
-extern KRB5_LIB_VARIABLE const char *krb5_cc_type_keyring;
+extern KRB5_LIB_VARIABLE const char *const krb5_cc_type_api;
+extern KRB5_LIB_VARIABLE const char *const krb5_cc_type_file;
+extern KRB5_LIB_VARIABLE const char *const krb5_cc_type_memory;
+extern KRB5_LIB_VARIABLE const char *const krb5_cc_type_kcm;
+extern KRB5_LIB_VARIABLE const char *const krb5_cc_type_scc;
+extern KRB5_LIB_VARIABLE const char *const krb5_cc_type_dcc;
+extern KRB5_LIB_VARIABLE const char *const krb5_cc_type_keyring;
 
 /* clang analyzer workarounds */
 

--- a/lib/krb5/krbhst.c
+++ b/lib/krb5/krbhst.c
@@ -700,9 +700,9 @@ plcallback(krb5_context context,
     return KRB5_PLUGIN_NO_HANDLE;
 }
 
-static const char *locate_plugin_deps[] = { "krb5", NULL };
+static const char *const locate_plugin_deps[] = { "krb5", NULL };
 
-static struct heim_plugin_data
+static const struct heim_plugin_data
 locate_plugin_data = {
     "krb5",
     KRB5_PLUGIN_LOCATE,

--- a/lib/krb5/kuserok.c
+++ b/lib/krb5/kuserok.c
@@ -67,10 +67,10 @@ plcallback(krb5_context context, const void *plug, void *plugctx, void *userctx)
 }
 
 static krb5_error_code plugin_reg_ret;
-static krb5plugin_kuserok_ftable kuserok_simple_plug;
-static krb5plugin_kuserok_ftable kuserok_sys_k5login_plug;
-static krb5plugin_kuserok_ftable kuserok_user_k5login_plug;
-static krb5plugin_kuserok_ftable kuserok_deny_plug;
+static const krb5plugin_kuserok_ftable kuserok_simple_plug;
+static const krb5plugin_kuserok_ftable kuserok_sys_k5login_plug;
+static const krb5plugin_kuserok_ftable kuserok_user_k5login_plug;
+static const krb5plugin_kuserok_ftable kuserok_deny_plug;
 
 static void
 reg_def_plugins_once(void *ctx)
@@ -455,9 +455,9 @@ krb5_kuserok(krb5_context context,
 }
 
 
-static const char *kuserok_plugin_deps[] = { "krb5", NULL };
+static const char *const kuserok_plugin_deps[] = { "krb5", NULL };
 
-static struct heim_plugin_data
+static const struct heim_plugin_data
 kuserok_plugin_data = {
     "krb5",
     KRB5_PLUGIN_KUSEROK,
@@ -723,28 +723,28 @@ kuser_ok_null_plugin_fini(void *ctx)
     return;
 }
 
-static krb5plugin_kuserok_ftable kuserok_simple_plug = {
+static const krb5plugin_kuserok_ftable kuserok_simple_plug = {
     KRB5_PLUGIN_KUSEROK_VERSION_0,
     kuser_ok_null_plugin_init,
     kuser_ok_null_plugin_fini,
     kuserok_simple_plug_f,
 };
 
-static krb5plugin_kuserok_ftable kuserok_sys_k5login_plug = {
+static const krb5plugin_kuserok_ftable kuserok_sys_k5login_plug = {
     KRB5_PLUGIN_KUSEROK_VERSION_0,
     kuser_ok_null_plugin_init,
     kuser_ok_null_plugin_fini,
     kuserok_sys_k5login_plug_f,
 };
 
-static krb5plugin_kuserok_ftable kuserok_user_k5login_plug = {
+static const krb5plugin_kuserok_ftable kuserok_user_k5login_plug = {
     KRB5_PLUGIN_KUSEROK_VERSION_0,
     kuser_ok_null_plugin_init,
     kuser_ok_null_plugin_fini,
     kuserok_user_k5login_plug_f,
 };
 
-static krb5plugin_kuserok_ftable kuserok_deny_plug = {
+static const krb5plugin_kuserok_ftable kuserok_deny_plug = {
     KRB5_PLUGIN_KUSEROK_VERSION_0,
     kuser_ok_null_plugin_init,
     kuser_ok_null_plugin_fini,

--- a/lib/krb5/mk_error.c
+++ b/lib/krb5/mk_error.c
@@ -76,8 +76,8 @@ krb5_mk_error_ext(krb5_context context,
 	msg.realm = server->realm;
 	msg.sname = server->name;
     }else{
-	static char unspec[] = "<unspecified realm>";
-	msg.realm = unspec;
+	static const char unspec[] = "<unspecified realm>";
+	msg.realm = rk_UNCONST(unspec);
     }
     msg.crealm = rk_UNCONST(client_realm);
     msg.cname = rk_UNCONST(client_name);

--- a/lib/krb5/pac.c
+++ b/lib/krb5/pac.c
@@ -137,7 +137,7 @@ pac_dealloc(void *ctx)
     free(pac->pac);
 }
 
-struct heim_type_data pac_object = {
+static const struct heim_type_data pac_object = {
     HEIM_TID_PAC,
     "heim-pac",
     NULL,
@@ -586,7 +586,7 @@ krb5_pac_get_buffer(krb5_context context, krb5_const_pac p,
     return ENOENT;
 }
 
-static struct {
+static const struct {
     uint32_t type;
     krb5_data name;
 } pac_buffer_name_map[] = {
@@ -2032,8 +2032,8 @@ _krb5_pac_get_attributes_info(krb5_context context,
     return 0;
 }
 
-static unsigned char single_zero = '\0';
-static krb5_data single_zero_pac = { 1, &single_zero };
+static const unsigned char single_zero = '\0';
+static const krb5_data single_zero_pac = { 1, rk_UNCONST(&single_zero) };
 
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 _krb5_kdc_pac_ticket_parse(krb5_context context,

--- a/lib/krb5/pcache.c
+++ b/lib/krb5/pcache.c
@@ -58,9 +58,9 @@ cc_plugin_register_to_context(krb5_context context, const void *plug, void *plug
     return KRB5_PLUGIN_NO_HANDLE;
 }
 
-static const char *ccache_plugin_deps[] = { "krb5", NULL };
+static const char *const ccache_plugin_deps[] = { "krb5", NULL };
 
-static struct heim_plugin_data
+static const struct heim_plugin_data
 ccache_plugin_data = {
     "krb5",
     KRB5_PLUGIN_CCACHE,

--- a/lib/krb5/plugin.c
+++ b/lib/krb5/plugin.c
@@ -75,7 +75,7 @@ KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_plugin_register(krb5_context context,
 		     enum krb5_plugin_type type,
 		     const char *name,
-		     void *symbol)
+		     const void *symbol)
 {
     /*
      * It's not clear that PLUGIN_TYPE_FUNC was ever used or supported. It likely
@@ -147,7 +147,7 @@ _krb5_unload_plugins(krb5_context context, const char *name)
  */
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 _krb5_plugin_run_f(krb5_context context,
-		   struct heim_plugin_data *caller,
+		   const struct heim_plugin_data *caller,
 		   int flags,
 		   void *userctx,
 		   krb5_error_code (KRB5_LIB_CALL *func)(krb5_context, const void *, void *, void *))

--- a/lib/krb5/salt-aes-sha1.c
+++ b/lib/krb5/salt-aes-sha1.c
@@ -33,7 +33,7 @@
 
 #include "krb5_locl.h"
 
-int _krb5_AES_SHA1_string_to_default_iterator = 4096;
+const int _krb5_AES_SHA1_string_to_default_iterator = 4096;
 
 static krb5_error_code
 AES_SHA1_string_to_key(krb5_context context,

--- a/lib/krb5/salt-aes-sha2.c
+++ b/lib/krb5/salt-aes-sha2.c
@@ -33,7 +33,7 @@
 
 #include "krb5_locl.h"
 
-int _krb5_AES_SHA2_string_to_default_iterator = 32768;
+const int _krb5_AES_SHA2_string_to_default_iterator = 32768;
 
 static krb5_error_code
 AES_SHA2_string_to_key(krb5_context context,

--- a/lib/krb5/send_to_kdc.c
+++ b/lib/krb5/send_to_kdc.c
@@ -96,9 +96,9 @@ realmcallback(krb5_context context, const void *plug, void *plugctx, void *userc
 				  ctx->send_data, ctx->receive);
 }
 
-static const char *send_to_kdc_plugin_deps[] = { "krb5", NULL };
+static const char *const send_to_kdc_plugin_deps[] = { "krb5", NULL };
 
-static struct heim_plugin_data
+static const struct heim_plugin_data
 send_to_kdc_plugin_data = {
     "krb5",
     KRB5_PLUGIN_SEND_TO_KDC,

--- a/lib/krb5/send_to_kdc.c
+++ b/lib/krb5/send_to_kdc.c
@@ -330,7 +330,7 @@ struct host {
     krb5_krbhst_info *hi;
     struct addrinfo *ai;
     rk_socket_t fd;
-    struct host_fun *fun;
+    const struct host_fun *fun;
     unsigned int tries;
     time_t timeout;
     krb5_data data;
@@ -715,19 +715,19 @@ recv_udp(krb5_context context, struct host *host, krb5_data *data)
     return 0;
 }
 
-static struct host_fun http_fun = {
+static const struct host_fun http_fun = {
     prepare_http,
     send_stream,
     recv_http,
     1
 };
-static struct host_fun tcp_fun = {
+static const struct host_fun tcp_fun = {
     prepare_tcp,
     send_stream,
     recv_tcp,
     1
 };
-static struct host_fun udp_fun = {
+static const struct host_fun udp_fun = {
     prepare_udp,
     send_udp,
     recv_udp,

--- a/lib/vers/make-print-version.c
+++ b/lib/vers/make-print-version.c
@@ -39,7 +39,7 @@
 #include <string.h>
 
 #ifdef KRB5
-extern const char *heimdal_version;
+extern const char *const heimdal_version;
 #endif
 #include <version.h>
 


### PR DESCRIPTION
This cuts down on a large amount of .data in libkrb5.so, moving it to .rodata, and, more importantly, substantially reduces the number of non-const globals that must be audited for thread safety.  I tracked all this down by iteratively running:

```
nm --defined-only lib/krb5/.libs/libkrb5.a \
| awk '$1 ~ /:/ { f = $1 } $2 ~ /[bBdD]/ { if (f) { printf("\n"); print f; f = "" }; print }'
```

to print all .data and .bss symbols and what file they came from, until I eliminated every unnecessarily mutable global I could, with some exceptions I didn't understand on cursory inspection (notably https://github.com/heimdal/heimdal/issues/1132 and https://github.com/heimdal/heimdal/issues/1133).

One more commit along these lines in my tree is queued up, to constify the checksum/encryption/string-to-key type structures.  However, it is blocked on https://github.com/heimdal/heimdal/issues/1131, so I'll do it separately.

All tests except check-gssmask pass with this on NetBSD 9.  (check-gssmask hangs, but it hung already without these changes, so that's not a regression: https://github.com/heimdal/heimdal/issues/1139)

I did not examine the other libraries than libkrb5.  My focus is on making it safe for clients to use this.  Next step would be libgssapi, which, from the nm | awk incantation, looks like it too has a lot of unnecessary mutable globals.