### PR TITLE
ktutil: Avoid even arithmetic on res after realloc(res, ...).

### DIFF
--- a/admin/add.c
+++ b/admin/add.c
@@ -187,7 +187,7 @@ read_file(FILE *f)
             if ((tmp = realloc(res, alloced + (alloced > 1))) == NULL)
                 err(1, "Out of memory");
             alloced += alloced > 1;
-            p = tmp + (p - res);
+            p = tmp + len;
             res = tmp;
             end = res + alloced;
         }


### PR DESCRIPTION
Under C99, Sec 6.2.4, paragraph 2:

> The value of a pointer becomes indeterminate when the object it points to reaches the end of its lifetime.

'Indeterminate' (3.17.2) includes a trap representation, and any reference to a trap representation is undefined behaviour.  Thus, after realloc(res, ...) succeeds, any reference to res (or p) is undefined behaviour.

So, instead of using `p - res` after res has been freed, use the existing name for the value we know it has now: len.  (We could also use alloced because p == end in this branch, and end = res + alloced, and p = res + len.  Of course, we would have to move it up a line to before we update alloced to have a different value.)

fix https://github.com/heimdal/heimdal/issues/1164