### PR TITLE
kadm5: allow setting password_lifetime to 0 to clear

### DIFF
--- a/lib/kadm5/bump_pw_expire.c
+++ b/lib/kadm5/bump_pw_expire.c
@@ -53,7 +53,12 @@ _kadm5_bump_pw_expire(kadm5_server_context *context,
 					    "password_lifetime",
 					    NULL);
 
-	*(ent->pw_end) = time(NULL) + life;
+	if (life != 0)
+	    *(ent->pw_end) = time(NULL) + life;
+	else {
+	    free(ent->pw_end);
+	    ent->pw_end = NULL;
+	}
     }
     return 0;
 }

--- a/lib/krb5/krb5.conf.5
+++ b/lib/krb5/krb5.conf.5
@@ -1301,7 +1301,8 @@ Certification authority related parameters are as for
 .Bl -tag -width "xxx" -offset indent
 .It Li password_lifetime = Va time
 If a principal already have its password set for expiration, this is
-the time it will be valid for after a change.
+the time it will be valid for after a change. A value of 0 will clear
+the password expiration after a successful password change.
 .It Li default_keys = Va keytypes...
 For each entry in
 .Va default_keys

--- a/lib/roken/parse_time-test.c
+++ b/lib/roken/parse_time-test.c
@@ -51,6 +51,7 @@ static struct testcase {
     { 15, 3601,	 	"1 hour 1 second" },
     { 16, 3602,	 	"1 hour 2 seconds" },
     { 9, 300,	 	"5 minutes" },
+    { 1, 0,	 	"0" },
 };
 
 int


### PR DESCRIPTION
when [kadmin] password_lifetime is set to 0, it should clear the time rather than making the freshly-changed password expire immediately