### PR TITLE
Makefile.am: Set AM_YFLAGS and AM_LFLAGS, not YFLAGS or LFLAGS.

### DIFF
--- a/lib/asn1/Makefile.am
+++ b/lib/asn1/Makefile.am
@@ -4,7 +4,7 @@ include $(top_srcdir)/Makefile.am.common
 
 WFLAGS += $(WFLAGS_ENUM_CONV)
 
-YFLAGS = -d -o asn1parse.c -t
+AM_YFLAGS = -d -o asn1parse.c -t
 
 AM_CPPFLAGS += $(ROKEN_RENAME) -I$(top_builddir)/include -I$(top_srcdir)/lib/base
 

--- a/lib/com_err/Makefile.am
+++ b/lib/com_err/Makefile.am
@@ -2,8 +2,8 @@
 
 include $(top_srcdir)/Makefile.am.common
 
-YFLAGS = -d -o parse.c
-LFLAGS = @FLEXNOUNPUTARGS@
+AM_YFLAGS = -d -o parse.c
+AM_LFLAGS = @FLEXNOUNPUTARGS@
 
 lib_LTLIBRARIES = libcom_err.la
 libcom_err_la_LDFLAGS = -version-info 2:3:1

--- a/lib/sl/Makefile.am
+++ b/lib/sl/Makefile.am
@@ -8,8 +8,8 @@ endif
 
 AM_CPPFLAGS += $(ROKEN_RENAME)
 
-YFLAGS = -d -o slc-gram.c
-LFLAGS = @FLEXNOUNPUTARGS@
+AM_YFLAGS = -d -o slc-gram.c
+AM_LFLAGS = @FLEXNOUNPUTARGS@
 
 include_HEADERS = sl.h
 


### PR DESCRIPTION
YFLAGS and LFLAGS are reserved for the user to set, not for makefiles to set:
https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html

fix https://github.com/heimdal/heimdal/issues/1171