### PR TITLE
Support later Visual Studio releases better

### DIFF
--- a/include/config.h.w32
+++ b/include/config.h.w32
@@ -577,19 +577,23 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 /* #undef HAVE_INNETGR */
 
 /* Define to 1 if the system has the type `int16_t'. */
-/* #define HAVE_INT16_T 1 */
+#if (_MSC_VER >= 1600)
+#define HAVE_INT16_T 1
 
 /* Define to 1 if the system has the type `int32_t'. */
-/* #define HAVE_INT32_T 1 */
+#define HAVE_INT32_T 1
 
 /* Define to 1 if the system has the type `int64_t'. */
-/* #define HAVE_INT64_T 1 */
+#define HAVE_INT64_T 1
 
 /* Define to 1 if the system has the type `int8_t'. */
-/* #define HAVE_INT8_T 1 */
+#define HAVE_INT8_T 1
+#endif
 
 /* Define to 1 if you have the <inttypes.h> header file. */
-/* #define HAVE_INTTYPES_H 1 */
+#if (_MSC_VER >= 1800)
+#define HAVE_INTTYPES_H 1
+#endif
 
 /* Define to 1 if you have the <io.h> header file. */
 #define HAVE_IO_H 1
@@ -844,7 +848,9 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 /* #undef HAVE_STANDARDS_H */
 
 /* Define to 1 if you have the <stdint.h> header file. */
-/* #define HAVE_STDINT_H 1 */
+#if (_MSC_VER >= 1600)
+#define HAVE_STDINT_H 1
+#endif
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -1116,17 +1122,19 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 /* Define to 1 if you have the <udb.h> header file. */
 /* #undef HAVE_UDB_H */
 
+#if (_MSC_VER >= 1600)
 /* Define to 1 if the system has the type `uint16_t'. */
-/* #define HAVE_UINT16_T 1 */
+#define HAVE_UINT16_T 1
 
 /* Define to 1 if the system has the type `uint32_t'. */
-/* #define HAVE_UINT32_T 1 */
+#define HAVE_UINT32_T 1
 
 /* Define to 1 if the system has the type `uint64_t'. */
-/* #define HAVE_UINT64_T 1 */
+#define HAVE_UINT64_T 1
 
 /* Define to 1 if the system has the type `uint8_t'. */
-/* #define HAVE_UINT8_T 1 */
+#define HAVE_UINT8_T 1
+#endif
 
 /* Define to 1 if the system has the type `uintptr_t'. */
 #define HAVE_UINTPTR_T 1
@@ -1365,7 +1373,7 @@ static const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 /* Define if getpwnam_r has POSIX flavour. */
 /* #define POSIX_GETPWNAM_R 1 */
 
-/* Define if getpwnam_r has POSIX flavour. */
+/* Define if getpwuid_r has POSIX flavour. */
 /* #define POSIX_GETPWUID_R 1 */
 
 /* Define if you have the readline package. */

--- a/lib/roken/NTMakefile
+++ b/lib/roken/NTMakefile
@@ -177,7 +177,9 @@ INCFILES = 			\
 	$(INCDIR)\roken-common.h	\
 	$(INCDIR)\rtbl.h	\
 	$(INCDIR)\search.h	\
+!ifndef HAVE_STDBOOL_H
 	$(INCDIR)\stdbool.h	\
+!endif
 	$(INCDIR)\syslog.h	\
 	$(INCDIR)\vis.h		\
 	$(INCDIR)\vis-extras.h	\

--- a/windows/NTMakefile.config
+++ b/windows/NTMakefile.config
@@ -16,9 +16,12 @@
 !  include <windows\NTMakefile.version>
 !endif
 
-!if [ $(PERL) $(SRC)\cf\w32-detect-vc-version.pl $(CC) ]==16
+!if [ $(PERL) $(SRC)\cf\w32-detect-vc-version.pl $(CC) ]>=16
 HAVE_STDINT_H=1
 HAVE_INT64_T=1
+!if [ $(PERL) $(SRC)\cf\w32-detect-vc-version.pl $(CC) ]>=18
+HAVE_STDBOOL_H=1
+!endif
 !endif
 
 

--- a/windows/NTMakefile.w32
+++ b/windows/NTMakefile.w32
@@ -125,7 +125,9 @@ PERL=perl.exe
 CMP=cmp.exe
 MAKECAT=makecat.exe
 HHC=hhc.exe
+!ifndef MAKEINFO
 MAKEINFO=makeinfo.exe
+!endif
 SED=sed.exe
 
 CANDLE_CMD=candle.exe


### PR DESCRIPTION
Hi,

This attempts to make the Heimdal builds against later Visual Studio better, by:

*  Updating `include\config.w32` to define that `stdint.h` and `inttypes.h` are available, when Visual Studio 2010 or later and Visual Studio 2013 or later are used, respectively, since these headers are shipped with these versions of Visual Studio.
*  Update `windows\NTMakefile.config` and `lib\roken\NTMakefile`  to reflect on the availability of `stdint.h` and `stdbool.h`, which are available since Visual Studio 2010 and Visual Studio 2013, repsectively.  As a consequence, the compatibility headers for these headers that comes in `lib\roken` is not copied in cases where Visual Studio ships with them).   This will fix builds that use Heimdal that is horribly broken when when the system `inttypes.h` is included, as things in the compatibility `stdint.h` will clash with the system's `inttypes.h` badly.
* Update the `makeinfo.exe` call to instead use whatever that that is passed in throught envvars or the NMake command line.

With blessings, thank you!