### PR TITLE
kdc s4u2proxy fixes for Windows (Samba AD) clients 

### DIFF
--- a/kdc/kdc-tester.c
+++ b/kdc/kdc-tester.c
@@ -50,6 +50,9 @@ int do_bonjour = -1;
 
 static krb5_kdc_configuration *kdc_config;
 static krb5_context kdc_context;
+static int expect_fast_tgs;
+static int expect_no_outer_authdata;
+static int seen_fast_tgs;
 
 static struct sockaddr_storage sa;
 static const char *astr = "0.0.0.0";
@@ -92,7 +95,28 @@ plugin_send_to_realm(krb5_context context,
 		     const krb5_data *in,
 		     krb5_data *out)
 {
+    TGS_REQ tgs_req;
     int ret;
+
+    memset(&tgs_req, 0, sizeof(tgs_req));
+    ret = decode_TGS_REQ(in->data, in->length, &tgs_req, NULL);
+    if (ret == 0) {
+	PA_DATA *pa = NULL;
+	int idx = 0;
+
+	if (tgs_req.padata)
+	    pa = krb5_find_padata(tgs_req.padata->val, tgs_req.padata->len,
+				  KRB5_PADATA_FX_FAST, &idx);
+	if (pa)
+	    seen_fast_tgs = 1;
+	else if (expect_fast_tgs)
+	    krb5_errx(kdc_context, 1, "TGS request was not FAST wrapped");
+	if (expect_no_outer_authdata &&
+	    tgs_req.req_body.enc_authorization_data)
+	    krb5_errx(kdc_context, 1,
+		      "TGS outer request included enc-authorization-data");
+	free_TGS_REQ(&tgs_req);
+    }
 
     krb5_kdc_update_time(NULL);
 
@@ -345,16 +369,24 @@ eval_kinit(heim_dict_t o)
 static void
 eval_kgetcred(heim_dict_t o)
 {
-    heim_string_t server, ccache;
+    heim_string_t server, ccache, authdata;
     krb5_get_creds_opt opt;
-    heim_bool_t nostore;
+    heim_bool_t nostore, require_fast, inner_authdata_only;
     krb5_error_code ret;
     krb5_ccache cc = NULL;
     krb5_principal s;
     krb5_creds *out = NULL;
+    krb5_creds in;
+    krb5_flags options = 0;
+    krb5_kdc_flags flags;
+    const char *getcred_func = "krb5_get_creds";
+    char *save_inner_authdata_only = NULL;
+    krb5_boolean set_inner_authdata_only = FALSE;
 
     if (ptop)
 	ptop->tgs_req++;
+
+    memset(&in, 0, sizeof(in));
 
     server = heim_dict_get_value(o, HSTR("server"));
     if (server == NULL)
@@ -368,6 +400,21 @@ eval_kgetcred(heim_dict_t o)
     if (nostore == NULL)
 	nostore = heim_bool_create(1);
 
+    authdata = heim_dict_get_value(o, HSTR("authdata"));
+    if (authdata) {
+	AuthorizationDataElement ade;
+	const char *s = heim_string_get_utf8(authdata);
+
+	memset(&ade, 0, sizeof(ade));
+	ade.ad_type = 777;
+	ade.ad_data.data = rk_UNCONST(s);
+	ade.ad_data.length = strlen(s);
+
+	ret = add_AuthorizationData(&in.authdata, &ade);
+	if (ret)
+	    krb5_err(kdc_context, 1, ret, "add_AuthorizationData");
+    }
+
     ret = krb5_cc_resolve(kdc_context, heim_string_get_utf8(ccache), &cc);
     if (ret)
 	krb5_err(kdc_context, 1, ret, "krb5_cc_resolve");
@@ -375,20 +422,69 @@ eval_kgetcred(heim_dict_t o)
     ret = krb5_parse_name(kdc_context, heim_string_get_utf8(server), &s);
     if (ret)
 	krb5_err(kdc_context, 1, ret, "krb5_parse_name");
+    in.server = s;
 
     ret = krb5_get_creds_opt_alloc(kdc_context, &opt);
     if (ret)
 	krb5_err(kdc_context, 1, ret, "krb5_get_creds_opt_alloc");
 
-    if (heim_bool_val(nostore))
+    if (heim_bool_val(nostore)) {
 	krb5_get_creds_opt_add_options(kdc_context, opt, KRB5_GC_NO_STORE);
+	options |= KRB5_GC_NO_STORE;
+    }
 
-    ret = krb5_get_creds(kdc_context, opt, cc, s, &out);
+    require_fast = heim_dict_get_value(o, HSTR("require-fast"));
+    expect_fast_tgs = require_fast && heim_bool_val(require_fast);
+    seen_fast_tgs = 0;
+
+    inner_authdata_only = heim_dict_get_value(o, HSTR("fast-inner-authdata-only"));
+    set_inner_authdata_only =
+	inner_authdata_only && heim_bool_val(inner_authdata_only);
+    if (set_inner_authdata_only) {
+	const char *e = getenv("HEIMDAL_TEST_FAST_INNER_AUTHDATA_ONLY");
+
+	if (authdata == NULL)
+	    krb5_errx(kdc_context, 1, "no authdata");
+	if (e) {
+	    save_inner_authdata_only = strdup(e);
+	    if (save_inner_authdata_only == NULL)
+		krb5_err(kdc_context, 1, ENOMEM, "strdup");
+	}
+	if (setenv("HEIMDAL_TEST_FAST_INNER_AUTHDATA_ONLY", "1", 1) != 0)
+	    krb5_err(kdc_context, 1, errno, "setenv");
+    }
+    expect_no_outer_authdata = set_inner_authdata_only;
+
+    if (authdata) {
+	ret = krb5_cc_get_principal(kdc_context, cc, &in.client);
+	if (ret)
+	    krb5_err(kdc_context, 1, ret, "krb5_cc_get_principal");
+	flags.i = 0;
+	getcred_func = "krb5_get_credentials_with_flags";
+	ret = krb5_get_credentials_with_flags(kdc_context, options, flags,
+					      cc, &in, &out);
+    } else {
+	ret = krb5_get_creds(kdc_context, opt, cc, s, &out);
+    }
     if (ret)
-	krb5_err(kdc_context, 1, ret, "krb5_get_creds");
+	krb5_err(kdc_context, 1, ret, "%s", getcred_func);
+    if (expect_fast_tgs && !seen_fast_tgs)
+	krb5_errx(kdc_context, 1, "TGS request did not use FAST");
+    expect_fast_tgs = 0;
+    expect_no_outer_authdata = 0;
+    if (set_inner_authdata_only) {
+	if (save_inner_authdata_only) {
+	    if (setenv("HEIMDAL_TEST_FAST_INNER_AUTHDATA_ONLY",
+		       save_inner_authdata_only, 1) != 0)
+		krb5_err(kdc_context, 1, errno, "setenv");
+	    free(save_inner_authdata_only);
+	} else {
+	    unsetenv("HEIMDAL_TEST_FAST_INNER_AUTHDATA_ONLY");
+	}
+    }
     
     krb5_free_creds(kdc_context, out);
-    krb5_free_principal(kdc_context, s);
+    krb5_free_cred_contents(kdc_context, &in);
     krb5_get_creds_opt_free(kdc_context, opt);
     krb5_cc_close(kdc_context, cc);
 }

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -185,6 +185,7 @@ struct astgs_request_desc {
     unsigned int rk_is_subkey : 1;
     unsigned int fast_asserted : 1;
     unsigned int explicit_armor_present : 1;
+    krb5_keyblock enc_ad_key;
 
     krb5_crypto armor_crypto;
     hdb_entry *armor_server;

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2839,6 +2839,7 @@ out:
     if (r->armor_server)
 	_kdc_free_ent(r->context, r->armor_serverdb, r->armor_server);
     krb5_free_keyblock_contents(r->context, &r->reply_key);
+    krb5_free_keyblock_contents(r->context, &r->enc_ad_key);
     krb5_free_keyblock_contents(r->context, &r->session_key);
     krb5_free_keyblock_contents(r->context, &r->strengthen_key);
     krb5_pac_free(r->context, r->pac);

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -556,7 +556,8 @@ tgs_make_reply(astgs_request_t r,
     rep->pvno = 5;
     rep->msg_type = krb_tgs_rep;
 
-    et->authtime = tgt->authtime;
+    if (et->authtime == 0)
+        et->authtime = tgt->authtime;
     _kdc_fix_time(&b->till);
     et->endtime = min(tgt->endtime, *b->till);
     ALLOC(et->starttime);

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1203,11 +1203,13 @@ next_kvno:
 	}
 	ALLOC(*auth_data);
 	if (*auth_data == NULL) {
+	    krb5_data_free(&ad);
 	    krb5_auth_con_free(r->context, ac);
 	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
 	    goto out;
 	}
 	ret = decode_AuthorizationData(ad.data, ad.length, *auth_data, NULL);
+	krb5_data_free(&ad);
 	if(ret){
 	    krb5_auth_con_free(r->context, ac);
 	    free(*auth_data);

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -935,8 +935,7 @@ tgs_parse_request(astgs_request_t r,
 		  const char *from,
 		  const struct sockaddr *from_addr,
 		  time_t **csec,
-		  int **cusec,
-		  AuthorizationData **auth_data)
+		  int **cusec)
 {
     krb5_kdc_configuration *config = r->config;
     KDC_REQ_BODY *b = &r->req.req_body;
@@ -947,16 +946,13 @@ tgs_parse_request(astgs_request_t r,
     krb5_auth_context ac = NULL;
     krb5_flags ap_req_options;
     krb5_flags verify_ap_req_flags = 0;
-    krb5_crypto crypto;
     krb5uint32 krbtgt_kvno;     /* kvno used for the PA-TGS-REQ AP-REQ Ticket */
     krb5uint32 krbtgt_kvno_try;
     int kvno_search_tries = 4;  /* number of kvnos to try when tkt_vno == 0 */
     const Keys *krbtgt_keys;/* keyset for TGT tkt_vno */
     Key *tkey;
     krb5_keyblock *subkey = NULL;
-    unsigned usage;
 
-    *auth_data = NULL;
     *csec  = NULL;
     *cusec = NULL;
 
@@ -1139,7 +1135,6 @@ next_kvno:
 	goto out;
     }
 
-    usage = KRB5_KU_TGS_REQ_AUTH_DAT_SUBKEY;
     r->rk_is_subkey = 1;
 
     ret = krb5_auth_con_getremotesubkey(r->context, ac, &subkey);
@@ -1151,7 +1146,6 @@ next_kvno:
 	goto out;
     }
     if(subkey == NULL){
-	usage = KRB5_KU_TGS_REQ_AUTH_DAT_SESSION;
 	r->rk_is_subkey = 0;
 
 	ret = krb5_auth_con_getkey(r->context, ac, &subkey);
@@ -1177,49 +1171,6 @@ next_kvno:
     if (ret)
 	goto out;
 
-    if (b->enc_authorization_data) {
-	krb5_data ad;
-
-	ret = krb5_crypto_init(r->context, &r->reply_key, 0, &crypto);
-	if (ret) {
-	    const char *msg = krb5_get_error_message(r->context, ret);
-	    krb5_auth_con_free(r->context, ac);
-	    kdc_log(r->context, config, 4, "krb5_crypto_init failed: %s", msg);
-	    krb5_free_error_message(r->context, msg);
-	    goto out;
-	}
-	ret = krb5_decrypt_EncryptedData (r->context,
-					  crypto,
-					  usage,
-					  b->enc_authorization_data,
-					  &ad);
-	krb5_crypto_destroy(r->context, crypto);
-	if(ret){
-	    krb5_auth_con_free(r->context, ac);
-	    kdc_log(r->context, config, 4,
-		    "Failed to decrypt enc-authorization-data");
-	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
-	    goto out;
-	}
-	ALLOC(*auth_data);
-	if (*auth_data == NULL) {
-	    krb5_data_free(&ad);
-	    krb5_auth_con_free(r->context, ac);
-	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
-	    goto out;
-	}
-	ret = decode_AuthorizationData(ad.data, ad.length, *auth_data, NULL);
-	krb5_data_free(&ad);
-	if(ret){
-	    krb5_auth_con_free(r->context, ac);
-	    free(*auth_data);
-	    *auth_data = NULL;
-	    kdc_log(r->context, config, 4, "Failed to decode authorization data");
-	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
-	    goto out;
-	}
-    }
-
     ret = validate_fast_ad(r, r->ticket->ticket.authorization_data);
     if (ret)
 	goto out;
@@ -1232,6 +1183,15 @@ next_kvno:
     ret = _kdc_fast_unwrap_request(r, r->ticket, ac);
     if (ret)
 	goto out;
+
+    krb5_free_keyblock_contents(r->context,  &r->enc_ad_key);
+    if (b->enc_authorization_data) {
+	ret = krb5_copy_keyblock_contents(r->context,
+					  &r->reply_key,
+					  &r->enc_ad_key);
+	if (ret)
+	    goto out;
+    }
 
     krb5_auth_con_free(r->context, ac);
 
@@ -1376,7 +1336,6 @@ _kdc_db_fetch_client(krb5_context context,
 static krb5_error_code
 tgs_build_reply(astgs_request_t priv,
 		krb5_enctype krbtgt_etype,
-		AuthorizationData **auth_data,
 		const struct sockaddr *from_addr)
 {
     krb5_context context = priv->context;
@@ -1406,6 +1365,7 @@ tgs_build_reply(astgs_request_t priv,
         krb5_principal_get_comp_string(context, priv->krbtgt->principal, 1);
     char **capath = NULL;
     size_t num_capath = 0;
+    AuthorizationData *auth_data = NULL;
 
     HDB *krbtgt_outdb = NULL;
     hdb_entry *krbtgt_out = NULL;
@@ -1937,6 +1897,60 @@ server_lookup:
     if (ret)
 	goto out;
 
+    if (b->enc_authorization_data) {
+	unsigned auth_data_usage;
+	krb5_crypto crypto;
+	krb5_data ad;
+
+	if (priv->rk_is_subkey != 0) {
+	    auth_data_usage = KRB5_KU_TGS_REQ_AUTH_DAT_SUBKEY;
+	} else {
+	    auth_data_usage = KRB5_KU_TGS_REQ_AUTH_DAT_SESSION;
+	}
+
+	ret = krb5_crypto_init(context, &priv->enc_ad_key, 0, &crypto);
+	if (ret) {
+	    const char *msg = krb5_get_error_message(context, ret);
+	    kdc_audit_addreason((kdc_request_t)priv,
+				"krb5_crypto_init() failed for "
+				"enc_authorization_data");
+	    kdc_log(context, config, 4, "krb5_crypto_init failed: %s", msg);
+	    krb5_free_error_message(context, msg);
+	    goto out;
+	}
+	ret = krb5_decrypt_EncryptedData(context,
+					 crypto,
+					 auth_data_usage,
+					 b->enc_authorization_data,
+					 &ad);
+	krb5_crypto_destroy(context, crypto);
+	if(ret){
+	    kdc_audit_addreason((kdc_request_t)priv,
+				"Failed to decrypt enc-authorization-data");
+	    kdc_log(context, config, 4,
+		    "Failed to decrypt enc-authorization-data");
+	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
+	    goto out;
+	}
+	ALLOC(auth_data);
+	if (auth_data == NULL) {
+	    krb5_data_free(&ad);
+	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
+	    goto out;
+	}
+	ret = decode_AuthorizationData(ad.data, ad.length, auth_data, NULL);
+	krb5_data_free(&ad);
+	if(ret){
+	    free(auth_data);
+	    auth_data = NULL;
+	    kdc_audit_addreason((kdc_request_t)priv,
+				"Failed to decode authorization data");
+	    kdc_log(context, config, 4, "Failed to decode authorization data");
+	    ret = KRB5KRB_AP_ERR_BAD_INTEGRITY; /* ? */
+	    goto out;
+	}
+    }
+
     /*
      * Check flags
      */
@@ -2048,7 +2062,7 @@ server_lookup:
 			 &tkey_sign->key,
 			 &sessionkey,
 			 kvno,
-			 *auth_data,
+			 auth_data,
                          tgt_realm,
 			 rodc_id,
 			 add_ticket_sig);
@@ -2067,6 +2081,11 @@ out:
     krb5_free_principal(context, user2user_princ);
     krb5_free_principal(context, krbtgt_out_principal);
     free(ref_realm);
+
+    if (auth_data) {
+       free_AuthorizationData(auth_data);
+       free(auth_data);
+    }
 
     free_EncTicketPart(&adtkt);
 
@@ -2088,7 +2107,6 @@ _kdc_tgs_rep(astgs_request_t r)
     const char *from = r->from;
     struct sockaddr *from_addr = r->addr;
     int datagram_reply = r->datagram_reply;
-    AuthorizationData *auth_data = NULL;
     krb5_error_code ret;
     int i = 0;
     const PA_DATA *tgs_req, *pa;
@@ -2126,8 +2144,7 @@ _kdc_tgs_rep(astgs_request_t r)
     ret = tgs_parse_request(r, tgs_req,
 			    &krbtgt_etype,
 			    from, from_addr,
-			    &csec, &cusec,
-			    &auth_data);
+			    &csec, &cusec);
     if (ret == HDB_ERR_NOT_FOUND_HERE) {
 	/* kdc_log() is called in tgs_parse_request() */
 	goto out;
@@ -2151,7 +2168,6 @@ _kdc_tgs_rep(astgs_request_t r)
 
     ret = tgs_build_reply(r,
 			  krbtgt_etype,
-			  &auth_data,
 			  from_addr);
     if (ret) {
 	kdc_log(r->context, config, 4,
@@ -2236,6 +2252,7 @@ out:
     if (r->explicit_armor_pac)
 	krb5_pac_free(r->context, r->explicit_armor_pac);
     krb5_free_keyblock_contents(r->context, &r->reply_key);
+    krb5_free_keyblock_contents(r->context, &r->enc_ad_key);
     krb5_free_keyblock_contents(r->context, &r->strengthen_key);
 
     if (r->ticket)
@@ -2251,11 +2268,6 @@ out:
     krb5_free_principal(r->context, r->server_princ);
     _kdc_free_fast_state(&r->fast);
     krb5_pac_free(r->context, r->pac);
-
-    if (auth_data) {
-	free_AuthorizationData(auth_data);
-	free(auth_data);
-    }
 
     return ret;
 }

--- a/kdc/mssfu.c
+++ b/kdc/mssfu.c
@@ -526,6 +526,15 @@ validate_constrained_delegation(astgs_request_t r)
 	    goto out;
     }
 
+    if (b->enc_authorization_data && r->rk_is_subkey == 0) {
+	krb5_free_keyblock_contents(r->context, &r->enc_ad_key);
+	ret = krb5_copy_keyblock_contents(r->context,
+					  &evidence_tkt.key,
+					  &r->enc_ad_key);
+	if (ret)
+	    goto out;
+    }
+
     kdc_log(r->context, r->config, 4, "constrained delegation for %s "
 	    "from %s (%s) to %s", s4ucname, r->cname, s4usname, r->sname);
 

--- a/kdc/mssfu.c
+++ b/kdc/mssfu.c
@@ -557,6 +557,8 @@ validate_constrained_delegation(astgs_request_t r)
 
     r->pac_attributes = s4u_pac_attributes;
 
+    r->et.authtime = evidence_tkt.authtime;
+
 out:
     if (s4u_client)
 	_kdc_free_ent(r->context, s4u_clientdb, s4u_client);

--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -130,6 +130,16 @@ set_auth_data (krb5_context context,
     }
 }
 
+static void
+clear_auth_data(KDC_REQ_BODY *req_body)
+{
+    if (req_body->enc_authorization_data) {
+	free_EncryptedData(req_body->enc_authorization_data);
+	free(req_body->enc_authorization_data);
+	req_body->enc_authorization_data = NULL;
+    }
+}
+
 /*
  * Create a tgs-req in `t' with `addresses', `flags', `second_ticket'
  * (if not-NULL), `in_creds', `krbtgt', and returning the generated
@@ -153,6 +163,7 @@ init_tgs_req (krb5_context context,
     krb5_auth_context ac = NULL;
     krb5_error_code ret = 0;
     krb5_data tgs_req;
+    krb5_boolean fast_inner_authdata_only = FALSE;
 
     krb5_data_zero(&tgs_req);
     memset(t, 0, sizeof(*t));
@@ -259,10 +270,20 @@ init_tgs_req (krb5_context context,
 	    goto fail;
     }
 
-    ret = set_auth_data(context, &t->req_body,
-			&in_creds->authdata, ac->local_subkey);
-    if (ret)
-	goto fail;
+    /*
+     * Test hook: keep the TGS outer body free of enc-authorization-data
+     * while carrying it in the FAST inner body.
+     */
+    fast_inner_authdata_only =
+	state != NULL && in_creds->authdata.len > 0 &&
+	secure_getenv("HEIMDAL_TEST_FAST_INNER_AUTHDATA_ONLY") != NULL;
+
+    if (!fast_inner_authdata_only) {
+	ret = set_auth_data(context, &t->req_body,
+			    &in_creds->authdata, ac->local_subkey);
+	if (ret)
+	    goto fail;
+    }
 
     ret = make_pa_tgs_req(context,
 			  &ac,
@@ -327,9 +348,19 @@ init_tgs_req (krb5_context context,
 	if (ret)
 	    goto fail;
 
+	if (fast_inner_authdata_only) {
+	    ret = set_auth_data(context, &t->req_body,
+				&in_creds->authdata, ac->local_subkey);
+	    if (ret)
+		goto fail;
+	}
+
 	ret = _krb5_fast_wrap_req(context, state, t);
 	if (ret)
 	    goto fail;
+
+	if (fast_inner_authdata_only)
+	    clear_auth_data(&t->req_body);
 
 	/* Its ok if there is no fast in the TGS-REP, older heimdal only support it in the AS code path */
 	state->flags &= ~KRB5_FAST_EXPECTED;

--- a/tests/kdc/Makefile.am
+++ b/tests/kdc/Makefile.am
@@ -133,7 +133,8 @@ check-kdc-weak: check-kdc krb5-weak.conf check-kdc-weak.in Makefile
 	$(chmod) +x check-kdc-weak.tmp && \
 	mv check-kdc-weak.tmp check-kdc-weak
 
-check-tester: check-tester.in kdc-tester4.json Makefile
+check-tester: check-tester.in kdc-tester4.json kdc-tester5.json \
+	kdc-tester6.json Makefile
 	$(do_subst) < $(srcdir)/check-tester.in > check-tester.tmp && \
 	$(chmod) +x check-tester.tmp && \
 	mv check-tester.tmp check-tester
@@ -351,6 +352,7 @@ CLEANFILES= \
 	iprop.keytab \
 	ipropd.dumpfile \
 	kdc-tester4.json \
+	krb5-tester-fast.conf \
 	krb5-authz.conf \
 	krb5-authz2.conf \
 	krb5-canon.conf \
@@ -433,6 +435,8 @@ EXTRA_DIST = \
 	kdc-tester2.json \
 	kdc-tester3.json \
 	kdc-tester4.json.in \
+	kdc-tester5.json \
+	kdc-tester6.json \
 	krb5-authz.conf.in \
 	krb5-authz2.conf.in \
 	krb5-bx509.conf.in \

--- a/tests/kdc/check-tester.in
+++ b/tests/kdc/check-tester.in
@@ -106,6 +106,19 @@ echo "FAST + keytab"
 ${kdc_tester} ${srcdir}/kdc-tester3.json > out-log 2>&1 || exit 1
 sed 's/^/	/' out-log
 
+echo "FAST + TGS enc-authorization-data"
+sed '/^\[libdefaults\]/a\
+        name_canon_rules = as-is:realm=TEST.H5L.SE:use_fast' \
+    "${KRB5_CONFIG}" > "${objdir}/krb5-tester-fast.conf" || exit 1
+KRB5_CONFIG="${objdir}/krb5-tester-fast.conf" \
+${kdc_tester} ${srcdir}/kdc-tester5.json > out-log 2>&1 || exit 1
+sed 's/^/	/' out-log
+
+echo "FAST + inner TGS enc-authorization-data"
+KRB5_CONFIG="${objdir}/krb5-tester-fast.conf" \
+${kdc_tester} ${srcdir}/kdc-tester6.json > out-log 2>&1 || exit 1
+sed 's/^/	/' out-log
+
 
 if test "$pkinit" = yes ; then
 

--- a/tests/kdc/kdc-tester5.json
+++ b/tests/kdc/kdc-tester5.json
@@ -1,0 +1,19 @@
+[
+	{
+	"op" : "kinit",
+	"client" : "foo@TEST.H5L.SE",
+	"password" : "foo",
+	"ccache" : "MEMORY:fast-authdata-cache"
+	},
+	{
+	"op" : "kgetcred",
+	"server" : "host/datan.test.h5l.se@TEST.H5L.SE",
+	"ccache" : "MEMORY:fast-authdata-cache",
+	"authdata" : "FAST TGS authorization data",
+	"require-fast" : true
+	},
+	{
+	"op" : "kdestroy",
+	"ccache" : "MEMORY:fast-authdata-cache"
+	}
+]

--- a/tests/kdc/kdc-tester6.json
+++ b/tests/kdc/kdc-tester6.json
@@ -1,0 +1,20 @@
+[
+	{
+	"op" : "kinit",
+	"client" : "foo@TEST.H5L.SE",
+	"password" : "foo",
+	"ccache" : "MEMORY:fast-inner-authdata-cache"
+	},
+	{
+	"op" : "kgetcred",
+	"server" : "host/datan.test.h5l.se@TEST.H5L.SE",
+	"ccache" : "MEMORY:fast-inner-authdata-cache",
+	"authdata" : "FAST inner TGS authorization data",
+	"require-fast" : true,
+	"fast-inner-authdata-only" : true
+	},
+	{
+	"op" : "kdestroy",
+	"ccache" : "MEMORY:fast-inner-authdata-cache"
+	}
+]


### PR DESCRIPTION
Further details can be found here:
https://bugzilla.samba.org/show_bug.cgi?id=13131
(S4U2Proxy requests with encrypted authorization-data are rejected by a Samba KDC)

https://bugzilla.samba.org/show_bug.cgi?id=13137
S4U2Proxy tickets from a Samba KDC don't pass PAC verification checks (authtime mismatch)

Here are the same changes including tests demonstrating
the problems and that they are fixed with the kdc changes:
https://gitlab.com/samba-team/samba/-/merge_requests/2458