### PR TITLE
pkinit: Correctly pad Diffie-Hellman key

### DIFF
--- a/kdc/pkinit.c
+++ b/kdc/pkinit.c
@@ -230,6 +230,7 @@ generate_dh_keyblock(krb5_context context,
 	    size -= dh_gen_keylen;
 	    memmove(dh_gen_key + size, dh_gen_key, dh_gen_keylen);
 	    memset(dh_gen_key, 0, size);
+	    dh_gen_keylen += size;
 	}
     } else if (client_params->keyex == USE_ECDH) {
 	if (client_params->u.ecdh.public_key == NULL) {

--- a/lib/krb5/pkinit.c
+++ b/lib/krb5/pkinit.c
@@ -1493,6 +1493,7 @@ pk_rd_pa_reply_dh(krb5_context context,
 	    size -= dh_gen_keylen;
 	    memmove(dh_gen_key + size, dh_gen_key, dh_gen_keylen);
 	    memset(dh_gen_key, 0, size);
+	    dh_gen_keylen += size;
 	}
 
     } else {


### PR DESCRIPTION
If the Diffie-Hellman key was ‘n’ bytes too short, we would shift it to the right ‘n’ places, padding it out to the correct length to compute the reply key.

Unfortunately, we forgot to increase the size of the key accordingly, so ‘n’ trailing key bytes would be discarded. This could mean failure to decrypt a reply when interoperating with a Kerberos implementation without this bug.