### PR TITLE
Add HDB entry auth-data-reqd flag

### DIFF
--- a/kadmin/kadmin.1
+++ b/kadmin/kadmin.1
@@ -473,25 +473,49 @@ The only policy supported by Heimdal is
 If a krb5 config file is given, it will be saved in the entry.
 .Pp
 Possible attributes are:
-.Li new-princ ,
-.Li support-desmd5 ,
-.Li pwchange-service ,
-.Li disallow-client ,
-.Li disallow-svr ,
-.Li requires-pw-change ,
-.Li requires-hw-auth ,
-.Li requires-pre-auth ,
-.Li allow-digest ,
-.Li trusted-for-delegation ,
-.Li ok-as-delegate ,
-.Li disallow-all-tix ,
-.Li disallow-dup-skey ,
-.Li disallow-proxiable ,
-.Li disallow-renewable ,
-.Li disallow-tgt-based ,
-.Li disallow-forwardable ,
-.Li disallow-postdated ,
-.Li no-auth-data-reqd
+.Bl -tag -width Ds
+.It new-princ
+not used
+.It support-desmd5
+not used
+.It pwchange-service
+for kadmin/admin style service principals
+.It requires-pw-change
+force the user to change their password
+.It requires-hw-auth
+.It requires-pre-auth
+.It allow-digest
+allow NTLM for this user in the KDC's digest service
+.It trusted-for-delegation
+.It ok-as-delegate
+allow forwarding of tickets to this service principal
+.It disallow-client
+disallow issuance of tickets for this principal as a client
+.It disallow-svr
+disallow issuance of tickets for this principal as a server
+.It disallow-all-tix
+disallow issuance of tickets for this principal as a client or
+server
+.It disallow-dup-skey
+not used
+.It disallow-proxiable
+disallow proxiable tickets
+.It disallow-renewable ,
+disallow reneable tickets
+.It disallow-tgt-based ,
+require initial tickets for this service, such as password
+changing services
+.It disallow-forwardable
+disallow forwardable tickets
+.It disallow-postdated
+disallow postdated tickets
+.It no-auth-data-reqd
+do not include a PAC in tickets issued to this service
+.It auth-data-reqd
+do include a PAC in tickets issued to this service even if the
+.Li disable_pac
+KDC configuration parameter is set to true
+.El
 .Pp
 Attributes may be negated with a "-", e.g.,
 .Pp

--- a/kadmin/util.c
+++ b/kadmin/util.c
@@ -47,6 +47,7 @@ get_response(const char *prompt, const char *def, char *buf, size_t len);
  */
 
 struct units kdb_attrs[] = {
+    { "auth-data-reqd",	        KRB5_KDB_AUTH_DATA_REQUIRED },
     { "no-auth-data-reqd",	KRB5_KDB_NO_AUTH_DATA_REQUIRED },
     { "disallow-client",	KRB5_KDB_DISALLOW_CLIENT },
     { "virtual",		KRB5_KDB_VIRTUAL },

--- a/kdc/default_config.c
+++ b/kdc/default_config.c
@@ -101,6 +101,7 @@ krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
     c->strict_nametypes = FALSE;
     c->trpolicy = TRPOLICY_ALWAYS_CHECK;
     c->require_pac = FALSE;
+    c->disable_pac = FALSE;
     c->enable_fast = TRUE;
     c->enable_armored_pa_enc_timestamp = TRUE;
     c->enable_unarmored_pa_enc_timestamp = TRUE;
@@ -261,6 +262,14 @@ krb5_kdc_get_config(krb5_context context, krb5_kdc_configuration **config)
 				     c->require_pac,
 				     "kdc",
 				     "require_pac",
+				     NULL);
+
+    c->disable_pac =
+	krb5_config_get_bool_default(context,
+				     NULL,
+				     c->disable_pac,
+				     "kdc",
+				     "disable_pac",
 				     NULL);
 
     c->enable_fast =

