### PR TITLE
Use perl module JSON:PP, part of core, instead of JSON package

### DIFF
--- a/cf/make-proto.pl
+++ b/cf/make-proto.pl
@@ -4,7 +4,7 @@
 use Getopt::Std;
 use File::Compare;
 
-use JSON;
+use JSON::PP
 
 my $comment = 0;
 my $doxygen = 0;
@@ -70,7 +70,7 @@ if($opt_x) {
     my $EXP;
     local $/;
     open(EXP, '<', $opt_x) || die "open ${opt_x}";
-    my $obj = JSON->new->utf8->decode(<EXP>);
+    my $obj = JSON::PP->new->utf8->decode(<EXP>);
     close $EXP;
 
     foreach my $x (keys %$obj) {

--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,6 @@ if ! test -f "$srcdir/lib/asn1/der-protos.h" ||
     AC_KRB_PROG_PERL
     AC_KRB_PERL_MOD(Getopt::Std)
     AC_KRB_PERL_MOD(File::Compare)
-    AC_KRB_PERL_MOD(JSON)
 fi
 
 AC_KRB_PROG_YACC


### PR DESCRIPTION
This patch removes the need for an external package.

Ported from
https://github.com/openwrt/packages/blob/master/net/samba4/patches/105-perl-json-pp.patch https://github.com/openwrt/packages/commit/402f4ba4eff65b80a9deaa6085256112bec4d67b#diff-208d4e0345c9d29fbec23d6f655ba794afd3052f5cb8dd73944db72ce81b847b