--- a/kdc/httpkadmind.c
+++ b/kdc/httpkadmind.c
@@ -1274,6 +1274,7 @@ make_kstuple(krb5_context context,
 
 /* Copied from kadmin/util.c */
 struct units kdb_attrs[] = {
+    { "auth-data-reqd",         KRB5_KDB_AUTH_DATA_REQUIRED },
     { "no-auth-data-reqd",      KRB5_KDB_NO_AUTH_DATA_REQUIRED },
     { "disallow-client",        KRB5_KDB_DISALLOW_CLIENT },
     { "virtual",                KRB5_KDB_VIRTUAL },

--- a/kdc/kdc_locl.h
+++ b/kdc/kdc_locl.h
@@ -100,6 +100,7 @@ struct krb5_kdc_configuration {
     enum krb5_kdc_trpolicy trpolicy;
 
     unsigned int require_pac : 1;
+    unsigned int disable_pac : 1;
     unsigned int enable_fast : 1;
     unsigned int enable_armored_pa_enc_timestamp : 1;
     unsigned int enable_unarmored_pa_enc_timestamp : 1;

--- a/kdc/misc.c
+++ b/kdc/misc.c
@@ -348,6 +348,10 @@ _kdc_include_pac_p(astgs_request_t r)
     }
     if (r->server->flags.no_auth_data_reqd)
 	return FALSE;
+    if (r->server->flags.auth_data_reqd)
+	return TRUE;
+    if (r->config->disable_pac)
+        return FALSE;
 
     return !!(r->pac_attributes & (KRB5_PAC_WAS_REQUESTED | KRB5_PAC_WAS_GIVEN_IMPLICITLY));
 }

--- a/lib/hdb/hdb.asn1
+++ b/lib/hdb/hdb.asn1
@@ -55,6 +55,7 @@ HDBFlags ::= BIT STRING {
 	virtual(21),			-- entry not stored; keys always derived
 	synthetic(22),			-- entry not stored; for PKINIT
 	no-auth-data-reqd(23),		-- omit PAC from service tickets
+	auth-data-reqd(24),		-- include PAC in service tickets
 
 	force-canonicalize(30),		-- force the KDC to return the canonical
 					-- principal irrespective of the setting

--- a/lib/kadm5/admin.h
+++ b/lib/kadm5/admin.h
@@ -78,6 +78,7 @@
 #define KRB5_KDB_VIRTUAL                0x00400000 /* MIT doesn't have this */
 #define KRB5_KDB_DISALLOW_CLIENT        0x00800000 /* MIT doesn't have this */
 #define KRB5_KDB_NO_AUTH_DATA_REQUIRED	0x01000000 /* 0x00400000 in MIT */
+#define KRB5_KDB_AUTH_DATA_REQUIRED	0x02000000
 
 /*
  * MIT has:

--- a/lib/kadm5/ent_setup.c
+++ b/lib/kadm5/ent_setup.c
@@ -64,6 +64,10 @@ attr_to_flags(unsigned attr, HDBFlags *flags)
     flags->virtual_keys =      !!(attr & KRB5_KDB_VIRTUAL_KEYS);
     flags->virtual =           !!(attr & KRB5_KDB_VIRTUAL);
     flags->no_auth_data_reqd = !!(attr & KRB5_KDB_NO_AUTH_DATA_REQUIRED);
+    flags->auth_data_reqd =    !!(attr & KRB5_KDB_AUTH_DATA_REQUIRED);
+
+    if (flags->no_auth_data_reqd && flags->auth_data_reqd)
+        flags->auth_data_reqd = 0;
 }
 
 /*

--- a/lib/kadm5/get_s.c
+++ b/lib/kadm5/get_s.c
@@ -186,6 +186,7 @@ kadm5_s_get_principal(void *server_handle,
 	out->attributes |= ent.flags.virtual_keys ? KRB5_KDB_VIRTUAL_KEYS : 0;
 	out->attributes |= ent.flags.virtual ? KRB5_KDB_VIRTUAL : 0;
 	out->attributes |= ent.flags.no_auth_data_reqd ? KRB5_KDB_NO_AUTH_DATA_REQUIRED : 0;
+	out->attributes |= ent.flags.auth_data_reqd ? KRB5_KDB_AUTH_DATA_REQUIRED : 0;
     }
     if(mask & KADM5_MAX_LIFE) {
 	if(ent.max_life)

--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -828,6 +828,11 @@ addresses in the tickets.
 .It Li allow-null-ticket-addresses = Va BOOL
 Allow address-less tickets.
 .\" XXX
+.It Li disable_pac = Va BOOL
+Do not include a PAC in service tickets.
+However, if a service has the
+.Li auth-data-reqd
+attribute then the KDC will include a PAC anyways.
 .It Li enable_fast = Va BOOL
 Enable RFC 6113 FAST support, this is enabled by default.
 .It Li enable_armored_pa_enc_timestamp = Va BOOL

--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -261,6 +261,7 @@ ${kadmin} ext -k ${keytab} ${alias1}@${R} || exit 1
 ${kadmin} modify --alias=${alias2}@${R} ${alias1}@${R}
 
 ${kadmin} add -p cross1 --use-defaults krbtgt/${R2}@${R} || exit 1
+${kadmin} modify --attributes=+no-auth-data-reqd krbtgt/${R2}@${R} || exit 1
 ${kadmin} add -p cross2 --use-defaults krbtgt/${R}@${R2} || exit 1
 
 ${kadmin} add -p cross1 --use-defaults krbtgt/${R3}@${R2} || exit 1
@@ -551,6 +552,20 @@ for a in $enctypes; do
 done
 ${kdestroy}
 
+echo "Getting client initial tickets with PAC"; > messages.log
+${kinit} --request-pac --password-file=${objdir}/foopassword foo@$R || \
+	{ ec=1 ; eval "${testfailed}"; }
+for a in $enctypes; do
+	echo "Getting tickets for PAC-less service principal ($a)"; > messages.log
+	${kgetcred} -e $a ${server4}@${R2} || { ec=1 ; eval "${testfailed}"; }
+	${test_ap_req} --verify-pac ${server4}@${R2} ${keytab} ${cache} && \
+		{ ec=1 ; eval "${testfailed}"; }
+	${test_ap_req} --no-verify-pac ${server4}@${R2} ${keytab} ${cache} || \
+		{ ec=1 ; eval "${testfailed}"; }
+	${kdestroy} --credential=${server4}@${R2}
+done
+${kdestroy}
+
 echo "Getting client authenticated anonymous initial tickets"; > messages.log
 ${kinit} -n --password-file=${objdir}/foopassword foo@$R || \
 	{ ec=1 ; eval "${testfailed}"; }
@@ -558,6 +573,8 @@ for a in $enctypes; do
 	echo "Getting tickets ($a)"; > messages.log
 	${kgetcred} -e $a ${server}@${R} || { ec=1 ; eval "${testfailed}"; }
 	${test_ap_req} --no-verify-pac ${server}@${R} ${keytab} ${cache} || \
+		{ ec=1 ; eval "${testfailed}"; }
+	${test_ap_req} --verify-pac ${server}@${R} ${keytab} ${cache} && \
 		{ ec=1 ; eval "${testfailed}"; }
 	${kdestroy} --credential=${server}@${R}
 done
@@ -575,7 +592,7 @@ for a in $enctypes; do
 done
 ${kdestroy}
 
-echo "Getting client initial tickets for cross realm case"; > messages.log
+echo "Getting client initial tickets for cross realm case (no-auth-data-reqd for ${R2})"; > messages.log
 ${kinit} --password-file=${objdir}/foopassword foo@$R || { ec=1 ; eval "${testfailed}"; }
 for a in $enctypes; do
 	echo "Getting cross realm tickets ($a)"; > messages.log
@@ -583,7 +600,24 @@ for a in $enctypes; do
 	echo "  checking we we got back right ticket"
 	${klist} | grep ${server2}@ > /dev/null || { ec=1 ; eval "${testfailed}"; }
 	echo "  checking if ticket is useful"
-	${test_ap_req} ${server2}@${R2} ${keytab} ${cache} || \
+	${test_ap_req} --no-verify-pac ${server2}@${R2} ${keytab} ${cache} || \
+		{ ec=1 ; eval "${testfailed}"; }
+	${test_ap_req} --verify-pac ${server2}@${R2} ${keytab} ${cache} && \
+		{ ec=1 ; eval "${testfailed}"; }
+	${kdestroy} --credential=${server2}@${R2}
+done
+${kdestroy}
+
+echo "Getting client initial tickets for cross realm case (w/ PAC)"; > messages.log
+${kadmin} modify --attributes=-no-auth-data-reqd krbtgt/${R2}@${R} || exit 1
+${kinit} --password-file=${objdir}/foopassword foo@$R || { ec=1 ; eval "${testfailed}"; }
+for a in $enctypes; do
+	echo "Getting cross realm tickets ($a)"; > messages.log
+	${kgetcred} -e $a ${server2}@${R2} || { ec=1 ; eval "${testfailed}"; }
+	echo "  checking we we got back right ticket"
+	${klist} | grep ${server2}@ > /dev/null || { ec=1 ; eval "${testfailed}"; }
+	echo "  checking if ticket is useful"
+	${test_ap_req} --verify-pac ${server2}@${R2} ${keytab} ${cache} || \
 		{ ec=1 ; eval "${testfailed}"; }
 	${kdestroy} --credential=${server2}@${R2}
 done


### PR DESCRIPTION
One site needs to disable PACs altogether for service tickets, but might need to enabled them on a case by case basis.

With these patches we now default to using PACs, which can be turned off on a per-service principal basis with the `no-auth-data-reqd` flag, or one can disable PACs for all but root `krbtgt`s and then enable PACs on a case by case basis (including cross-realm `krbtgt`s) with the new `auth-data-reqd` HDB entry flag.

If both flags get set, then you end up with `no-auth-data-reqd` set and `auth-data-reqd` reset:
![image](https://github.com/heimdal/heimdal/assets/604851/948f614e-4106-4ad8-b79f-0f9761a5bcc7)
