### PR TITLE
Source code documentation `/**` unification.

### DIFF
--- a/lib/base/array.c
+++ b/lib/base/array.c
@@ -68,9 +68,9 @@ struct heim_type_data array_object = {
 };
 
 /**
- * Allocate an array
+ * Allocate an array.
  *
- * @return A new allocated array, free with heim_release()
+ * @return A new allocated array, free with heim_release().
  */
 
 heim_array_t
@@ -91,9 +91,9 @@ heim_array_create(void)
 }
 
 /**
- * Get type id of an dict
+ * Get type id of an dict.
  *
- * @return the type id
+ * @return the type id.
  */
 
 heim_tid_t
@@ -103,12 +103,12 @@ heim_array_get_type_id(void)
 }
 
 /**
- * Append object to array
+ * Append object to array.
  *
- * @param array array to add too
- * @param object the object to add
+ * @param array array to add too.
+ * @param object the object to add.
  *
- * @return zero if added, errno otherwise
+ * @return zero if added, errno otherwise.
  */
 
 int
@@ -204,13 +204,13 @@ heim_array_prepend_value(heim_array_t array, heim_object_t object)
 }
 
 /**
- * Insert an object at a given index in an array
+ * Insert an object at a given index in an array.
  *
- * @param array array to add too
- * @param idx index where to add element (-1 == append, -2 next to last, ...)
- * @param object the object to add
+ * @param array array to add too.
+ * @param idx index where to add element (-1 == append, -2 next to last, ...).
+ * @param object the object to add.
  *
- * @return zero if added, errno otherwise
+ * @return zero if added, errno otherwise.
  */
 
 int
@@ -244,11 +244,11 @@ heim_array_insert_value(heim_array_t array, size_t idx, heim_object_t object)
 }
 
 /**
- * Iterate over all objects in array
+ * Iterate over all objects in array.
  *
- * @param array array to iterate over
- * @param ctx context passed to fn
- * @param fn function to call on each object
+ * @param array array to iterate over.
+ * @param ctx context passed to fn.
+ * @param fn function to call on each object.
  */
 
 void
@@ -265,10 +265,10 @@ heim_array_iterate_f(heim_array_t array, void *ctx, heim_array_iterator_f_t fn)
 
 #ifdef __BLOCKS__
 /**
- * Iterate over all objects in array
+ * Iterate over all objects in array.
  *
- * @param array array to iterate over
- * @param fn block to call on each object
+ * @param array array to iterate over.
+ * @param fn block to call on each object.
  */
 
 void
@@ -285,11 +285,11 @@ heim_array_iterate(heim_array_t array, void (^fn)(heim_object_t, int *))
 #endif
 
 /**
- * Iterate over all objects in array, backwards
+ * Iterate over all objects in array, backwards.
  *
- * @param array array to iterate over
- * @param ctx context passed to fn
- * @param fn function to call on each object
+ * @param array array to iterate over.
+ * @param ctx context passed to fn.
+ * @param fn function to call on each object.
  */
 
 void
@@ -307,10 +307,10 @@ heim_array_iterate_reverse_f(heim_array_t array, void *ctx, heim_array_iterator_
 
 #ifdef __BLOCKS__
 /**
- * Iterate over all objects in array, backwards
+ * Iterate over all objects in array, backwards.
  *
- * @param array array to iterate over
- * @param fn block to call on each object
+ * @param array array to iterate over.
+ * @param fn block to call on each object.
  */
 
 void
@@ -327,11 +327,11 @@ heim_array_iterate_reverse(heim_array_t array, void (^fn)(heim_object_t, int *))
 #endif
 
 /**
- * Get length of array
+ * Get length of array.
  *
- * @param array array to get length of
+ * @param array array to get length of.
  *
- * @return length of array
+ * @return length of array.
  */
 
 size_t
@@ -341,13 +341,13 @@ heim_array_get_length(heim_array_t array)
 }
 
 /**
- * Get value of element at array index
+ * Get value of element at array index.
  *
- * @param array array copy object from
+ * @param array array copy object from.
  * @param idx index of object, 0 based, must be smaller then
- *        heim_array_get_length()
+ *        heim_array_get_length().
  *
- * @return a not-retained copy of the object
+ * @return a not-retained copy of the object.
  */
 
 heim_object_t
@@ -359,13 +359,13 @@ heim_array_get_value(heim_array_t array, size_t idx)
 }
 
 /**
- * Get value of element at array index
+ * Get value of element at array index.
  *
- * @param array array copy object from
+ * @param array array copy object from.
  * @param idx index of object, 0 based, must be smaller then
- *        heim_array_get_length()
+ *        heim_array_get_length().
  *
- * @return a retained copy of the object
+ * @return a retained copy of the object.
  */
 
 heim_object_t
@@ -377,12 +377,12 @@ heim_array_copy_value(heim_array_t array, size_t idx)
 }
 
 /**
- * Set value at array index
+ * Set value at array index.
  *
- * @param array array copy object from
+ * @param array array copy object from.
  * @param idx index of object, 0 based, must be smaller then
- *        heim_array_get_length()
- * @param value value to set 
+ *        heim_array_get_length().
+ * @param value value to set.
  *
  */
 
@@ -396,10 +396,10 @@ heim_array_set_value(heim_array_t array, size_t idx, heim_object_t value)
 }
 
 /**
- * Delete value at idx
+ * Delete value at idx.
  *
- * @param array the array to modify
- * @param idx the key to delete
+ * @param array the array to modify.
+ * @param idx the key to delete.
  */
 
 void
@@ -432,10 +432,10 @@ heim_array_delete_value(heim_array_t array, size_t idx)
 }
 
 /**
- * Filter out entres of array when function return true
+ * Filter out entres of array when function return true.
  *
- * @param array the array to modify
- * @param fn filter function
+ * @param array the array to modify.
+ * @param fn filter function.
  */
 
 void
@@ -455,10 +455,10 @@ heim_array_filter_f(heim_array_t array, void *ctx, heim_array_filter_f_t fn)
 #ifdef __BLOCKS__
 
 /**
- * Filter out entres of array when block return true
+ * Filter out entres of array when block return true.
  *
- * @param array the array to modify
- * @param block filter block
+ * @param array the array to modify.
+ * @param block filter block.
  */
 
 void

--- a/lib/base/config_file.c
+++ b/lib/base/config_file.c
@@ -476,8 +476,9 @@ is_plist_file(const char *fname)
  * into one resulting heim_config_section by calling it repeatably.
  *
  * @param context a Kerberos 5 context.
- * @param dname a directory name to a Kerberos configuration file
+ * @param dname a directory name to a Kerberos configuration file.
  * @param res the returned result, must be free with heim_free_config_files().
+ *
  * @return Return an error code or 0, see heim_get_error_message().
  *
  * @ingroup heim_support
@@ -557,8 +558,9 @@ HEIMDAL_THREAD_LOCAL int config_include_depth = 0;
  * resulting heim_config_section by calling it repeatably.
  *
  * @param context a Kerberos 5 context.
- * @param fname a file name to a Kerberos configuration file
+ * @param fname a file name to a Kerberos configuration file.
  * @param res the returned result, must be free with heim_free_config_files().
+ *
  * @return Return an error code or 0, see heim_get_error_message().
  *
  * @ingroup heim_support
@@ -705,8 +707,8 @@ free_binding(heim_context context, heim_config_binding *b)
  * Free configuration file section, the result of
  * heim_config_parse_file() and heim_config_parse_file_multi().
  *
- * @param context A Kerberos 5 context
- * @param s the configuration section to free
+ * @param context A Kerberos 5 context.
+ * @param s the configuration section to free.
  *
  * @return returns 0 on successes, otherwise an error code, see
  *          heim_get_error_message()
@@ -857,10 +859,10 @@ heim_config_vget(heim_context context,
 }
 
 /**
- * Get a list of configuration binding list for more processing
+ * Get a list of configuration binding list for more processing.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
  * @return NULL if configuration list is not found, a list otherwise
@@ -883,13 +885,13 @@ heim_config_get_list(heim_context context,
 }
 
 /**
- * Get a list of configuration binding list for more processing
+ * Get a list of configuration binding list for more processing.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
- * @return NULL if configuration list is not found, a list otherwise
+ * @return NULL if configuration list is not found, a list otherwise.
  *
  * @ingroup heim_support
  */
@@ -909,10 +911,10 @@ heim_config_vget_list(heim_context context,
  * the string.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
- * @return NULL if configuration string not found, a string otherwise
+ * @return NULL if configuration string not found, a string otherwise.
  *
  * @ingroup heim_support
  */
@@ -935,10 +937,10 @@ heim_config_get_string(heim_context context,
  * Like heim_config_get_string(), but uses a va_list instead of ...
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
- * @return NULL if configuration string not found, a string otherwise
+ * @return NULL if configuration string not found, a string otherwise.
  *
  * @ingroup heim_support
  */
@@ -956,12 +958,12 @@ heim_config_vget_string(heim_context context,
  * instead return a default value.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
- * @param args a va_list of arguments
+ * @param args a va_list of arguments.
  *
- * @return a configuration string
+ * @return a configuration string.
  *
  * @ingroup heim_support
  */
@@ -990,7 +992,7 @@ heim_config_vget_string_default(heim_context context,
  *        found in the database.
  * @param ... a list of names, terminated with NULL.
  *
- * @return a configuration string
+ * @return a configuration string.
  *
  * @ingroup heim_support
  */
@@ -1059,8 +1061,8 @@ next_component_string(char * begin, const char * delims, char **state)
  * heim_config_free_strings().
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
  * @return TRUE or FALSE
  *
@@ -1123,7 +1125,7 @@ cleanup:
  * heim_config_free_strings().
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
  * @return TRUE or FALSE
@@ -1148,7 +1150,7 @@ heim_config_get_strings(heim_context context,
  * Free the resulting strings from heim_config-get_strings() and
  * heim_config_vget_strings().
  *
- * @param strings strings to free
+ * @param strings strings to free.
  *
  * @ingroup heim_support
  */
@@ -1173,10 +1175,10 @@ heim_config_free_strings(char **strings)
  * non-zero number means TRUE and other value is FALSE.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
- * @param args a va_list of arguments
+ * @param args a va_list of arguments.
  *
  * @return TRUE or FALSE
  *
@@ -1204,8 +1206,8 @@ heim_config_vget_bool_default(heim_context context,
  * number means TRUE and other value is FALSE.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
  * @return TRUE or FALSE
  *
@@ -1226,7 +1228,7 @@ heim_config_vget_bool(heim_context context,
  * number means TRUE and other value is FALSE.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
  * @param ... a list of names, terminated with NULL.
@@ -1259,7 +1261,7 @@ heim_config_get_bool_default(heim_context context,
  * non-zero number means TRUE and other value is FALSE.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
  * @return TRUE or FALSE
@@ -1287,12 +1289,12 @@ heim_config_get_bool(heim_context context,
  * configuration selection.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
- * @param args a va_list of arguments
+ * @param args a va_list of arguments.
  *
- * @return parsed the time (or def_value on parse error)
+ * @return parsed the time (or def_value on parse error).
  *
  * @ingroup heim_support
  */
@@ -1315,10 +1317,10 @@ heim_config_vget_time_default(heim_context context,
  * Get the time from the configuration file using a relative time, for example: 1h30s
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
- * @return parsed the time or -1 on error
+ * @return parsed the time or -1 on error.
  *
  * @ingroup heim_support
  */
@@ -1335,12 +1337,12 @@ heim_config_vget_time(heim_context context,
  * Get the time from the configuration file using a relative time, for example: 1h30s
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
  * @param ... a list of names, terminated with NULL.
  *
- * @return parsed the time (or def_value on parse error)
+ * @return parsed the time (or def_value on parse error).
  *
  * @ingroup heim_support
  */
@@ -1364,10 +1366,10 @@ heim_config_get_time_default(heim_context context,
  * Get the time from the configuration file using a relative time, for example: 1h30s
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
- * @return parsed the time or -1 on error
+ * @return parsed the time or -1 on error.
  *
  * @ingroup heim_support
  */

--- a/lib/base/data.c
+++ b/lib/base/data.c
@@ -86,11 +86,11 @@ struct heim_type_data _heim_data_object = {
 };
 
 /**
- * Create a data object
+ * Create a data object.
  *
- * @param string the string to create, must be an utf8 string
+ * @param string the string to create, must be an utf8 string.
  *
- * @return string object
+ * @return string object.
  */
 
 heim_data_t
@@ -126,9 +126,9 @@ heim_data_ref_create(const void *data, size_t length,
 
 
 /**
- * Return the type ID of data objects
+ * Return the type ID of data objects.
  *
- * @return type id of data objects
+ * @return type id of data objects.
  */
 
 heim_tid_t
@@ -140,9 +140,9 @@ heim_data_get_type_id(void)
 /**
  * Get the data value of the content.
  *
- * @param data the data object to get the value from
+ * @param data the data object to get the value from.
  *
- * @return a heim_octet_string
+ * @return a heim_octet_string.
  */
 
 const heim_octet_string *

--- a/lib/base/db.c
+++ b/lib/base/db.c
@@ -161,11 +161,11 @@ plugin_dealloc(void *arg)
 }
 
 /** heim_db_register
- * @brief Registers a DB type for use with heim_db_create().
+ * Registers a DB type for use with heim_db_create().
  *
- * @param dbtype Name of DB type
- * @param data   Private data argument to the dbtype's openf method
- * @param plugin Structure with DB type methods (function pointers)
+ * @param dbtype Name of DB type.
+ * @param data   Private data argument to the dbtype's openf method.
+ * @param plugin Structure with DB type methods (function pointers).
  *
  * Backends that provide begin/commit/rollback methods must provide ACID
  * semantics.
@@ -304,13 +304,13 @@ dbtype_iter2create_f(heim_object_t dbtype, heim_object_t junk, void *arg)
  *  - "sync", with any value (make transactions durable)
  *  - "journal-name", with a string value naming a journal file name
  *
- * @param dbtype  Name of DB type
- * @param dbname  Name of DB (likely a file path)
- * @param options Options dict
- * @param db      Output open DB handle
- * @param error   Output error  object
+ * @param dbtype  Name of DB type.
+ * @param dbname  Name of DB (likely a file path).
+ * @param options Options dict.
+ * @param db      Output open DB handle.
+ * @param error   Output error  object.
  *
- * @return a DB handle
+ * @return a DB handle.
  *
  * @addtogroup heimbase
  */
@@ -431,10 +431,10 @@ heim_db_create(const char *dbtype, const char *dbname,
  *
  * Returns EBUSY if there is an open transaction for the input db.
  *
- * @param db      Open DB handle
- * @param error   Output error object
+ * @param db      Open DB handle.
+ * @param error   Output error object.
  *
- * @return a DB handle
+ * @return a DB handle.
  *
  * @addtogroup heimbase
  */
@@ -479,10 +479,10 @@ heim_db_clone(heim_db_t db, heim_error_t *error)
 /**
  * Open a transaction on the given db.
  *
- * @param db    Open DB handle
- * @param error Output error object
+ * @param db    Open DB handle.
+ * @param error Output error object.
  *
- * @return 0 on success, system error otherwise
+ * @return 0 on success, system error otherwise.
  *
  * @addtogroup heimbase
  */
@@ -544,10 +544,10 @@ heim_db_begin(heim_db_t db, int read_only, heim_error_t *error)
 /**
  * Commit an open transaction on the given db.
  *
- * @param db    Open DB handle
- * @param error Output error object
+ * @param db    Open DB handle.
+ * @param error Output error object.
  *
- * @return 0 on success, system error otherwise
+ * @return 0 on success, system error otherwise.
  *
  * @addtogroup heimbase
  */
@@ -679,10 +679,10 @@ err:
 /**
  * Rollback an open transaction on the given db.
  *
- * @param db    Open DB handle
- * @param error Output error object
+ * @param db    Open DB handle.
+ * @param error Output error object.
  *
- * @return 0 on success, system error otherwise
+ * @return 0 on success, system error otherwise.
  *
  * @addtogroup heimbase
  */
@@ -737,11 +737,11 @@ _heim_db_get_value(heim_db_t db, heim_string_t table, heim_data_t key,
  * Returns 0 on success, -1 if the key does not exist in the DB, or a
  * system error number on failure.
  *
- * @param db    Open DB handle
- * @param key   Key
- * @param error Output error object
+ * @param db    Open DB handle.
+ * @param key   Key.
+ * @param error Output error object.
  *
- * @return the value (retained), if there is one for the given key
+ * @return the value (retained), if there is one for the given key.
  *
  * @addtogroup heimbase
  */
@@ -790,12 +790,12 @@ heim_db_copy_value(heim_db_t db, heim_string_t table, heim_data_t key,
 /**
  * Set a key's value in the DB.
  *
- * @param db    Open DB handle
- * @param key   Key
- * @param value Value (if NULL the key will be deleted, but empty is OK)
- * @param error Output error object
+ * @param db    Open DB handle.
+ * @param key   Key.
+ * @param value Value (if NULL the key will be deleted, but empty is OK).
+ * @param error Output error object.
  *
- * @return 0 on success, system error otherwise
+ * @return 0 on success, system error otherwise.
  *
  * @addtogroup heimbase
  */
@@ -866,14 +866,13 @@ err:
 }
 
 /**
- * Delete a key and its value from the DB
+ * Delete a key and its value from the DB.
  *
+ * @param db    Open DB handle.
+ * @param key   Key.
+ * @param error Output error object.
  *
- * @param db    Open DB handle
- * @param key   Key
- * @param error Output error object
- *
- * @return 0 on success, system error otherwise
+ * @return 0 on success, system error otherwise.
  *
  * @addtogroup heimbase
  */
@@ -937,10 +936,10 @@ err:
 /**
  * Iterate a callback function over keys and values from a DB.
  *
- * @param db        Open DB handle
- * @param iter_data Callback function's private data
- * @param iter_f    Callback function, called once per-key/value pair
- * @param error     Output error object
+ * @param db        Open DB handle.
+ * @param iter_data Callback function's private data.
+ * @param iter_f    Callback function, called once per-key/value pair.
+ * @param error     Output error object.
  *
  * @addtogroup heimbase
  */

--- a/lib/base/dict.c
+++ b/lib/base/dict.c
@@ -104,9 +104,9 @@ findprime(size_t p)
 }
 
 /**
- * Allocate an array
+ * Allocate an array.
  *
- * @return A new allocated array, free with heim_release()
+ * @return A new allocated array, free with heim_release().
  */
 
 heim_dict_t
@@ -135,9 +135,9 @@ heim_dict_create(size_t size)
 }
 
 /**
- * Get type id of an dict
+ * Get type id of an dict.
  *
- * @return the type id
+ * @return the type id.
  */
 
 heim_tid_t
@@ -162,12 +162,12 @@ _search(heim_dict_t dict, heim_object_t ptr)
 }
 
 /**
- * Search for element in hash table
+ * Search for element in hash table.
  *
- * @value dict the dict to search in
- * @value key the key to search for
+ * @param dict the dict to search in.
+ * @param key the key to search for.
  *
- * @return a not-retained copy of the value for key or NULL if not found
+ * @return a not-retained copy of the value for key or NULL if not found.
  */
 
 heim_object_t
@@ -182,12 +182,12 @@ heim_dict_get_value(heim_dict_t dict, heim_object_t key)
 }
 
 /**
- * Search for element in hash table
+ * Search for element in hash table.
  *
- * @value dict the dict to search in
- * @value key the key to search for
+ * @param dict the dict to search in.
+ * @param key the key to search for.
  *
- * @return a retained copy of the value for key or NULL if not found
+ * @return a retained copy of the value for key or NULL if not found.
  */
 
 heim_object_t
@@ -202,13 +202,13 @@ heim_dict_copy_value(heim_dict_t dict, heim_object_t key)
 }
 
 /**
- * Add key and value to dict
+ * Add key and value to dict.
  *
- * @value dict the dict to add too
- * @value key the key to add
- * @value value the value to add
+ * @param dict the dict to add too.
+ * @param key the key to add.
+ * @param value the value to add.
  *
- * @return 0 if added, errno if not
+ * @return 0 if added, errno if not.
  */
 
 int
@@ -244,10 +244,10 @@ heim_dict_set_value(heim_dict_t dict, heim_object_t key, heim_object_t value)
 }
 
 /**
- * Delete element with key key
+ * Delete element with key key.
  *
- * @value dict the dict to delete from
- * @value key the key to delete
+ * @param dict the dict to delete from.
+ * @param key the key to delete.
  */
 
 void
@@ -268,11 +268,11 @@ heim_dict_delete_key(heim_dict_t dict, heim_object_t key)
 }
 
 /**
- * Do something for each element
+ * Do something for each element.
  *
- * @value dict the dict to interate over
- * @value func the function to search for
- * @value arg argument to func
+ * @param dict the dict to interate over.
+ * @param func the function to search for.
+ * @param arg argument to func.
  */
 
 void
@@ -287,10 +287,10 @@ heim_dict_iterate_f(heim_dict_t dict, void *arg, heim_dict_iterator_f_t func)
 
 #ifdef __BLOCKS__
 /**
- * Do something for each element
+ * Do something for each element.
  *
- * @value dict the dict to interate over
- * @value func the function to search for
+ * @param dict the dict to interate over.
+ * @param func the function to search for.
  */
 
 void

--- a/lib/base/heimbase.c
+++ b/lib/base/heimbase.c
@@ -80,11 +80,11 @@ struct heim_auto_release {
 
 
 /**
- * Retain object (i.e., take a reference)
+ * Retain object (i.e., take a reference).
  *
- * @param object to be released, NULL is ok
+ * @param object to be released, NULL is ok.
  *
- * @return the same object as passed in
+ * @return the same object as passed in.
  */
 
 heim_object_t
@@ -106,9 +106,9 @@ heim_retain(heim_object_t ptr)
 }
 
 /**
- * Release object, free if reference count reaches zero
+ * Release object, free if reference count reaches zero.
  *
- * @param object to be released
+ * @param object to be released.
  */
 
 void
@@ -196,11 +196,11 @@ _heim_get_isa(heim_object_t ptr)
 }
 
 /**
- * Get type ID of object
+ * Get type ID of object.
  *
- * @param object object to get type id of
+ * @param object object to get type id of.
  *
- * @return type id of object
+ * @return type id of object.
  */
 
 heim_tid_t
@@ -211,11 +211,11 @@ heim_get_tid(heim_object_t ptr)
 }
 
 /**
- * Get hash value of object
+ * Get hash value of object.
  *
- * @param object object to get hash value for
+ * @param object object to get hash value for.
  *
- * @return a hash value
+ * @return a hash value.
  */
 
 uintptr_t
@@ -231,10 +231,10 @@ heim_get_hash(heim_object_t ptr)
  * Compare two objects, returns 0 if equal, can use used for qsort()
  * and friends.
  *
- * @param a first object to compare
- * @param b first object to compare
+ * @param a first object to compare.
+ * @param b first object to compare.
  *
- * @return 0 if objects are equal
+ * @return 0 if objects are equal.
  */
 
 int
@@ -258,7 +258,7 @@ heim_cmp(heim_object_t a, heim_object_t b)
 }
 
 /*
- * Private - allocates an memory object
+ * Private - allocates an memory object.
  */
 
 static void HEIM_CALLCONV
@@ -284,15 +284,15 @@ static const struct heim_type_data memory_object = {
 };
 
 /**
- * Allocate memory for an object of anonymous type
+ * Allocate memory for an object of anonymous type.
  *
- * @param size size of object to be allocated
- * @param name name of ad-hoc type
- * @param dealloc destructor function
+ * @param size size of object to be allocated.
+ * @param name name of ad-hoc type.
+ * @param dealloc destructor function.
  *
  * Objects allocated with this interface do not serialize.
  *
- * @return allocated object
+ * @return allocated object.
  */
 
 void *
@@ -405,11 +405,11 @@ once_callback_caller(void)
 #endif
 
 /**
- * Call func once and only once
+ * Call func once and only once.
  *
- * @param once pointer to a heim_base_once_t
- * @param ctx context passed to func
- * @param func function to be called
+ * @param once pointer to a heim_base_once_t.
+ * @param ctx context passed to func.
+ * @param func function to be called.
  */
 
 void
@@ -502,7 +502,7 @@ heim_base_once_f(heim_base_once_t *once, void *ctx, void (*func)(void *))
 }
 
 /**
- * Abort and log the failure (using syslog)
+ * Abort and log the failure (using syslog).
  */
 
 void
@@ -517,7 +517,7 @@ heim_abort(const char *fmt, ...)
 }
 
 /**
- * Abort and log the failure (using syslog)
+ * Abort and log the failure (using syslog).
  */
 
 void
@@ -644,7 +644,7 @@ static struct heim_type_data _heim_autorel_object = {
 };
 
 /**
- * Create thread-specific object auto-release pool
+ * Create thread-specific object auto-release pool.
  *
  * Objects placed on the per-thread auto-release pool (with
  * heim_auto_release()) can be released in one fell swoop by calling
@@ -674,9 +674,9 @@ heim_auto_release_create(void)
 }
 
 /**
- * Place the current object on the thread's auto-release pool
+ * Place the current object on the thread's auto-release pool.
  *
- * @param ptr object
+ * @param ptr object.
  */
 
 heim_object_t
@@ -712,7 +712,7 @@ heim_auto_release(heim_object_t ptr)
 }
 
 /**
- * Release all objects on the given auto-release pool
+ * Release all objects on the given auto-release pool.
  */
 
 void
@@ -797,13 +797,13 @@ heim_path_vget2(heim_object_t ptr, heim_object_t *parent, heim_object_t *key,
 }
 
 /**
- * Get a node in a heim_object tree by path
+ * Get a node in a heim_object tree by path.
  *
- * @param ptr tree
- * @param error error (output)
- * @param ap NULL-terminated va_list of heim_object_ts that form a path
+ * @param ptr tree.
+ * @param error error (output).
+ * @param ap NULL-terminated va_list of heim_object_ts that form a path.
  *
- * @return object (not retained) if found
+ * @return object (not retained) if found.
  *
  * @addtogroup heimbase
  */
@@ -817,13 +817,13 @@ heim_path_vget(heim_object_t ptr, heim_error_t *error, va_list ap)
 }
 
 /**
- * Get a node in a tree by path, with retained reference
+ * Get a node in a tree by path, with retained reference.
  *
- * @param ptr tree
- * @param error error (output)
- * @param ap NULL-terminated va_list of heim_object_ts that form a path
+ * @param ptr tree.
+ * @param error error (output).
+ * @param ap NULL-terminated va_list of heim_object_ts that form a path.
  *
- * @return retained object if found
+ * @return retained object if found.
  *
  * @addtogroup heimbase
  */
@@ -837,13 +837,13 @@ heim_path_vcopy(heim_object_t ptr, heim_error_t *error, va_list ap)
 }
 
 /**
- * Get a node in a tree by path
+ * Get a node in a tree by path.
  *
- * @param ptr tree
- * @param error error (output)
- * @param ... NULL-terminated va_list of heim_object_ts that form a path
+ * @param ptr tree.
+ * @param error error (output).
+ * @param ... NULL-terminated va_list of heim_object_ts that form a path.
  *
- * @return object (not retained) if found
+ * @return object (not retained) if found.
  *
  * @addtogroup heimbase
  */
@@ -865,13 +865,13 @@ heim_path_get(heim_object_t ptr, heim_error_t *error, ...)
 }
 
 /**
- * Get a node in a tree by path, with retained reference
+ * Get a node in a tree by path, with retained reference.
  *
- * @param ptr tree
- * @param error error (output)
- * @param ... NULL-terminated va_list of heim_object_ts that form a path
+ * @param ptr tree.
+ * @param error error (output).
+ * @param ... NULL-terminated va_list of heim_object_ts that form a path.
  *
- * @return retained object if found
+ * @return retained object if found.
  *
  * @addtogroup heimbase
  */
@@ -893,19 +893,19 @@ heim_path_copy(heim_object_t ptr, heim_error_t *error, ...)
 }
 
 /**
- * Create a path in a heim_object_t tree
+ * Create a path in a heim_object_t tree.
  *
- * @param ptr the tree
- * @param size the size of the heim_dict_t nodes to be created
- * @param leaf leaf node to be added, if any
- * @param error error (output)
- * @param ap NULL-terminated of path component objects
+ * @param ptr the tree.
+ * @param size the size of the heim_dict_t nodes to be created.
+ * @param leaf leaf node to be added, if any.
+ * @param error error (output).
+ * @param ap NULL-terminated of path component objects.
  *
  * Create a path of heim_dict_t interior nodes in a given heim_object_t
  * tree, as necessary, and set/replace a leaf, if given (if leaf is NULL
  * then the leaf is not deleted).
  *
- * @return 0 on success, else a system error
+ * @return 0 on success, else a system error.
  *
  * @addtogroup heimbase
  */
@@ -1024,19 +1024,19 @@ err:
 }
 
 /**
- * Create a path in a heim_object_t tree
+ * Create a path in a heim_object_t tree.
  *
- * @param ptr the tree
- * @param size the size of the heim_dict_t nodes to be created
- * @param leaf leaf node to be added, if any
- * @param error error (output)
- * @param ... NULL-terminated list of path component objects
+ * @param ptr the tree.
+ * @param size the size of the heim_dict_t nodes to be created.
+ * @param leaf leaf node to be added, if any.
+ * @param error error (output).
+ * @param ... NULL-terminated list of path component objects.
  *
  * Create a path of heim_dict_t interior nodes in a given heim_object_t
  * tree, as necessary, and set/replace a leaf, if given (if leaf is NULL
  * then the leaf is not deleted).
  *
- * @return 0 on success, else a system error
+ * @return 0 on success, else a system error.
  *
  * @addtogroup heimbase
  */
@@ -1055,11 +1055,11 @@ heim_path_create(heim_object_t ptr, size_t size, heim_object_t leaf,
 }
 
 /**
- * Delete leaf node named by a path in a heim_object_t tree
+ * Delete leaf node named by a path in a heim_object_t tree.
  *
- * @param ptr the tree
- * @param error error (output)
- * @param ap NULL-terminated list of path component objects
+ * @param ptr the tree.
+ * @param error error (output).
+ * @param ap NULL-terminated list of path component objects.
  *
  * @addtogroup heimbase
  */
@@ -1082,11 +1082,11 @@ heim_path_vdelete(heim_object_t ptr, heim_error_t *error, va_list ap)
 }
 
 /**
- * Delete leaf node named by a path in a heim_object_t tree
+ * Delete leaf node named by a path in a heim_object_t tree.
  *
- * @param ptr the tree
- * @param error error (output)
- * @param ap NULL-terminated list of path component objects
+ * @param ptr the tree.
+ * @param error error (output).
+ * @param ap NULL-terminated list of path component objects.
  *
  * @addtogroup heimbase
  */

--- a/lib/base/json.c
+++ b/lib/base/json.c
@@ -1288,9 +1288,9 @@ show_printf(void *ctx, const char *str)
 }
 
 /**
- * Dump a heimbase object to stderr (useful from the debugger!)
+ * Dump a heimbase object to stderr (useful from the debugger!).
  *
- * @param obj object to dump using JSON or JSON-like format
+ * @param obj object to dump using JSON or JSON-like format.
  *
  * @addtogroup heimbase
  */

--- a/lib/base/number.c
+++ b/lib/base/number.c
@@ -78,11 +78,11 @@ struct heim_type_data _heim_number_object = {
 };
 
 /**
- * Create a number object
+ * Create a number object.
  *
- * @param the number to contain in the object
+ * @param the number to contain in the object.
  *
- * @return a number object
+ * @return a number object.
  */
 
 heim_number_t
@@ -100,9 +100,9 @@ heim_number_create(int64_t number)
 }
 
 /**
- * Return the type ID of number objects
+ * Return the type ID of number objects.
  *
- * @return type id of number objects
+ * @return type id of number objects.
  */
 
 heim_tid_t
@@ -112,11 +112,11 @@ heim_number_get_type_id(void)
 }
 
 /**
- * Get the int value of the content
+ * Get the int value of the content.
  *
- * @param number the number object to get the value from
+ * @param number the number object to get the value from.
  *
- * @return an int
+ * @return an int.
  */
 
 int

--- a/lib/base/plugin.c
+++ b/lib/base/plugin.c
@@ -184,10 +184,12 @@ plugin_register_check_dup(heim_object_t value, void *ctx, int *stop)
 
 /**
  * Register a plugin symbol name of specific type.
- * @param context a Keberos context
- * @param module name of plugin module (e.g., "krb5")
- * @param name name of plugin symbol (e.g., "krb5_plugin_kuserok")
- * @param ftable a pointer to a function pointer table
+ *
+ * @param context a Keberos context.
+ * @param module name of plugin module (e.g., "krb5").
+ * @param name name of plugin symbol (e.g., "krb5_plugin_kuserok").
+ * @param ftable a pointer to a function pointer table.
+ *
  * @return In case of error a non zero error com_err error is returned
  * and the Kerberos error string is set.
  *

--- a/lib/base/string.c
+++ b/lib/base/string.c
@@ -96,11 +96,11 @@ struct heim_type_data _heim_string_object = {
 };
 
 /**
- * Create a string object
+ * Create a string object.
  *
- * @param string the string to create, must be an utf8 string
+ * @param string the string to create, must be an utf8 string.
  *
- * @return string object
+ * @return string object.
  */
 
 heim_string_t
@@ -112,10 +112,10 @@ heim_string_create(const char *string)
 /**
  * Create a string object without copying the source.
  *
- * @param string the string to referenced, must be UTF-8
- * @param dealloc the function to use to release the referece to the string
+ * @param string the string to referenced, must be UTF-8.
+ * @param dealloc the function to use to release the referece to the string.
  *
- * @return string object
+ * @return string object.
  */
 
 heim_string_t
@@ -138,12 +138,12 @@ heim_string_ref_create(const char *string, heim_string_free_f_t dealloc)
 }
 
 /**
- * Create a string object
+ * Create a string object.
  *
- * @param string the string to create, must be an utf8 string
- * @param len the length of the string
+ * @param string the string to create, must be an utf8 string.
+ * @param len the length of the string.
  *
- * @return string object
+ * @return string object.
  */
 
 heim_string_t
@@ -161,12 +161,12 @@ heim_string_create_with_bytes(const void *data, size_t len)
 }
 
 /**
- * Create a string object using a format string
+ * Create a string object using a format string.
  *
- * @param fmt format string
+ * @param fmt format string.
  * @param ...
  *
- * @return string object
+ * @return string object.
  */
 
 heim_string_t
@@ -190,9 +190,9 @@ heim_string_create_with_format(const char *fmt, ...)
 }
 
 /**
- * Return the type ID of string objects
+ * Return the type ID of string objects.
  *
- * @return type id of string objects
+ * @return type id of string objects.
  */
 
 heim_tid_t
@@ -204,9 +204,9 @@ heim_string_get_type_id(void)
 /**
  * Get the string value of the content.
  *
- * @param string the string object to get the value from
+ * @param string the string object to get the value from.
  *
- * @return a utf8 string
+ * @return a utf8 string.
  */
 
 const char *

--- a/lib/base/warn.c
+++ b/lib/base/warn.c
@@ -100,9 +100,9 @@ _warnerr(heim_context context, int do_errtext,
  * the last failure.
  *
  * @param context A Kerberos 5 context.
- * @param code error code of the last error
- * @param fmt message to print
- * @param ap arguments
+ * @param code error code of the last error.
+ * @param fmt message to print.
+ * @param ap arguments.
  *
  * @ingroup heim_error
  */
@@ -120,8 +120,8 @@ heim_vwarn(heim_context context, heim_error_code code,
  * the last failure.
  *
  * @param context A Kerberos 5 context.
- * @param code error code of the last error
- * @param fmt message to print
+ * @param code error code of the last error.
+ * @param fmt message to print.
  *
  * @ingroup heim_error
  */
@@ -138,8 +138,8 @@ heim_warn(heim_context context, heim_error_code code, const char *fmt, ...)
  * Log a warning to the log, default stderr.
  *
  * @param context A Kerberos 5 context.
- * @param fmt message to print
- * @param ap arguments
+ * @param fmt message to print.
+ * @param ap arguments.
  *
  * @ingroup heim_error
  */
@@ -155,7 +155,7 @@ heim_vwarnx(heim_context context, const char *fmt, va_list ap)
  * Log a warning to the log, default stderr.
  *
  * @param context A Kerberos 5 context.
- * @param fmt message to print
+ * @param fmt message to print.
  *
  * @ingroup heim_error
  */

--- a/lib/gssapi/mech/gss_add_oid_set_member.c
+++ b/lib/gssapi/mech/gss_add_oid_set_member.c
@@ -40,8 +40,8 @@
  * added to to the set.
  *
  * @param minor_status minor status code.
- * @param member_oid member to add to the oid set
- * @param oid_set oid set to add the member too
+ * @param member_oid member to add to the oid set.
+ * @param oid_set oid set to add the member too.
  *
  * @returns a gss_error code, see gss_display_status() about printing
  *          the error code.

--- a/lib/gssapi/mech/gss_aeap.c
+++ b/lib/gssapi/mech/gss_aeap.c
@@ -77,7 +77,6 @@ gss_wrap_iov(OM_uint32 * minor_status,
 /**
  * Decrypt or verifies the signature on the data.
  *
- *
  * @ingroup gssapi
  */
 

--- a/lib/gssapi/mech/gss_canonicalize_name.c
+++ b/lib/gssapi/mech/gss_canonicalize_name.c
@@ -49,7 +49,7 @@
  *         gss_release_name(), independent of input_name.
  *
  *  @returns a gss_error code, see gss_display_status() about printing
- *         the error code.
+ *           the error code.
  *
  *  @ingroup gssapi
  */

--- a/lib/gssapi/mech/gss_destroy_cred.c
+++ b/lib/gssapi/mech/gss_destroy_cred.c
@@ -30,12 +30,14 @@
 #include <heim_threads.h>
 
 /**
- * Destroy a credential 
+ * Destroy a credential.
  *
- * gss_release_cred() frees the memory, gss_destroy_cred() removes the credentials from memory/disk and then call gss_release_cred() on the credential.
+ * gss_release_cred() frees the memory,
+ * gss_destroy_cred() removes the credentials from memory/disk and
+ * then call gss_release_cred() on the credential.
  *
- * @param min_stat minor status code
- * @param cred_handle credentail to destory
+ * @param min_stat minor status code.
+ * @param cred_handle credentail to destory.
  *
  * @returns a gss_error code, see gss_display_status() about printing
  *          the error code.

--- a/lib/gssapi/mech/gss_display_status.c
+++ b/lib/gssapi/mech/gss_display_status.c
@@ -134,19 +134,19 @@ supplementary_error(OM_uint32 v)
 }
 
 /**
- * Convert a GSS-API status code to text
+ * Convert a GSS-API status code to text.
  *
- * @param minor_status     minor status code
- * @param status_value     status value to convert
+ * @param minor_status     minor status code.
+ * @param status_value     status value to convert.
  * @param status_type      One of:
  *                         GSS_C_GSS_CODE - status_value is a GSS status code,
- *                         GSS_C_MECH_CODE - status_value is a mechanism status code
+ *                         GSS_C_MECH_CODE - status_value is a mechanism status code.
  * @param mech_type        underlying mechanism. Use GSS_C_NO_OID to obtain the
  *                         system default.
  * @param message_context  state information to extract further messages from the
- *                         status_value
+ *                         status_value.
  * @param status_string    the allocated text representation. Release with
- *                         gss_release_buffer()
+ *                         gss_release_buffer().
  *
  * @returns a gss_error code.
  *

--- a/lib/gssapi/mech/gss_export_name.c
+++ b/lib/gssapi/mech/gss_export_name.c
@@ -35,12 +35,12 @@
  *
  * @sa gss_import_name(), @ref internalVSmechname.
  *
- * @param minor_status   minor status code
- * @param input_name     input name in internal name form
- * @param exported_name  output name in contiguos string form
+ * @param minor_status   minor status code.
+ * @param input_name     input name in internal name form.
+ * @param exported_name  output name in contiguos string form.
  *
  * @returns a gss_error code, see gss_display_status() about printing
- *        the error code.
+ *          the error code.
  *
  * @ingroup gssapi
  */

--- a/lib/gssapi/mech/gss_import_name.c
+++ b/lib/gssapi/mech/gss_import_name.c
@@ -183,11 +183,11 @@ _gss_import_export_name(OM_uint32 *minor_status,
  *
  * @sa gss_export_name(), @ref internalVSmechname.
  *
- * @param minor_status       minor status code
- * @param input_name_buffer  import name buffer
- * @param input_name_type    type of the import name buffer
+ * @param minor_status       minor status code.
+ * @param input_name_buffer  import name buffer.
+ * @param input_name_type    type of the import name buffer.
  * @param output_name        the resulting type, release with
- *        gss_release_name(), independent of input_name
+ *        gss_release_name(), independent of input_name.
  *
  * @returns a gss_error code, see gss_display_status() about printing
  *        the error code.

--- a/lib/gssapi/mech/gss_init_sec_context.c
+++ b/lib/gssapi/mech/gss_init_sec_context.c
@@ -109,13 +109,13 @@ log_init_sec_context(struct _gss_context *ctx,
  *        section.
  *
  * @param req_flags flags using when building the context, see @ref
- *        gssapi_context_flags
+ *        gssapi_context_flags.
  *
  * @param time_req time requested this context should be valid in
- *        seconds, common used value is GSS_C_INDEFINITE
+ *        seconds, common used value is GSS_C_INDEFINITE.
  *
  * @param input_chan_bindings Channel bindings used, if not exepected
- *        otherwise, used GSS_C_NO_CHANNEL_BINDINGS
+ *        otherwise, used GSS_C_NO_CHANNEL_BINDINGS.
  *
  * @param input_token input token sent from the acceptor, for the
  * 	  initial packet the buffer of { NULL, 0 } should be used.
@@ -125,13 +125,13 @@ log_init_sec_context(struct _gss_context *ctx,
  *
  * @param output_token if there is an output token, regardless of
  * 	  complete, continue_needed, or error it should be sent to the
- * 	  acceptor
+ * 	  acceptor.
  *
  * @param ret_flags return what flags was negotitated, caller should
  * 	  check if they are accetable. For example, if
  * 	  GSS_C_MUTUAL_FLAG was negotiated with the acceptor or not.
  *
- * @param time_rec amount of time this context is valid for
+ * @param time_rec amount of time this context is valid for.
  *
  * @returns a gss_error code, see gss_display_status() about printing
  *          the error code.

--- a/lib/gssapi/mech/gss_mo.c
+++ b/lib/gssapi/mech/gss_mo.c
@@ -261,11 +261,11 @@ inquire_saslname_for_mech_compat(OM_uint32 *minor,
 /**
  * Returns different protocol names and description of the mechanism.
  *
- * @param minor_status minor status code
- * @param desired_mech mech list query
- * @param sasl_mech_name SASL GS2 protocol name
- * @param mech_name gssapi protocol name
- * @param mech_description description of gssapi mech
+ * @param minor_status minor status code.
+ * @param desired_mech mech list query.
+ * @param sasl_mech_name SASL GS2 protocol name.
+ * @param mech_name gssapi protocol name.
+ * @param mech_description description of gssapi mech.
  *
  * @return returns GSS_S_COMPLETE or a error code.
  *
@@ -330,11 +330,11 @@ gss_inquire_saslname_for_mech(OM_uint32 *minor_status,
 }
 
 /**
- * Find a mech for a sasl name
+ * Find a mech for a sasl name.
  *
- * @param minor_status minor status code
- * @param sasl_mech_name
- * @param mech_type
+ * @param minor_status minor status code.
+ * @param sasl_mech_name.
+ * @param mech_type.
  *
  * @return returns GSS_S_COMPLETE or an error code.
  */
@@ -432,12 +432,12 @@ test_mech_attrs(gssapi_mech_interface mi,
 }
 
 /**
- * Return set of mechanism that fullfill the criteria
+ * Return set of mechanism that fullfill the criteria.
  *
- * @param minor_status minor status code
- * @param desired_mech_attrs
- * @param except_mech_attrs
- * @param critical_mech_attrs
+ * @param minor_status minor status code.
+ * @param desired_mech_attrs.
+ * @param except_mech_attrs.
+ * @param critical_mech_attrs.
  * @param mechs returned mechs, free with gss_release_oid_set().
  *
  * @return returns GSS_S_COMPLETE or an error code.
@@ -501,7 +501,7 @@ gss_indicate_mechs_by_attrs(OM_uint32 * minor_status,
 /**
  * List support attributes for a mech and/or all mechanisms.
  *
- * @param minor_status minor status code
+ * @param minor_status minor status code.
  * @param mech given together with mech_attr will return the list of
  *        attributes for mechanism, can optionally be GSS_C_NO_OID.
  * @param mech_attr see mech parameter, can optionally be NULL,
@@ -571,13 +571,13 @@ gss_inquire_attrs_for_mech(OM_uint32 * minor_status,
 }
 
 /**
- * Return names and descriptions of mech attributes
+ * Return names and descriptions of mech attributes.
  *
- * @param minor_status minor status code
- * @param mech_attr
- * @param name
- * @param short_desc
- * @param long_desc
+ * @param minor_status minor status code.
+ * @param mech_attr.
+ * @param name.
+ * @param short_desc.
+ * @param long_desc.
  *
  * @return returns GSS_S_COMPLETE or an error code.
  */

--- a/lib/gssapi/mech/gss_oid_equal.c
+++ b/lib/gssapi/mech/gss_oid_equal.c
@@ -38,8 +38,8 @@
  *
  * GSS_C_NO_OID matches nothing, not even it-self.
  *
- * @param a first oid to compare
- * @param b second oid to compare
+ * @param a first oid to compare.
+ * @param b second oid to compare.
  *
  * @return non-zero when both oid are the same OID, zero when they are
  *         not the same.

--- a/lib/gssapi/mech/gss_release_cred.c
+++ b/lib/gssapi/mech/gss_release_cred.c
@@ -29,7 +29,7 @@
 #include "mech_locl.h"
 
 /**
- * Release a credentials
+ * Release a credentials.
  *
  * Its ok to release the GSS_C_NO_CREDENTIAL/NULL credential, it will
  * return a GSS_S_COMPLETE error code. On return cred_handle is set ot
@@ -42,10 +42,10 @@
  * major = gss_release_cred(&minor, &cred);
  * @endcode
  *
- * @param minor_status minor status return code, mech specific
- * @param cred_handle a pointer to the credential too release
+ * @param minor_status minor status return code, mech specific.
+ * @param cred_handle a pointer to the credential too release.
  *
- * @return an gssapi error code
+ * @return an gssapi error code.
  *
  * @ingroup gssapi
  */

--- a/lib/gssapi/mech/gss_release_name.c
+++ b/lib/gssapi/mech/gss_release_name.c
@@ -29,17 +29,17 @@
 #include "mech_locl.h"
 
 /**
- * Free a name
+ * Free a name.
  *
  * import_name can point to NULL or be NULL, or a pointer to a
  * gss_name_t structure. If it was a pointer to gss_name_t, the
  * pointer will be set to NULL on success and failure.
  *
- * @param minor_status minor status code
- * @param input_name name to free
+ * @param minor_status minor status code.
+ * @param input_name name to free.
  *
  * @returns a gss_error code, see gss_display_status() about printing
- *        the error code.
+ *          the error code.
  *
  * @ingroup gssapi
  */

--- a/lib/gssapi/mech/gss_store_cred_into.c
+++ b/lib/gssapi/mech/gss_store_cred_into.c
@@ -75,7 +75,7 @@ store_mech_cred(OM_uint32 *minor_status,
  * const key/value hashmap-like thing that specifies a credential store in a
  * mechanism- and implementation-specific way, though Heimdal and MIT agree on
  * at least the following keys for the Kerberos mechanism: ccache, keytab, and
- * client_keytab.  A set of environment variables may be output as well
+ * client_keytab.  A set of environment variables may be output as well.
  */
 GSSAPI_LIB_FUNCTION OM_uint32 GSSAPI_LIB_CALL
 gss_store_cred_into2(OM_uint32 *minor_status,

--- a/lib/gssapi/mech/gss_wrap.c
+++ b/lib/gssapi/mech/gss_wrap.c
@@ -36,7 +36,7 @@
  * @param context_handle context handle.
  * @param conf_req_flag if non zero, confidentiality is requestd.
  * @param qop_req type of protection needed, in most cases it GSS_C_QOP_DEFAULT should be passed in.
- * @param input_message_buffer messages to wrap
+ * @param input_message_buffer messages to wrap.
  * @param conf_state returns non zero if confidentiality was honoured.
  * @param output_message_buffer the resulting buffer, release with gss_release_buffer().
  *

--- a/lib/hcrypto/des.c
+++ b/lib/hcrypto/des.c
@@ -110,6 +110,7 @@ static void FP(uint32_t [2]);
  * random key. See @ref des_keygen.
  *
  * @param key key to fixup the parity for.
+ *
  * @ingroup hcrypto_des
  */
 
@@ -171,6 +172,7 @@ static DES_cblock weak_keys[] = {
  * @param key key to check.
  *
  * @return 1 if the key is weak, 0 otherwise.
+ *
  * @ingroup hcrypto_des
  */
 
@@ -194,6 +196,7 @@ DES_is_weak_key(DES_cblock *key)
  * @param ks a key schedule to initialize.
  *
  * @return 0 on success
+ *
  * @ingroup hcrypto_des
  */
 
@@ -213,6 +216,7 @@ DES_set_key(DES_cblock *key, DES_key_schedule *ks)
  * @param ks a key schedule to initialize.
  *
  * @return 0 on success
+ *
  * @ingroup hcrypto_des
  */
 
@@ -290,6 +294,7 @@ DES_set_key_unchecked(DES_cblock *key, DES_key_schedule *ks)
  * @param ks a key schedule to initialize.
  *
  * @return 0 on success, -1 on invalid parity, -2 on weak key.
+ *
  * @ingroup hcrypto_des
  */
 
@@ -315,6 +320,7 @@ DES_set_key_checked(DES_cblock *key, DES_key_schedule *ks)
  * @param ks a key schedule to initialize.
  *
  * @return 0 on success, -1 on invalid parity, -2 on weak key.
+ *
  * @ingroup hcrypto_des
  */
 
@@ -355,10 +361,10 @@ store(const uint32_t v[2], unsigned char *b)
 }
 
 /**
- * Encrypt/decrypt a block using DES. Also called ECB mode
+ * Encrypt/decrypt a block using DES. Also called ECB mode.
  *
- * @param u data to encrypt
- * @param ks key schedule to use
+ * @param u data to encrypt.
+ * @param ks key schedule to use.
  * @param encp if non zero, encrypt. if zero, decrypt.
  *
  * @ingroup hcrypto_des
@@ -375,9 +381,9 @@ DES_encrypt(uint32_t u[2], DES_key_schedule *ks, int encp)
 /**
  * Encrypt/decrypt a block using DES.
  *
- * @param input data to encrypt
- * @param output data to encrypt
- * @param ks key schedule to use
+ * @param input data to encrypt.
+ * @param output data to encrypt.
+ * @param ks key schedule to use.
  * @param encp if non zero, encrypt. if zero, decrypt.
  *
  * @ingroup hcrypto_des
@@ -398,11 +404,11 @@ DES_ecb_encrypt(DES_cblock *input, DES_cblock *output,
  *
  * The IV must always be diffrent for diffrent input data blocks.
  *
- * @param in data to encrypt
- * @param out data to encrypt
- * @param length length of data
- * @param ks key schedule to use
- * @param iv initial vector to use
+ * @param in data to encrypt.
+ * @param out data to encrypt.
+ * @param length length of data.
+ * @param ks key schedule to use.
+ * @param iv initial vector to use.
  * @param encp if non zero, encrypt. if zero, decrypt.
  *
  * @ingroup hcrypto_des
@@ -474,11 +480,11 @@ DES_cbc_encrypt(const void *in, void *out, long length,
  *
  * The IV must always be diffrent for diffrent input data blocks.
  *
- * @param in data to encrypt
- * @param out data to encrypt
- * @param length length of data
- * @param ks key schedule to use
- * @param iv initial vector to use
+ * @param in data to encrypt.
+ * @param out data to encrypt.
+ * @param length length of data.
+ * @param ks key schedule to use.
+ * @param iv initial vector to use.
  * @param encp if non zero, encrypt. if zero, decrypt.
  *
  * @ingroup hcrypto_des
@@ -569,11 +575,11 @@ _des3_encrypt(uint32_t u[2], DES_key_schedule *ks1, DES_key_schedule *ks2,
  * Encrypt/decrypt a block using triple DES using EDE mode,
  * encrypt/decrypt/encrypt.
  *
- * @param input data to encrypt
- * @param output data to encrypt
- * @param ks1 key schedule to use
- * @param ks2 key schedule to use
- * @param ks3 key schedule to use
+ * @param input data to encrypt.
+ * @param output data to encrypt.
+ * @param ks1 key schedule to use.
+ * @param ks2 key schedule to use.
+ * @param ks3 key schedule to use.
  * @param encp if non zero, encrypt. if zero, decrypt.
  *
  * @ingroup hcrypto_des
@@ -599,13 +605,13 @@ DES_ecb3_encrypt(DES_cblock *input,
  *
  * The IV must always be diffrent for diffrent input data blocks.
  *
- * @param in data to encrypt
- * @param out data to encrypt
- * @param length length of data
- * @param ks1 key schedule to use
- * @param ks2 key schedule to use
- * @param ks3 key schedule to use
- * @param iv initial vector to use
+ * @param in data to encrypt.
+ * @param out data to encrypt.
+ * @param length length of data.
+ * @param ks1 key schedule to use.
+ * @param ks2 key schedule to use.
+ * @param ks3 key schedule to use.
+ * @param iv initial vector to use.
  * @param encp if non zero, encrypt. if zero, decrypt.
  *
  * @ingroup hcrypto_des
@@ -679,11 +685,11 @@ DES_ede3_cbc_encrypt(const void *in, void *out,
  *
  * The IV must always be diffrent for diffrent input data blocks.
  *
- * @param in data to encrypt
- * @param out data to encrypt
- * @param length length of data
- * @param ks key schedule to use
- * @param iv initial vector to use
+ * @param in data to encrypt.
+ * @param out data to encrypt.
+ * @param length length of data.
+ * @param ks key schedule to use.
+ * @param iv initial vector to use.
  * @param num offset into in cipher block encryption/decryption stop last time.
  * @param encp if non zero, encrypt. if zero, decrypt.
  *
@@ -758,11 +764,11 @@ DES_cfb64_encrypt(const void *in, void *out,
  *
  * The IV must always be diffrent for diffrent input data blocks.
  *
- * @param in data to checksum
- * @param output the checksum
- * @param length length of data
- * @param ks key schedule to use
- * @param iv initial vector to use
+ * @param in data to checksum.
+ * @param output the checksum.
+ * @param length length of data.
+ * @param ks key schedule to use.
+ * @param iv initial vector to use.
  *
  * @ingroup hcrypto_des
  */
@@ -821,8 +827,8 @@ bitswap8(unsigned char b)
  * Convert a string to a DES key. Use something like
  * PKCS5_PBKDF2_HMAC_SHA1() to create key from passwords.
  *
- * @param str The string to convert to a key
- * @param key the resulting key
+ * @param str The string to convert to a key.
+ * @param key the resulting key.
  *
  * @ingroup hcrypto_des
  */
@@ -862,8 +868,8 @@ DES_string_to_key(const char *str, DES_cblock *key)
  * DES_string_to_key(). Really, go use a really string2key function
  * like PKCS5_PBKDF2_HMAC_SHA1().
  *
- * @param key key to convert to
- * @param prompt prompt to display user
+ * @param key key to convert to.
+ * @param prompt prompt to display user.
  * @param verify prompt twice.
  *
  * @return 1 on success, non 1 on failure.

--- a/lib/hcrypto/dh.c
+++ b/lib/hcrypto/dh.c
@@ -208,7 +208,7 @@ DH_set_ex_data(DH *dh, int idx, void *data)
  * @param dh DH object.
  * @param idx index to get the data for.
  *
- * @return the object store in index idx
+ * @return the object store in index idx.
  *
  * @ingroup hcrypto_dh
  */
@@ -223,8 +223,8 @@ DH_get_ex_data(DH *dh, int idx)
  * Generate DH parameters for the DH object give parameters.
  *
  * @param dh The DH object to generate parameters for.
- * @param prime_len length of the prime
- * @param generator generator, g
+ * @param prime_len length of the prime.
+ * @param generator generator, g.
  * @param cb Callback parameters to show progress, can be NULL.
  *
  * @return the maximum size in bytes of the out data.
@@ -248,7 +248,7 @@ DH_generate_parameters_ex(DH *dh, int prime_len, int generator, BN_GENCB *cb)
  * @param codes return that the failures of the pub_key are.
  *
  * @return 1 on success, 0 on failure and *codes is set the the
- * combined fail check for the public key
+ * combined fail check for the public key.
  *
  * @ingroup hcrypto_dh
  */

--- a/lib/hcrypto/evp-cc.c
+++ b/lib/hcrypto/evp-cc.c
@@ -149,7 +149,7 @@ cc_des_ede3_cbc_init(EVP_CIPHER_CTX *ctx,
 #endif /* HAVE_COMMONCRYPTO_COMMONCRYPTOR_H */
 
 /**
- * The triple DES cipher type (Apple CommonCrypto provider)
+ * The triple DES cipher type (Apple CommonCrypto provider).
  *
  * @return the DES-EDE3-CBC EVP_CIPHER pointer.
  *
@@ -201,7 +201,7 @@ cc_des_cbc_init(EVP_CIPHER_CTX *ctx,
 #endif
 
 /**
- * The DES cipher type (Apple CommonCrypto provider)
+ * The DES cipher type (Apple CommonCrypto provider).
  *
  * @return the DES-CBC EVP_CIPHER pointer.
  *
@@ -253,7 +253,7 @@ cc_aes_cbc_init(EVP_CIPHER_CTX *ctx,
 #endif
 
 /**
- * The AES-128 cipher type (Apple CommonCrypto provider)
+ * The AES-128 cipher type (Apple CommonCrypto provider).
  *
  * @return the AES-128-CBC EVP_CIPHER pointer.
  *
@@ -288,7 +288,7 @@ EVP_cc_aes_128_cbc(void)
 }
 
 /**
- * The AES-192 cipher type (Apple CommonCrypto provider)
+ * The AES-192 cipher type (Apple CommonCrypto provider).
  *
  * @return the AES-192-CBC EVP_CIPHER pointer.
  *
@@ -323,7 +323,7 @@ EVP_cc_aes_192_cbc(void)
 }
 
 /**
- * The AES-256 cipher type (Apple CommonCrypto provider)
+ * The AES-256 cipher type (Apple CommonCrypto provider).
  *
  * @return the AES-256-CBC EVP_CIPHER pointer.
  *
@@ -375,7 +375,7 @@ cc_aes_cfb8_init(EVP_CIPHER_CTX *ctx,
 #endif
 
 /**
- * The AES-128 CFB8 cipher type (Apple CommonCrypto provider)
+ * The AES-128 CFB8 cipher type (Apple CommonCrypto provider).
  *
  * @return the AES-128-CFB8 EVP_CIPHER pointer.
  *
@@ -410,7 +410,7 @@ EVP_cc_aes_128_cfb8(void)
 }
 
 /**
- * The AES-192 CFB8 cipher type (Apple CommonCrypto provider)
+ * The AES-192 CFB8 cipher type (Apple CommonCrypto provider).
  *
  * @return the AES-192-CFB8 EVP_CIPHER pointer.
  *
@@ -445,7 +445,7 @@ EVP_cc_aes_192_cfb8(void)
 }
 
 /**
- * The AES-256 CFB8 cipher type (Apple CommonCrypto provider)
+ * The AES-256 CFB8 cipher type (Apple CommonCrypto provider).
  *
  * @return the AES-256-CFB8 EVP_CIPHER pointer.
  *
@@ -497,7 +497,7 @@ cc_rc2_cbc_init(EVP_CIPHER_CTX *ctx,
 #endif
 
 /**
- * The RC2 cipher type - common crypto
+ * The RC2 cipher type - common crypto.
  *
  * @return the RC2 EVP_CIPHER pointer.
  *
@@ -533,7 +533,7 @@ EVP_cc_rc2_cbc(void)
 }
 
 /**
- * The RC2-40 cipher type - common crypto
+ * The RC2-40 cipher type - common crypto.
  *
  * @return the RC2-40 EVP_CIPHER pointer.
  *
@@ -570,7 +570,7 @@ EVP_cc_rc2_40_cbc(void)
 
 
 /**
- * The RC2-64 cipher type - common crypto
+ * The RC2-64 cipher type - common crypto.
  *
  * @return the RC2-64 EVP_CIPHER pointer.
  *
@@ -607,7 +607,7 @@ EVP_cc_rc2_64_cbc(void)
 
 
 /**
- * The CommonCrypto md4 provider
+ * The CommonCrypto md4 provider.
  *
  * @ingroup hcrypto_evp
  */
@@ -634,7 +634,7 @@ EVP_cc_md4(void)
 }
 
 /**
- * The CommonCrypto md5 provider
+ * The CommonCrypto md5 provider.
  *
  * @ingroup hcrypto_evp
  */
@@ -661,7 +661,7 @@ EVP_cc_md5(void)
 }
 
 /**
- * The CommonCrypto sha1 provider
+ * The CommonCrypto sha1 provider.
  *
  * @ingroup hcrypto_evp
  */
@@ -688,7 +688,7 @@ EVP_cc_sha1(void)
 }
 
 /**
- * The CommonCrypto sha256 provider
+ * The CommonCrypto sha256 provider.
  *
  * @ingroup hcrypto_evp
  */
@@ -715,7 +715,7 @@ EVP_cc_sha256(void)
 }
 
 /**
- * The CommonCrypto sha384 provider
+ * The CommonCrypto sha384 provider.
  *
  * @ingroup hcrypto_evp
  */
@@ -742,7 +742,7 @@ EVP_cc_sha384(void)
 }
 
 /**
- * The CommonCrypto sha512 provider
+ * The CommonCrypto sha512 provider.
  *
  * @ingroup hcrypto_evp
  */
@@ -769,7 +769,7 @@ EVP_cc_sha512(void)
 }
 
 /**
- * The Camellia-128 cipher type - CommonCrypto
+ * The Camellia-128 cipher type - CommonCrypto.
  *
  * @return the Camellia-128 EVP_CIPHER pointer.
  *
@@ -787,7 +787,7 @@ EVP_cc_camellia_128_cbc(void)
 }
 
 /**
- * The Camellia-198 cipher type - CommonCrypto
+ * The Camellia-198 cipher type - CommonCrypto.
  *
  * @return the Camellia-198 EVP_CIPHER pointer.
  *
@@ -805,7 +805,7 @@ EVP_cc_camellia_192_cbc(void)
 }
 
 /**
- * The Camellia-256 cipher type - CommonCrypto
+ * The Camellia-256 cipher type - CommonCrypto.
  *
  * @return the Camellia-256 EVP_CIPHER pointer.
  *
@@ -843,7 +843,7 @@ cc_rc4_init(EVP_CIPHER_CTX *ctx,
 
 /**
 
- * The RC4 cipher type (Apple CommonCrypto provider)
+ * The RC4 cipher type (Apple CommonCrypto provider).
  *
  * @return the RC4 EVP_CIPHER pointer.
  *
@@ -879,7 +879,7 @@ EVP_cc_rc4(void)
 
 
 /**
- * The RC4-40 cipher type (Apple CommonCrypto provider)
+ * The RC4-40 cipher type (Apple CommonCrypto provider).
  *
  * @return the RC4 EVP_CIPHER pointer.
  *

--- a/lib/hcrypto/evp-crypt.c
+++ b/lib/hcrypto/evp-crypt.c
@@ -133,7 +133,7 @@ crypto_des_ede3_cbc_init(EVP_CIPHER_CTX *ctx,
 }
 
 /**
- * The triple DES cipher type (Micrsoft crypt provider)
+ * The triple DES cipher type (Micrsoft crypt provider).
  *
  * @return the DES-EDE3-CBC EVP_CIPHER pointer.
  *

--- a/lib/hcrypto/evp-hcrypto.c
+++ b/lib/hcrypto/evp-hcrypto.c
@@ -87,7 +87,7 @@ aes_do_cipher(EVP_CIPHER_CTX *ctx,
 }
 
 /**
- * The AES-128 cipher type (hcrypto)
+ * The AES-128 cipher type (hcrypto).
  *
  * @return the AES-128 EVP_CIPHER pointer.
  *
@@ -117,7 +117,7 @@ EVP_hcrypto_aes_128_cbc(void)
 }
 
 /**
- * The AES-192 cipher type (hcrypto)
+ * The AES-192 cipher type (hcrypto).
  *
  * @return the AES-192 EVP_CIPHER pointer.
  *
@@ -146,7 +146,7 @@ EVP_hcrypto_aes_192_cbc(void)
 }
 
 /**
- * The AES-256 cipher type (hcrypto)
+ * The AES-256 cipher type (hcrypto).
  *
  * @return the AES-256 EVP_CIPHER pointer.
  *
@@ -175,7 +175,7 @@ EVP_hcrypto_aes_256_cbc(void)
 }
 
 /**
- * The AES-128 CFB8 cipher type (hcrypto)
+ * The AES-128 CFB8 cipher type (hcrypto).
  *
  * @return the AES-128 EVP_CIPHER pointer.
  *
@@ -205,7 +205,7 @@ EVP_hcrypto_aes_128_cfb8(void)
 }
 
 /**
- * The AES-192 CFB8 cipher type (hcrypto)
+ * The AES-192 CFB8 cipher type (hcrypto).
  *
  * @return the AES-192 EVP_CIPHER pointer.
  *
@@ -234,7 +234,7 @@ EVP_hcrypto_aes_192_cfb8(void)
 }
 
 /**
- * The AES-256 CFB8 cipher type (hcrypto)
+ * The AES-256 CFB8 cipher type (hcrypto).
  *
  * @return the AES-256 EVP_CIPHER pointer.
  *
@@ -263,7 +263,7 @@ EVP_hcrypto_aes_256_cfb8(void)
 }
 
 /**
- * The message digest SHA256 - hcrypto
+ * The message digest SHA256 - hcrypto.
  *
  * @return the message digest type.
  *
@@ -286,7 +286,7 @@ EVP_hcrypto_sha256(void)
 }
 
 /**
- * The message digest SHA384 - hcrypto
+ * The message digest SHA384 - hcrypto.
  *
  * @return the message digest type.
  *
@@ -309,7 +309,7 @@ EVP_hcrypto_sha384(void)
 }
 
 /**
- * The message digest SHA512 - hcrypto
+ * The message digest SHA512 - hcrypto.
  *
  * @return the message digest type.
  *
@@ -332,7 +332,7 @@ EVP_hcrypto_sha512(void)
 }
 
 /**
- * The message digest SHA1 - hcrypto
+ * The message digest SHA1 - hcrypto.
  *
  * @return the message digest type.
  *
@@ -355,7 +355,7 @@ EVP_hcrypto_sha1(void)
 }
 
 /**
- * The message digest MD5 - hcrypto
+ * The message digest MD5 - hcrypto.
  *
  * @return the message digest type.
  *
@@ -378,7 +378,7 @@ EVP_hcrypto_md5(void)
 }
 
 /**
- * The message digest MD4 - hcrypto
+ * The message digest MD4 - hcrypto.
  *
  * @return the message digest type.
  *
@@ -431,7 +431,7 @@ des_cbc_do_cipher(EVP_CIPHER_CTX *ctx,
 }
 
 /**
- * The DES cipher type
+ * The DES cipher type.
  *
  * @return the DES-CBC EVP_CIPHER pointer.
  *
@@ -505,7 +505,7 @@ des_ede3_cbc_do_cipher(EVP_CIPHER_CTX *ctx,
 }
 
 /**
- * The triple DES cipher type - hcrypto
+ * The triple DES cipher type - hcrypto.
  *
  * @return the DES-EDE3-CBC EVP_CIPHER pointer.
  *
@@ -569,7 +569,7 @@ rc2_do_cipher(EVP_CIPHER_CTX *ctx,
 }
 
 /**
- * The RC2 cipher type - hcrypto
+ * The RC2 cipher type - hcrypto.
  *
  * @return the RC2 EVP_CIPHER pointer.
  *
@@ -598,7 +598,7 @@ EVP_hcrypto_rc2_cbc(void)
 }
 
 /**
- * The RC2-40 cipher type
+ * The RC2-40 cipher type.
  *
  * @return the RC2-40 EVP_CIPHER pointer.
  *
@@ -627,7 +627,7 @@ EVP_hcrypto_rc2_40_cbc(void)
 }
 
 /**
- * The RC2-64 cipher type
+ * The RC2-64 cipher type.
  *
  * @return the RC2-64 EVP_CIPHER pointer.
  *
@@ -679,7 +679,7 @@ camellia_do_cipher(EVP_CIPHER_CTX *ctx,
 }
 
 /**
- * The Camellia-128 cipher type - hcrypto
+ * The Camellia-128 cipher type - hcrypto.
  *
  * @return the Camellia-128 EVP_CIPHER pointer.
  *
@@ -708,7 +708,7 @@ EVP_hcrypto_camellia_128_cbc(void)
 }
 
 /**
- * The Camellia-198 cipher type - hcrypto
+ * The Camellia-198 cipher type - hcrypto.
  *
  * @return the Camellia-198 EVP_CIPHER pointer.
  *
@@ -737,7 +737,7 @@ EVP_hcrypto_camellia_192_cbc(void)
 }
 
 /**
- * The Camellia-256 cipher type - hcrypto
+ * The Camellia-256 cipher type - hcrypto.
  *
  * @return the Camellia-256 EVP_CIPHER pointer.
  *

--- a/lib/hcrypto/evp-wincng.c
+++ b/lib/hcrypto/evp-wincng.c
@@ -263,7 +263,7 @@ wincng_key_init(EVP_CIPHER_CTX *ctx,
     }
 
 /**
- * The triple DES cipher type (Windows CNG provider)
+ * The triple DES cipher type (Windows CNG provider).
  *
  * @return the DES-EDE3-CBC EVP_CIPHER pointer.
  *
@@ -278,7 +278,7 @@ WINCNG_CIPHER_ALGORITHM(des_ede3_cbc,
 			EVP_CIPH_CBC_MODE);
 
 /**
- * The DES cipher type (Windows CNG provider)
+ * The DES cipher type (Windows CNG provider).
  *
  * @return the DES-CBC EVP_CIPHER pointer.
  *
@@ -293,7 +293,7 @@ WINCNG_CIPHER_ALGORITHM(des_cbc,
 			EVP_CIPH_CBC_MODE);
 
 /**
- * The AES-128 cipher type (Windows CNG provider)
+ * The AES-128 cipher type (Windows CNG provider).
  *
  * @return the AES-128-CBC EVP_CIPHER pointer.
  *
@@ -308,7 +308,7 @@ WINCNG_CIPHER_ALGORITHM(aes_128_cbc,
 			EVP_CIPH_CBC_MODE);
 
 /**
- * The AES-192 cipher type (Windows CNG provider)
+ * The AES-192 cipher type (Windows CNG provider).
  *
  * @return the AES-192-CBC EVP_CIPHER pointer.
  *
@@ -323,7 +323,7 @@ WINCNG_CIPHER_ALGORITHM(aes_192_cbc,
 			EVP_CIPH_CBC_MODE);
 
 /**
- * The AES-256 cipher type (Windows CNG provider)
+ * The AES-256 cipher type (Windows CNG provider).
  *
  * @return the AES-256-CBC EVP_CIPHER pointer.
  *
@@ -338,7 +338,7 @@ WINCNG_CIPHER_ALGORITHM(aes_256_cbc,
 			EVP_CIPH_CBC_MODE);
 
 /**
- * The AES-128 CFB8 cipher type (Windows CNG provider)
+ * The AES-128 CFB8 cipher type (Windows CNG provider).
  *
  * @return the AES-128-CFB8 EVP_CIPHER pointer.
  *
@@ -353,7 +353,7 @@ WINCNG_CIPHER_ALGORITHM(aes_128_cfb8,
 			EVP_CIPH_CFB8_MODE);
 
 /**
- * The AES-192 CFB8 cipher type (Windows CNG provider)
+ * The AES-192 CFB8 cipher type (Windows CNG provider).
  *
  * @return the AES-192-CFB8 EVP_CIPHER pointer.
  *
@@ -368,7 +368,7 @@ WINCNG_CIPHER_ALGORITHM(aes_192_cfb8,
 			EVP_CIPH_CFB8_MODE);
 
 /**
- * The AES-256 CFB8 cipher type (Windows CNG provider)
+ * The AES-256 CFB8 cipher type (Windows CNG provider).
  *
  * @return the AES-256-CFB8 EVP_CIPHER pointer.
  *
@@ -383,7 +383,7 @@ WINCNG_CIPHER_ALGORITHM(aes_256_cfb8,
 			EVP_CIPH_CFB8_MODE);
 
 /**
- * The RC2 cipher type - Windows CNG
+ * The RC2 cipher type - Windows CNG.
  *
  * @return the RC2 EVP_CIPHER pointer.
  *
@@ -398,7 +398,7 @@ WINCNG_CIPHER_ALGORITHM(rc2_cbc,
 			EVP_CIPH_CBC_MODE);
 
 /**
- * The RC2-40 cipher type - Windows CNG
+ * The RC2-40 cipher type - Windows CNG.
  *
  * @return the RC2-40 EVP_CIPHER pointer.
  *
@@ -413,7 +413,7 @@ WINCNG_CIPHER_ALGORITHM(rc2_40_cbc,
 			EVP_CIPH_CBC_MODE);
 
 /**
- * The RC2-64 cipher type - Windows CNG
+ * The RC2-64 cipher type - Windows CNG.
  *
  * @return the RC2-64 EVP_CIPHER pointer.
  *
@@ -428,7 +428,7 @@ WINCNG_CIPHER_ALGORITHM(rc2_64_cbc,
 			EVP_CIPH_CBC_MODE);
 
 /**
- * The Camellia-128 cipher type - CommonCrypto
+ * The Camellia-128 cipher type - CommonCrypto.
  *
  * @return the Camellia-128 EVP_CIPHER pointer.
  *
@@ -438,7 +438,7 @@ WINCNG_CIPHER_ALGORITHM(rc2_64_cbc,
 WINCNG_CIPHER_ALGORITHM_UNAVAILABLE(camellia_128_cbc);
 
 /**
- * The Camellia-198 cipher type - CommonCrypto
+ * The Camellia-198 cipher type - CommonCrypto.
  *
  * @return the Camellia-198 EVP_CIPHER pointer.
  *
@@ -448,7 +448,7 @@ WINCNG_CIPHER_ALGORITHM_UNAVAILABLE(camellia_128_cbc);
 WINCNG_CIPHER_ALGORITHM_UNAVAILABLE(camellia_192_cbc);
 
 /**
- * The Camellia-256 cipher type - CommonCrypto
+ * The Camellia-256 cipher type - CommonCrypto.
  *
  * @return the Camellia-256 EVP_CIPHER pointer.
  *
@@ -458,7 +458,7 @@ WINCNG_CIPHER_ALGORITHM_UNAVAILABLE(camellia_192_cbc);
 WINCNG_CIPHER_ALGORITHM_UNAVAILABLE(camellia_256_cbc);
 
 /**
- * The RC4 cipher type (Windows CNG provider)
+ * The RC4 cipher type (Windows CNG provider).
  *
  * @return the RC4 EVP_CIPHER pointer.
  *
@@ -473,7 +473,7 @@ WINCNG_CIPHER_ALGORITHM(rc4,
 			EVP_CIPH_STREAM_CIPHER | EVP_CIPH_VARIABLE_LENGTH);
 
 /**
- * The RC4-40 cipher type (Windows CNG provider)
+ * The RC4-40 cipher type (Windows CNG provider).
  *
  * @return the RC4 EVP_CIPHER pointer.
  *

--- a/lib/hcrypto/evp.c
+++ b/lib/hcrypto/evp.c
@@ -103,7 +103,7 @@ struct hc_EVP_MD_CTX {
 /**
  * Return the output size of the message digest function.
  *
- * @param md the evp message
+ * @param md the evp message.
  *
  * @return size output size of the message digest function.
  *
@@ -119,9 +119,9 @@ EVP_MD_size(const EVP_MD *md)
 /**
  * Return the blocksize of the message digest function.
  *
- * @param md the evp message
+ * @param md the evp message.
  *
- * @return size size of the message digest block size
+ * @return size size of the message digest block size.
  *
  * @ingroup hcrypto_evp
  */
@@ -223,7 +223,7 @@ EVP_MD_CTX_md(EVP_MD_CTX *ctx)
 /**
  * Return the output size of the message digest function.
  *
- * @param ctx the evp message digest context
+ * @param ctx the evp message digest context.
  *
  * @return size output size of the message digest function.
  *
@@ -239,9 +239,9 @@ EVP_MD_CTX_size(EVP_MD_CTX *ctx)
 /**
  * Return the blocksize of the message digest function.
  *
- * @param ctx the evp message digest context
+ * @param ctx the evp message digest context.
  *
- * @return size size of the message digest block size
+ * @return size size of the message digest block size.
  *
  * @ingroup hcrypto_evp
  */
@@ -286,9 +286,9 @@ EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *md, ENGINE *engine)
 /**
  * Update the digest with some data.
  *
- * @param ctx the context to update
- * @param data the data to update the context with
- * @param size length of data
+ * @param ctx the context to update.
+ * @param data the data to update the context with.
+ * @param size length of data.
  *
  * @return 1 on success.
  *
@@ -329,11 +329,11 @@ EVP_DigestFinal_ex(EVP_MD_CTX *ctx, void *hash, unsigned int *size)
  * EVP_DigestUpdate(), EVP_DigestFinal_ex(), EVP_MD_CTX_destroy()
  * dance in one call.
  *
- * @param data the data to update the context with
- * @param dsize length of data
+ * @param data the data to update the context with.
+ * @param dsize length of data.
  * @param hash output data of at least EVP_MD_size() length.
  * @param hsize output length of hash.
- * @param md message digest to use
+ * @param md message digest to use.
  * @param engine engine to use, NULL for default engine.
  *
  * @return 1 on success.
@@ -367,7 +367,7 @@ EVP_Digest(const void *data, size_t dsize, void *hash, unsigned int *hsize,
 }
 
 /**
- * The message digest SHA256
+ * The message digest SHA256.
  *
  * @return the message digest type.
  *
@@ -382,7 +382,7 @@ EVP_sha256(void)
 }
 
 /**
- * The message digest SHA384
+ * The message digest SHA384.
  *
  * @return the message digest type.
  *
@@ -397,7 +397,7 @@ EVP_sha384(void)
 }
 
 /**
- * The message digest SHA512
+ * The message digest SHA512.
  *
  * @return the message digest type.
  *
@@ -412,7 +412,7 @@ EVP_sha512(void)
 }
 
 /**
- * The message digest SHA1
+ * The message digest SHA1.
  *
  * @return the message digest type.
  *
@@ -427,7 +427,7 @@ EVP_sha1(void)
 }
 
 /**
- * The message digest SHA1
+ * The message digest SHA1.
  *
  * @return the message digest type.
  *
@@ -443,7 +443,7 @@ EVP_sha(void) HC_DEPRECATED
 }
 
 /**
- * The message digest MD5
+ * The message digest MD5.
  *
  * @return the message digest type.
  *
@@ -458,7 +458,7 @@ EVP_md5(void) HC_DEPRECATED_CRYPTO
 }
 
 /**
- * The message digest MD4
+ * The message digest MD4.
  *
  * @return the message digest type.
  *
@@ -500,7 +500,7 @@ null_Final(void *res, void *m)
 }
 
 /**
- * The null message digest
+ * The null message digest.
  *
  * @return the message digest type.
  *
@@ -613,10 +613,10 @@ EVP_CIPHER_CTX_cleanup(EVP_CIPHER_CTX *c)
 }
 
 /**
- * If the cipher type supports it, change the key length
+ * If the cipher type supports it, change the key length.
  *
- * @param c the cipher context to change the key length for
- * @param length new key length
+ * @param c the cipher context to change the key length for.
+ * @param length new key length.
  *
  * @return 1 on success.
  *
@@ -708,7 +708,7 @@ EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx)
 /**
  * Get the flags for an EVP_CIPHER_CTX context.
  *
- * @param ctx the EVP_CIPHER_CTX to get the flags from
+ * @param ctx the EVP_CIPHER_CTX to get the flags from.
  *
  * @return the flags for an EVP_CIPHER_CTX.
  *
@@ -724,7 +724,7 @@ EVP_CIPHER_CTX_flags(const EVP_CIPHER_CTX *ctx)
 /**
  * Get the mode for an EVP_CIPHER_CTX context.
  *
- * @param ctx the EVP_CIPHER_CTX to get the mode from
+ * @param ctx the EVP_CIPHER_CTX to get the mode from.
  *
  * @return the mode for an EVP_CIPHER_CTX.
  *
@@ -740,7 +740,7 @@ EVP_CIPHER_CTX_mode(const EVP_CIPHER_CTX *ctx)
 /**
  * Get the app data for an EVP_CIPHER_CTX context.
  *
- * @param ctx the EVP_CIPHER_CTX to get the app data from
+ * @param ctx the EVP_CIPHER_CTX to get the app data from.
  *
  * @return the app data for an EVP_CIPHER_CTX.
  *
@@ -756,7 +756,7 @@ EVP_CIPHER_CTX_get_app_data(EVP_CIPHER_CTX *ctx)
 /**
  * Set the app data for an EVP_CIPHER_CTX context.
  *
- * @param ctx the EVP_CIPHER_CTX to set the app data for
+ * @param ctx the EVP_CIPHER_CTX to set the app data for.
  * @param data the app data to set for an EVP_CIPHER_CTX.
  *
  * @ingroup hcrypto_evp
@@ -772,7 +772,7 @@ EVP_CIPHER_CTX_set_app_data(EVP_CIPHER_CTX *ctx, void *data)
  * Initiate the EVP_CIPHER_CTX context to encrypt or decrypt data.
  * Clean up with EVP_CIPHER_CTX_cleanup().
  *
- * @param ctx context to initiate
+ * @param ctx context to initiate.
  * @param c cipher to use.
  * @param engine crypto engine to use, NULL to select default.
  * @param key the crypto key to use, NULL will use the previous value.
@@ -844,11 +844,11 @@ EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *c, ENGINE *engine,
 }
 
 /**
- * Encipher/decipher partial data
+ * Encipher/decipher partial data.
  *
  * @param ctx the cipher context.
  * @param out output data from the operation.
- * @param outlen output length
+ * @param outlen output length.
  * @param in input data to the operation.
  * @param inlen length of data.
  *
@@ -933,11 +933,11 @@ EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, void *out, int *outlen,
 }
 
 /**
- * Encipher/decipher final data
+ * Encipher/decipher final data.
  *
  * @param ctx the cipher context.
  * @param out output data from the operation.
- * @param outlen output length
+ * @param outlen output length.
  *
  * The input length needs to be at least EVP_CIPHER_block_size() bytes
  * long.
@@ -976,7 +976,7 @@ EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, void *out, int *outlen)
 }
 
 /**
- * Encipher/decipher data
+ * Encipher/decipher data.
  *
  * @param ctx the cipher context.
  * @param out out data from the operation.
@@ -1051,7 +1051,7 @@ EVP_enc_null(void)
 }
 
 /**
- * The RC2 cipher type
+ * The RC2 cipher type.
  *
  * @return the RC2 EVP_CIPHER pointer.
  *
@@ -1073,7 +1073,7 @@ EVP_rc2_cbc(void)
 }
 
 /**
- * The RC2 cipher type
+ * The RC2 cipher type.
  *
  * @return the RC2 EVP_CIPHER pointer.
  *
@@ -1117,7 +1117,7 @@ EVP_rc2_64_cbc(void)
 }
 
 /**
- * The RC4 cipher type
+ * The RC4 cipher type.
  *
  * @return the RC4 EVP_CIPHER pointer.
  *
@@ -1139,7 +1139,7 @@ EVP_rc4(void)
 }
 
 /**
- * The RC4-40 cipher type
+ * The RC4-40 cipher type.
  *
  * @return the RC4-40 EVP_CIPHER pointer.
  *
@@ -1161,7 +1161,7 @@ EVP_rc4_40(void)
 }
 
 /**
- * The DES cipher type
+ * The DES cipher type.
  *
  * @return the DES-CBC EVP_CIPHER pointer.
  *
@@ -1183,7 +1183,7 @@ EVP_des_cbc(void)
 }
 
 /**
- * The triple DES cipher type
+ * The triple DES cipher type.
  *
  * @return the DES-EDE3-CBC EVP_CIPHER pointer.
  *
@@ -1198,7 +1198,7 @@ EVP_des_ede3_cbc(void)
 }
 
 /**
- * The AES-128 cipher type
+ * The AES-128 cipher type.
  *
  * @return the AES-128 EVP_CIPHER pointer.
  *
@@ -1213,7 +1213,7 @@ EVP_aes_128_cbc(void)
 }
 
 /**
- * The AES-192 cipher type
+ * The AES-192 cipher type.
  *
  * @return the AES-192 EVP_CIPHER pointer.
  *
@@ -1228,7 +1228,7 @@ EVP_aes_192_cbc(void)
 }
 
 /**
- * The AES-256 cipher type
+ * The AES-256 cipher type.
  *
  * @return the AES-256 EVP_CIPHER pointer.
  *
@@ -1243,7 +1243,7 @@ EVP_aes_256_cbc(void)
 }
 
 /**
- * The AES-128 cipher type
+ * The AES-128 cipher type.
  *
  * @return the AES-128 EVP_CIPHER pointer.
  *
@@ -1258,7 +1258,7 @@ EVP_aes_128_cfb8(void)
 }
 
 /**
- * The AES-192 cipher type
+ * The AES-192 cipher type.
  *
  * @return the AES-192 EVP_CIPHER pointer.
  *
@@ -1273,7 +1273,7 @@ EVP_aes_192_cfb8(void)
 }
 
 /**
- * The AES-256 cipher type
+ * The AES-256 cipher type.
  *
  * @return the AES-256 EVP_CIPHER pointer.
  *
@@ -1288,7 +1288,7 @@ EVP_aes_256_cfb8(void)
 }
 
 /**
- * The Camellia-128 cipher type
+ * The Camellia-128 cipher type.
  *
  * @return the Camellia-128 EVP_CIPHER pointer.
  *
@@ -1303,7 +1303,7 @@ EVP_camellia_128_cbc(void)
 }
 
 /**
- * The Camellia-198 cipher type
+ * The Camellia-198 cipher type.
  *
  * @return the Camellia-198 EVP_CIPHER pointer.
  *
@@ -1318,7 +1318,7 @@ EVP_camellia_192_cbc(void)
 }
 
 /**
- * The Camellia-256 cipher type
+ * The Camellia-256 cipher type.
  *
  * @return the Camellia-256 EVP_CIPHER pointer.
  *
@@ -1388,8 +1388,8 @@ EVP_get_cipherbyname(const char *name)
  * New protocols should use new string to key functions like NIST
  * SP56-800A or PKCS#5 v2.0 (see PKCS5_PBKDF2_HMAC_SHA1()).
  *
- * @param type type of cipher to use
- * @param md message digest to use
+ * @param type type of cipher to use.
+ * @param md message digest to use.
  * @param salt salt salt string, should be an binary 8 byte buffer.
  * @param data the password/input key string.
  * @param datalen length of data parameter.
@@ -1504,13 +1504,13 @@ EVP_CIPHER_CTX_rand_key(EVP_CIPHER_CTX *ctx, void *key)
 }
 
 /**
- * Perform a operation on a ctx
+ * Perform a operation on a ctx.
  *
  * @param ctx context to perform operation on.
  * @param type type of operation.
  * @param arg argument to operation.
  * @param data addition data to operation.
-
+ *
  * @return 1 for success, 0 for failure.
  *
  * @ingroup hcrypto_core

--- a/lib/hcrypto/pkcs5.c
+++ b/lib/hcrypto/pkcs5.c
@@ -46,7 +46,7 @@
  *
  * @param password Password.
  * @param password_len Length of password.
- * @param salt Salt
+ * @param salt Salt.
  * @param salt_len Length of salt.
  * @param iter iteration counter.
  * @param md the digest function.
@@ -132,7 +132,7 @@ PKCS5_PBKDF2_HMAC(const void * password, size_t password_len,
  *
  * @param password Password.
  * @param password_len Length of password.
- * @param salt Salt
+ * @param salt Salt.
  * @param salt_len Length of salt.
  * @param iter iteration counter.
  * @param keylen the output key length.

--- a/lib/hcrypto/rand.c
+++ b/lib/hcrypto/rand.c
@@ -74,8 +74,8 @@ init_method(void)
  * Seed that random number generator. Secret material can securely be
  * feed into the function, they will never be returned.
  *
- * @param indata seed data
- * @param size length seed data
+ * @param indata seed data.
+ * @param size length seed data.
  *
  * @ingroup hcrypto_rand
  */
@@ -90,8 +90,8 @@ RAND_seed(const void *indata, size_t size)
 /**
  * Get a random block from the random generator, can be used for key material.
  *
- * @param outdata random data
- * @param size length random data
+ * @param outdata random data.
+ * @param size length random data.
  *
  * @return 1 on success, 0 on failure.
  *
@@ -135,7 +135,6 @@ RAND_cleanup(void)
  * @param size size of in data.
  * @param entropi entropi in data.
  *
- *
  * @ingroup hcrypto_rand
  */
 
@@ -149,8 +148,8 @@ RAND_add(const void *indata, size_t size, double entropi)
 /**
  * Get a random block from the random generator, should NOT be used for key material.
  *
- * @param outdata random data
- * @param size length random data
+ * @param outdata random data.
+ * @param size length random data.
  *
  * @return 1 on success, 0 on failure.
  *
@@ -206,7 +205,7 @@ RAND_set_rand_method(const RAND_METHOD *meth)
 /**
  * Get the default random method.
  *
- * @return Returns a RAND_METHOD
+ * @return Returns a RAND_METHOD.
  *
  * @ingroup hcrypto_rand
  */
@@ -264,7 +263,7 @@ RAND_set_rand_engine(ENGINE *engine)
  * @param filename name of file to read.
  * @param size minimum size to read.
  *
- * @return Returns the number of seed bytes loaded (0 indicates failure)
+ * @return Returns the number of seed bytes loaded (0 indicates failure).
  *
  * @ingroup hcrypto_rand
  */
@@ -300,6 +299,7 @@ RAND_load_file(const char *filename, size_t size)
  * @param filename name of file to write.
  *
  * @return 1 on success and non-one on failure.
+ *
  * @ingroup hcrypto_rand
  */
 

--- a/lib/hcrypto/rnd_keys.c
+++ b/lib/hcrypto/rnd_keys.c
@@ -108,7 +108,7 @@ DES_new_random_key(DES_cblock *key)
 }
 
 /**
- * Seed the random number generator. Deprecated, use @ref page_rand
+ * Seed the random number generator. Deprecated, use @ref page_rand.
  *
  * @param seed a seed to seed that random number generate with.
  *

--- a/lib/hcrypto/rsa.c
+++ b/lib/hcrypto/rsa.c
@@ -132,6 +132,7 @@ RSA_new_method(ENGINE *engine)
  * Free an allocation RSA object.
  *
  * @param rsa the RSA object to free.
+ *
  * @ingroup hcrypto_rsa
  */
 
@@ -227,8 +228,8 @@ RSA_set_method(RSA *rsa, const RSA_METHOD *method)
 /**
  * Set the application data for the RSA object.
  *
- * @param rsa the rsa object to set the parameter for
- * @param arg the data object to store
+ * @param rsa the rsa object to set the parameter for.
+ * @param arg the data object to store.
  *
  * @return 1 on success.
  *
@@ -245,9 +246,9 @@ RSA_set_app_data(RSA *rsa, void *arg)
 /**
  * Get the application data for the RSA object.
  *
- * @param rsa the rsa object to get the parameter for
+ * @param rsa the rsa object to get the parameter for.
  *
- * @return the data object
+ * @return the data object.
  *
  * @ingroup hcrypto_rsa
  */

--- a/lib/hdb/ext.c
+++ b/lib/hdb/ext.c
@@ -697,10 +697,10 @@ hdb_validate_key_rotations(krb5_context context,
  * change.  One of `entry' and `krs' must be NULL, and the other non-NULL, and
  * whichever is given will be altered.
  *
- * @param context Context
- * @param entry An HDB entry
- * @param krs A key rotation extension for hdb_entry
- * @param kr A new KeyRotation value
+ * @param context Context.
+ * @param entry An HDB entry.
+ * @param krs A key rotation extension for hdb_entry.
+ * @param kr A new KeyRotation value.
  *
  * @return Zero on success, an error otherwise.
  */

--- a/lib/hdb/hdb-mitdb.c
+++ b/lib/hdb/hdb-mitdb.c
@@ -218,12 +218,12 @@ fix_salt(krb5_context context, hdb_entry *ent, Key *k)
  * This function takes a key from a krb5_storage from an MIT KDB encoded
  * entry and places it in the given Key object.
  *
- * @param context   Context
- * @param entry	    HDB entry
+ * @param context   Context.
+ * @param entry	    HDB entry.
  * @param sp	    krb5_storage with current offset set to the beginning of a
- *		    key
- * @param version   See comments in caller body for the backstory on this
- * @param k	    Key * to load the key into
+ *		    key.
+ * @param version   See comments in caller body for the backstory on this.
+ * @param k	    Key * to load the key into.
  */
 static krb5_error_code
 mdb_keyvalue2key(krb5_context context, hdb_entry *entry, krb5_storage *sp, uint16_t version, Key *k)
@@ -402,10 +402,10 @@ dup_similar_keys(krb5_context context, hdb_entry *entry)
  * This function parses an MIT krb5 encoded KDB entry and fills in the
  * given HDB entry with it.
  *
- * @param context	krb5_context
- * @param data		Encoded MIT KDB entry
- * @param target_kvno	Desired kvno, or 0 for the entry's current kvno
- * @param entry		Desired kvno, or 0 for the entry's current kvno
+ * @param context	krb5_context.
+ * @param data		Encoded MIT KDB entry.
+ * @param target_kvno	Desired kvno, or 0 for the entry's current kvno.
+ * @param entry		Desired kvno, or 0 for the entry's current kvno.
  */
 krb5_error_code
 _hdb_mdb_value2entry(krb5_context context, krb5_data *data,

--- a/lib/hdb/hdb-sqlite.c
+++ b/lib/hdb/hdb-sqlite.c
@@ -118,12 +118,12 @@ typedef struct hdb_sqlite_db {
 /**
  * Wrapper around sqlite3_prepare_v2.
  *
- * @param context   The current krb5 context
+ * @param context   The current krb5 context.
  * @param statement Where to store the pointer to the statement
- *                  after preparing it
- * @param str       SQL code for the statement
+ *                  after preparing it.
+ * @param str       SQL code for the statement.
  *
- * @return          0 if OK, an error code if not
+ * @return          0 if OK, an error code if not.
  */
 static krb5_error_code
 hdb_sqlite_prepare_stmt(krb5_context context,
@@ -265,12 +265,12 @@ finalize_stmts(krb5_context context, hdb_sqlite_db *hsdb)
 /**
  * A wrapper around sqlite3_exec.
  *
- * @param context    The current krb5 context
- * @param database   An open sqlite3 database handle
- * @param statement  SQL code to execute
- * @param error_code What to return if the statement fails
+ * @param context    The current krb5 context.
+ * @param database   An open sqlite3 database handle.
+ * @param statement  SQL code to execute.
+ * @param error_code What to return if the statement fails.
  *
- * @return           0 if OK, else error_code
+ * @return           0 if OK, else error_code.
  */
 static krb5_error_code
 hdb_sqlite_exec_stmt(krb5_context context,
@@ -334,10 +334,10 @@ static int hdb_sqlite_step(krb5_context, sqlite3 *, sqlite3_stmt *);
  * Opens an sqlite3 database handle to a file, may create the
  * database file depending on flags.
  *
- * @param context The current krb5 context
- * @param db      Heimdal database handle
+ * @param context The current krb5 context.
+ * @param db      Heimdal database handle.
  * @param flags   Controls whether or not the file may be created,
- *                may be 0 or SQLITE_OPEN_CREATE
+ *                may be 0 or SQLITE_OPEN_CREATE.
  */
 static krb5_error_code
 hdb_sqlite_open_database(krb5_context context, HDB *db, int flags)
@@ -382,8 +382,8 @@ hdb_sqlite_step(krb5_context context, sqlite3 *db, sqlite3_stmt *stmt)
 /**
  * Closes the database and frees memory allocated for statements.
  *
- * @param context The current krb5 context
- * @param db      Heimdal database handle
+ * @param context The current krb5 context.
+ * @param db      Heimdal database handle.
  */
 static krb5_error_code
 hdb_sqlite_close_database(krb5_context context, HDB *db)
@@ -407,11 +407,11 @@ hdb_sqlite_close_database(krb5_context context, HDB *db)
  * Opens an sqlite database file and prepares it for use.
  * If the file does not exist it will be created.
  *
- * @param context  The current krb5_context
- * @param db       The heimdal database handle
- * @param filename Where to store the database file
+ * @param context  The current krb5_context.
+ * @param db       The heimdal database handle.
+ * @param filename Where to store the database file.
  *
- * @return         0 if everything worked, an error code if not
+ * @return         0 if everything worked, an error code if not.
  */
 static krb5_error_code
 hdb_sqlite_make_database(krb5_context context, HDB *db, const char *filename)
@@ -485,13 +485,13 @@ hdb_sqlite_make_database(krb5_context context, HDB *db, const char *filename)
  * principal in the Principal database table, both
  * for canonical principals and aliases.
  *
- * @param context   The current krb5_context
- * @param db        Heimdal database handle
- * @param principal The principal whose entry to search for
- * @param flags     Currently only for HDB_F_DECRYPT
- * @param kvno	    kvno to fetch is HDB_F_KVNO_SPECIFIED use used
+ * @param context   The current krb5_context.
+ * @param db        Heimdal database handle.
+ * @param principal The principal whose entry to search for.
+ * @param flags     Currently only for HDB_F_DECRYPT.
+ * @param kvno	    kvno to fetch is HDB_F_KVNO_SPECIFIED use used.
  *
- * @return          0 if everything worked, an error code if not
+ * @return          0 if everything worked, an error code if not.
  */
 static krb5_error_code
 hdb_sqlite_fetch_kvno(krb5_context context, HDB *db, krb5_const_principal principal,
@@ -568,10 +568,10 @@ out:
  * Convenience function to step a prepared statement with no
  * value once.
  *
- * @param context   The current krb5_context
- * @param statement A prepared sqlite3 statement
+ * @param context   The current krb5_context.
+ * @param statement A prepared sqlite3 statement.
  *
- * @return        0 if everything worked, an error code if not
+ * @return        0 if everything worked, an error code if not.
  */
 static krb5_error_code
 hdb_sqlite_step_once(krb5_context context, HDB *db, sqlite3_stmt *statement)
@@ -591,12 +591,12 @@ hdb_sqlite_step_once(krb5_context context, HDB *db, sqlite3_stmt *statement)
  * Stores an hdb_entry in the database. If flags contains HDB_F_REPLACE
  * a previous entry may be replaced.
  *
- * @param context The current krb5_context
- * @param db      Heimdal database handle
- * @param flags   May currently only contain HDB_F_REPLACE
- * @param entry   The data to store
+ * @param context The current krb5_context.
+ * @param db      Heimdal database handle.
+ * @param flags   May currently only contain HDB_F_REPLACE.
+ * @param entry   The data to store.
  *
- * @return        0 if everything worked, an error code if not
+ * @return        0 if everything worked, an error code if not.
  */
 static krb5_error_code
 hdb_sqlite_store(krb5_context context, HDB *db, unsigned flags,
@@ -770,10 +770,10 @@ rollback:
  * and closing/opening the handle is an expensive operation.
  * Hence, this function does nothing.
  *
- * @param context The current krb5 context
- * @param db      Heimdal database handle
+ * @param context The current krb5 context.
+ * @param db      Heimdal database handle.
  *
- * @return        Always returns 0
+ * @return        Always returns 0.
  */
 static krb5_error_code
 hdb_sqlite_close(krb5_context context, HDB *db)
@@ -786,10 +786,10 @@ hdb_sqlite_close(krb5_context context, HDB *db)
  * many open handles to the database file the handle does not
  * need to be closed, or reopened.
  *
- * @param context The current krb5 context
- * @param db      Heimdal database handle
- * @param flags
- * @param mode_t
+ * @param context The current krb5 context.
+ * @param db      Heimdal database handle.
+ * @param flags.
+ * @param mode_t.
  *
  * @return        Always returns 0
  */
@@ -802,10 +802,10 @@ hdb_sqlite_open(krb5_context context, HDB *db, int flags, mode_t mode)
 /**
  * Closes the databse and frees all resources.
  *
- * @param context The current krb5 context
- * @param db      Heimdal database handle
+ * @param context The current krb5 context.
+ * @param db      Heimdal database handle.
  *
- * @return        0 on success, an error code if not
+ * @return        0 on success, an error code if not.
  */
 static krb5_error_code
 hdb_sqlite_destroy(krb5_context context, HDB *db)
@@ -1009,9 +1009,9 @@ hdb_sqlite_remove(krb5_context context, HDB *db,
  *
  * @param context A Kerberos 5 context.
  * @param db a returned database handle.
- * @param filename filename
+ * @param filename filename.
  *
- * @return        0 on success, an error code if not
+ * @return        0 on success, an error code if not.
  */
 
 krb5_error_code

--- a/lib/hdb/hdb.c
+++ b/lib/hdb/hdb.c
@@ -107,9 +107,9 @@ static struct hdb_method methods[] = {
  * Returns the Keys of `e' for `kvno', or NULL if not found.  The Keys will
  * remain valid provided that the entry is not mutated.
  *
- * @param context Context
- * @param e The HDB entry
- * @param kvno The kvno
+ * @param context Context.
+ * @param e The HDB entry.
+ * @param kvno The kvno.
  *
  * @return A pointer to the Keys for the requested kvno.
  */
@@ -165,10 +165,10 @@ dequeue_HDB_Ext_KeySet(HDB_Ext_KeySet *data, unsigned int element, hdb_keyset *k
 /**
  * Removes from `e' and optionally outputs the keyset for the requested `kvno'.
  *
- * @param context Context
- * @param e The HDB entry
- * @param kvno The key version number
- * @param ks A pointer to a variable of type hdb_keyset (may be NULL)
+ * @param context Context.
+ * @param e The HDB entry.
+ * @param kvno The key version number.
+ * @param ks A pointer to a variable of type hdb_keyset (may be NULL).
  *
  * @return Zero on success, an error code otherwise.
  */
@@ -229,10 +229,10 @@ hdb_remove_keys(krb5_context context,
  * Removes from `e' and outputs all the base keys for virtual principal and/or
  * key derivation.
  *
- * @param context Context
- * @param e The HDB entry
- * @param ks A pointer to a variable of type HDB_Ext_KeySet
- * @param ckr A pointer to stable (copied) HDB_Ext_KeyRotation
+ * @param context Context.
+ * @param e The HDB entry.
+ * @param ks A pointer to a variable of type HDB_Ext_KeySet.
+ * @param ckr A pointer to stable (copied) HDB_Ext_KeyRotation.
  *
  * @return Zero on success, an error code otherwise.
  */
@@ -278,10 +278,10 @@ _hdb_remove_base_keys(krb5_context context,
  * Removes from `e' and outputs all the base keys for virtual principal and/or
  * key derivation.
  *
- * @param context Context
- * @param e The HDB entry
- * @param is_current_keyset Whether to make the keys the current keys for `e'
- * @param ks A pointer to an hdb_keyset containing the keys to set
+ * @param context Context.
+ * @param e The HDB entry.
+ * @param is_current_keyset Whether to make the keys the current keys for `e'.
+ * @param ks A pointer to an hdb_keyset containing the keys to set.
  *
  * @return Zero on success, an error code otherwise.
  */
@@ -720,9 +720,9 @@ load_config(krb5_context context, HDB *db)
  * ".db".  Also, for backends such as "ldap:" and "ldapi:" the
  * `filename' is more like a URI.
  *
- * @param [in] context Context
- * @param [out] db HDB handle output
- * @param [in] filename The name of the HDB
+ * @param [in] context Context.
+ * @param [out] db HDB handle output.
+ * @param [in] filename The name of the HDB.
  *
  * @return Zero on success else a krb5 error code.
  */

--- a/lib/hdb/keys.c
+++ b/lib/hdb/keys.c
@@ -203,9 +203,9 @@ parse_key_set(krb5_context context, const char *key,
 /**
  * This function prunes an HDB entry's historic keys by kvno.
  *
- * @param context   Context
- * @param entry	    HDB entry
- * @param kvno      Keyset kvno to prune, or zero to prune all too-old keys
+ * @param context   Context.
+ * @param entry	    HDB entry.
+ * @param kvno      Keyset kvno to prune, or zero to prune all too-old keys.
  */
 krb5_error_code
 hdb_prune_keys_kvno(krb5_context context, hdb_entry *entry, int kvno)
@@ -276,8 +276,8 @@ hdb_prune_keys_kvno(krb5_context context, hdb_entry *entry, int kvno)
  * This function prunes an HDB entry's keys that are too old to have been used
  * to mint still valid tickets (based on the entry's maximum ticket lifetime).
  * 
- * @param context   Context
- * @param entry	    HDB entry
+ * @param context   Context.
+ * @param entry	    HDB entry.
  */
 krb5_error_code
 hdb_prune_keys(krb5_context context, hdb_entry *entry)
@@ -291,10 +291,10 @@ hdb_prune_keys(krb5_context context, hdb_entry *entry)
 /**
  * This function adds a keyset to an HDB entry's key history.
  *
- * @param context   Context
- * @param entry	    HDB entry
- * @param kvno	    Key version number of the key to add to the history
- * @param key	    The Key to add
+ * @param context   Context.
+ * @param entry	    HDB entry.
+ * @param kvno	    Key version number of the key to add to the history.
+ * @param key	    The Key to add.
  */
 krb5_error_code
 hdb_add_history_keyset(krb5_context context,
@@ -340,8 +340,8 @@ hdb_add_history_keyset(krb5_context context,
  * history.  The current keyset is left alone; the caller is responsible
  * for freeing it.
  *
- * @param context   Context
- * @param entry	    HDB entry
+ * @param context   Context.
+ * @param entry	    HDB entry.
  *
  * @return Zero on success, or an error code otherwise.
  */
@@ -372,10 +372,10 @@ hdb_add_current_keys_to_history(krb5_context context, hdb_entry *entry)
 /**
  * This function adds a key to an HDB entry's key history.
  *
- * @param context   Context
- * @param entry	    HDB entry
- * @param kvno	    Key version number of the key to add to the history
- * @param key	    The Key to add
+ * @param context   Context.
+ * @param entry	    HDB entry.
+ * @param kvno	    Key version number of the key to add to the history.
+ * @param key	    The Key to add.
  *
  * @return Zero on success, or an error code otherwise.
  */
@@ -432,9 +432,9 @@ out:
  * set with a historical keyset.  If no historical keys are found then
  * an error is returned (the caller can still set entry->kvno directly).
  *
- * @param context	krb5_context
- * @param new_kvno	New kvno for the entry
- * @param entry		hdb_entry to modify
+ * @param context	krb5_context.
+ * @param new_kvno	New kvno for the entry.
+ * @param entry		hdb_entry to modify.
  */
 krb5_error_code
 hdb_change_kvno(krb5_context context, krb5_kvno new_kvno, hdb_entry *entry)

--- a/lib/hx509/ca.c
+++ b/lib/hx509/ca.c
@@ -130,7 +130,7 @@ hx509_ca_tbs_free(hx509_ca_tbs *tbs)
  *
  * @param context A hx509 context.
  * @param tbs object to be signed.
- * @param t time the certificated will start to be valid
+ * @param t time the certificated will start to be valid.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -151,7 +151,7 @@ hx509_ca_tbs_set_notBefore(hx509_context context,
  *
  * @param context A hx509 context.
  * @param tbs object to be signed.
- * @param t time when the certificate will expire
+ * @param t time when the certificate will expire.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -429,7 +429,7 @@ hx509_ca_tbs_set_serialnumber(hx509_context context,
  *
  * @param context A hx509 context.
  * @param tbs object to be signed.
- * @param req CSR
+ * @param req CSR.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -1447,8 +1447,8 @@ hx509_ca_tbs_set_subject(hx509_context context,
  *
  * @param context A hx509 context.
  * @param tbs object to be signed.
- * @param issuerUniqueID to be set
- * @param subjectUniqueID to be set
+ * @param issuerUniqueID to be set.
+ * @param subjectUniqueID to be set.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -1525,7 +1525,7 @@ hx509_ca_tbs_get_name(hx509_ca_tbs tbs)
  *
  * @param context A hx509 context.
  * @param tbs object to be signed.
- * @param sigalg signature algorithm to use
+ * @param sigalg signature algorithm to use.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *

--- a/lib/hx509/cert.c
+++ b/lib/hx509/cert.c
@@ -243,7 +243,7 @@ hx509_set_warn_dest(hx509_context context, heim_log_facility *fac)
  *
  * @param context hx509 context to change the flag for.
  * @param flag zero, revocation method required, non zero missing
- * revocation method ok
+ * revocation method ok.
  *
  * @ingroup hx509_verify
  */
@@ -336,10 +336,10 @@ cert_init(hx509_context context, heim_error_t *error)
  * certificate `c´.
  *
  * @param context A hx509 context.
- * @param c
- * @param error
+ * @param c.
+ * @param error.
  *
- * @return Returns an hx509 certificate
+ * @return Returns an hx509 certificate.
  *
  * @ingroup hx509_cert
  */
@@ -373,10 +373,10 @@ hx509_cert_init(hx509_context context, const Certificate *c, heim_error_t *error
  * Copy a certificate object, but drop any private key assignment.
  *
  * @param context A hx509 context.
- * @param src Certificate object
- * @param error
+ * @param src Certificate object.
+ * @param error.
  *
- * @return Returns an hx509 certificate
+ * @return Returns an hx509 certificate.
  *
  * @ingroup hx509_cert
  */
@@ -394,10 +394,10 @@ hx509_cert_copy_no_private_key(hx509_context context,
  * (but no Certificate).
  *
  * @param context A hx509 context.
- * @param key
- * @param error
+ * @param key.
+ * @param error.
  *
- * @return Returns an hx509 certificate
+ * @return Returns an hx509 certificate.
  *
  * @ingroup hx509_cert
  */
@@ -426,9 +426,9 @@ hx509_cert_init_private_key(hx509_context context,
  * @param context A hx509 context.
  * @param ptr pointer to memory region containing encoded certificate.
  * @param len length of memory region.
- * @param error possibly returns an error
+ * @param error possibly returns an error.
  *
- * @return An hx509 certificate
+ * @return An hx509 certificate.
  *
  * @ingroup hx509_cert
  */
@@ -607,7 +607,7 @@ hx509_verify_destroy_ctx(hx509_verify_ctx ctx)
  * independent of the destruction of the verification context (ctx).
  * If there already is a keyset attached, it's released.
  *
- * @param ctx a verification context
+ * @param ctx a verification context.
  * @param set a keyset containing the trust anchors.
  *
  * @ingroup hx509_verify
@@ -671,7 +671,7 @@ _hx509_verify_get_time(hx509_verify_ctx ctx)
  * Set the maximum depth of the certificate chain that the path
  * builder is going to try.
  *
- * @param ctx a verification context
+ * @param ctx a verification context.
  * @param max_depth maxium depth of the certificate chain, include
  * trust anchor.
  *
@@ -687,7 +687,7 @@ hx509_verify_set_max_depth(hx509_verify_ctx ctx, unsigned int max_depth)
 /**
  * Allow or deny the use of proxy certificates
  *
- * @param ctx a verification context
+ * @param ctx a verification context.
  * @param boolean if non zero, allow proxy certificates.
  *
  * @ingroup hx509_verify
@@ -707,7 +707,7 @@ hx509_verify_set_proxy_certificate(hx509_verify_ctx ctx, int boolean)
  * checking key usage on CA certificates, this will make version 1
  * certificiates unuseable.
  *
- * @param ctx a verification context
+ * @param ctx a verification context.
  * @param boolean if non zero, use strict verification.
  *
  * @ingroup hx509_verify
@@ -726,10 +726,9 @@ hx509_verify_set_strict_rfc3280_verification(hx509_verify_ctx ctx, int boolean)
  * Allow using the operating system builtin trust anchors if no other
  * trust anchors are configured.
  *
- * @param ctx a verification context
+ * @param ctx a verification context.
  * @param boolean if non zero, useing the operating systems builtin
  * trust anchors.
- *
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -1671,7 +1670,7 @@ hx509_cert_get_serialnumber(hx509_cert p, heim_integer *i)
  *
  * @param p a hx509 certificate object.
  *
- * @return return not before time
+ * @return return not before time.
  *
  * @ingroup hx509_cert
  */
@@ -1830,13 +1829,13 @@ get_x_unique_id(hx509_context context, const char *name,
 /**
  * Get a copy of the Issuer Unique ID
  *
- * @param context a hx509_context
- * @param p a hx509 certificate
- * @param issuer the issuer id returned, free with der_free_bit_string()
+ * @param context a hx509_context.
+ * @param p a hx509 certificate.
+ * @param issuer the issuer id returned, free with der_free_bit_string().
  *
  * @return An hx509 error code, see hx509_get_error_string(). The
  * error code HX509_EXTENSION_NOT_FOUND is returned if the certificate
- * doesn't have a issuerUniqueID
+ * doesn't have a issuerUniqueID.
  *
  * @ingroup hx509_cert
  */
@@ -1848,15 +1847,15 @@ hx509_cert_get_issuer_unique_id(hx509_context context, hx509_cert p, heim_bit_st
 }
 
 /**
- * Get a copy of the Subect Unique ID
+ * Get a copy of the Subect Unique ID.
  *
- * @param context a hx509_context
- * @param p a hx509 certificate
- * @param subject the subject id returned, free with der_free_bit_string()
+ * @param context a hx509_context.
+ * @param p a hx509 certificate.
+ * @param subject the subject id returned, free with der_free_bit_string().
  *
  * @return An hx509 error code, see hx509_get_error_string(). The
  * error code HX509_EXTENSION_NOT_FOUND is returned if the certificate
- * doesn't have a subjectUniqueID
+ * doesn't have a subjectUniqueID.
  *
  * @ingroup hx509_cert
  */
@@ -1877,7 +1876,7 @@ _hx509_cert_private_key(hx509_cert p)
 /**
  * Indicate whether a hx509_cert has a private key.
  *
- * @param p a hx509 certificate
+ * @param p a hx509 certificate.
  *
  * @return 1 if p has a private key, 0 otherwise.
  *
@@ -1892,7 +1891,7 @@ hx509_cert_have_private_key(hx509_cert p)
 /**
  * Indicate whether a hx509_cert has a private key only (no certificate).
  *
- * @param p a hx509 certificate
+ * @param p a hx509 certificate.
  *
  * @return 1 if p has a private key only (no certificate), 0 otherwise.
  *
@@ -2753,15 +2752,15 @@ _hx509_verify_signature_bitstring(hx509_context context,
  * and address.
  *
  * @param context A hx509 context.
- * @param cert the certificate to match with
+ * @param cert the certificate to match with.
  * @param flags Flags to modify the behavior:
  * - HX509_VHN_F_ALLOW_NO_MATCH no match is ok
  * @param type type of hostname:
  * - HX509_HN_HOSTNAME for plain hostname.
  * - HX509_HN_DNSSRV for DNS SRV names.
- * @param hostname the hostname to check
- * @param sa address of the host
- * @param sa_size length of address
+ * @param hostname the hostname to check.
+ * @param sa address of the host.
+ * @param sa_size length of address.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -2909,7 +2908,7 @@ _hx509_set_cert_attribute(hx509_context context,
  * Get an external attribute for the certificate, examples are
  * friendly name and id.
  *
- * @param cert hx509 certificate object to search
+ * @param cert hx509 certificate object to search.
  * @param oid an oid to search for.
  *
  * @return an hx509_cert_attribute, only valid as long as the
@@ -2931,7 +2930,7 @@ hx509_cert_get_attribute(hx509_cert cert, const heim_oid *oid)
 /**
  * Set the friendly name on the certificate.
  *
- * @param cert The certificate to set the friendly name on
+ * @param cert The certificate to set the friendly name on.
  * @param name Friendly name.
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -3078,8 +3077,8 @@ hx509_query_match_option(hx509_query *q, hx509_query_option option)
  * Set the issuer and serial number of match in the query
  * controller. The function make copies of the isser and serial number.
  *
- * @param q a hx509 query controller
- * @param issuer issuer to search for
+ * @param q a hx509 query controller.
+ * @param issuer issuer to search for.
  * @param serialNumber the serialNumber of the issuer.
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -3127,7 +3126,7 @@ hx509_query_match_issuer_serial(hx509_query *q,
  * Set the query controller to match on a friendly name
  *
  * @param q a hx509 query controller.
- * @param name a friendly name to match on
+ * @param name a friendly name to match on.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -3437,7 +3436,7 @@ _hx509_query_match_cert(hx509_context context, const hx509_query *q, hx509_cert 
  * Set a statistic file for the query statistics.
  *
  * @param context A hx509 context.
- * @param fn statistics file name
+ * @param fn statistics file name.
  *
  * @ingroup hx509_cert
  */
@@ -3507,7 +3506,7 @@ stat_sort(const void *a, const void *b)
  * Unparse the statistics file and print the result on a FILE descriptor.
  *
  * @param context A hx509 context.
- * @param printtype tyep to print
+ * @param printtype tyep to print.
  * @param out the FILE to write the data on.
  *
  * @ingroup hx509_cert
@@ -3593,7 +3592,7 @@ hx509_query_unparse_stats(hx509_context context, int printtype, FILE *out)
  *
  * @param context A hx509 context.
  * @param cert A hx509 context.
- * @param eku the EKU to check for
+ * @param eku the EKU to check for.
  * @param allow_any_eku if the any EKU is set, allow that to be a
  * substitute.
  *
@@ -3888,13 +3887,13 @@ out:
 }
 
 /**
- * Print a simple representation of a certificate
+ * Print a simple representation of a certificate.
  *
- * @param context A hx509 context, can be NULL
- * @param cert certificate to print
- * @param out the stdio output stream, if NULL, stdout is used
+ * @param context A hx509 context, can be NULL.
+ * @param cert certificate to print.
+ * @param out the stdio output stream, if NULL, stdout is used.
  *
- * @return An hx509 error code
+ * @return An hx509 error code.
  *
  * @ingroup hx509_cert
  */

--- a/lib/hx509/cms.c
+++ b/lib/hx509/cms.c
@@ -549,7 +549,7 @@ out:
  * @param length length of the data that data point to.
  * @param encryption_type Encryption cipher to use for the bulk data,
  * use NULL to get default.
- * @param contentType type of the data that is encrypted
+ * @param contentType type of the data that is encrypted.
  * @param content the output of the function,
  * free with der_free_octet_string().
  *
@@ -838,7 +838,7 @@ hx509_cms_verify_signed(hx509_context context,
  * @param signer_certs list of the cerficates used to sign this
  * request, free with hx509_certs_free().
  * @param verify_flags flags indicating whether the certificate
- * was verified or not
+ * was verified or not.
  *
  * @return an hx509 error code.
  *
@@ -1193,9 +1193,9 @@ add_one_attribute(Attribute **attr,
  * Sign and encode a SignedData structure.
  *
  * @param context A hx509 context.
- * @param flags
+ * @param flags.
  * @param eContentType the type of the data.
- * @param data data to sign
+ * @param data data to sign.
  * @param length length of the data that data points to.
  * @param digest_alg digest algorithm to use, use NULL to get the
  * default or the peer determined algorithm.
@@ -1203,7 +1203,7 @@ add_one_attribute(Attribute **attr,
  * @param peer info about the peer the message to send the message to,
  * like what digest algorithm to use.
  * @param anchors trust anchors that the client will use, used to
- * polulate the certificates included in the message
+ * polulate the certificates included in the message.
  * @param pool certificates to use in try to build the path to the
  * trust anchors.
  * @param signed_data the output of the function, free with

--- a/lib/hx509/env.c
+++ b/lib/hx509/env.c
@@ -44,8 +44,8 @@
  *
  * @param context A hx509 context.
  * @param env environment to add the environment variable too.
- * @param key key to add
- * @param value value to add
+ * @param key key to add.
+ * @param value value to add.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -95,8 +95,8 @@ hx509_env_add(hx509_context context, hx509_env *env,
  *
  * @param context A hx509 context.
  * @param env environment to add the environment variable too.
- * @param key key to add
- * @param list binding list to add
+ * @param key key to add.
+ * @param list binding list to add.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *

--- a/lib/hx509/error.c
+++ b/lib/hx509/error.c
@@ -68,10 +68,10 @@ hx509_clear_error_string(hx509_context context)
  * @param context A hx509 context.
  * @param flags
  * - HX509_ERROR_APPEND appends the error string to the old messages
-     (code is updated).
- * @param code error code related to error message
- * @param fmt error message format
- * @param ap arguments to error message format
+ *   (code is updated).
+ * @param code error code related to error message.
+ * @param fmt error message format.
+ * @param ap arguments to error message format.
  *
  * @ingroup hx509_error
  */
@@ -100,10 +100,10 @@ hx509_set_error_stringv(hx509_context context, int flags, int code,
  * @param context A hx509 context.
  * @param flags
  * - HX509_ERROR_APPEND appends the error string to the old messages
-     (code is updated).
- * @param code error code related to error message
- * @param fmt error message format
- * @param ... arguments to error message format
+ *   (code is updated).
+ * @param code error code related to error message.
+ * @param fmt error message format.
+ * @param ... arguments to error message format.
  *
  * @ingroup hx509_error
  */
@@ -187,7 +187,7 @@ hx509_free_error_string(char *str)
 }
 
 /**
- * Print error message and fatally exit from error code
+ * Print error message and fatally exit from error code.
  *
  * @param context A hx509 context.
  * @param exit_code exit() code from process.

--- a/lib/hx509/keyset.c
+++ b/lib/hx509/keyset.c
@@ -98,7 +98,7 @@ _hx509_ks_register(hx509_context context, struct hx509_keyset_ops *ops)
 /**
  * Open or creates a new hx509 certificate store.
  *
- * @param context A hx509 context
+ * @param context A hx509 context.
  * @param name name of the store, format is TYPE:type-specific-string,
  * if NULL is used the MEMORY store is used.
  * @param flags list of flags:
@@ -177,8 +177,8 @@ hx509_certs_init(hx509_context context,
 /**
  * Destroys and frees a hx509 certificate store.
  *
- * @param context A hx509 context
- * @param certs A store to destroy
+ * @param context A hx509 context.
+ * @param certs A store to destroy.
  *
  * @return Returns an hx509 error code.
  *
@@ -209,7 +209,7 @@ hx509_certs_destroy(hx509_context context,
  *
  * @param context A hx509 context.
  * @param certs a certificate store to store.
- * @param flags currently one flag is defined: HX509_CERTS_STORE_NO_PRIVATE_KEYS
+ * @param flags currently one flag is defined: HX509_CERTS_STORE_NO_PRIVATE_KEYS.
  * @param lock a lock that unlocks the certificates store, use NULL to
  * select no password/certifictes/prompt lock (see @ref page_lock).
  *
@@ -274,10 +274,10 @@ hx509_certs_free(hx509_certs *certs)
 }
 
 /**
- * Start the integration
+ * Start the integration.
  *
  * @param context a hx509 context.
- * @param certs certificate store to iterate over
+ * @param certs certificate store to iterate over.
  * @param cursor cursor that will keep track of progress, free with
  * hx509_certs_end_seq().
  *
@@ -444,7 +444,7 @@ hx509_certs_iter(hx509_context context,
  *
  * @param context a hx509 context.
  * @param ctx used by hx509_certs_iter_f().
- * @param c a certificate
+ * @param c a certificate.
  *
  * @return Returns an hx509 error code.
  *
@@ -689,7 +689,7 @@ hx509_certs_merge(hx509_context context, hx509_certs to, hx509_certs from)
  * @param to the store to merge into.
  * @param lock a lock that unlocks the certificates store, use NULL to
  * select no password/certifictes/prompt lock (see @ref page_lock).
- * @param name name of the source store
+ * @param name name of the source store.
  *
  * @return Returns an hx509 error code.
  *

--- a/lib/hx509/name.c
+++ b/lib/hx509/name.c
@@ -226,8 +226,8 @@ stringtooid(const char *name, size_t len, heim_oid *oid)
  * Convert the hx509 name object into a printable string.
  * The resulting string should be freed with free().
  *
- * @param name name to print
- * @param str the string to return
+ * @param name name to print.
+ * @param str the string to return.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -804,8 +804,8 @@ out:
  * Copy a hx509 name object.
  *
  * @param context A hx509 cotext.
- * @param from the name to copy from
- * @param to the name to copy to
+ * @param from the name to copy from.
+ * @param to the name to copy to.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -832,8 +832,8 @@ hx509_name_copy(hx509_context context, const hx509_name from, hx509_name *to)
 /**
  * Convert a hx509_name into a Name.
  *
- * @param from the name to copy from
- * @param to the name to copy to
+ * @param from the name to copy from.
+ * @param to the name to copy to.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -1051,8 +1051,8 @@ hx509_name_free(hx509_name *name)
 /**
  * Convert a DER encoded name info a string.
  *
- * @param data data to a DER/BER encoded name
- * @param length length of data
+ * @param data data to a DER/BER encoded name.
+ * @param length length of data.
  * @param str the resulting string, is NULL on failure.
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -1079,8 +1079,8 @@ hx509_unparse_der_name(const void *data, size_t length, char **str)
 /**
  * Convert a hx509_name object to DER encoded name.
  *
- * @param name name to concert
- * @param os data to a DER encoded name, free the resulting octet
+ * @param name name to concert.
+ * @param os data to a DER encoded name, free the resulting octet.
  * string with hx509_xfree(os->data).
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -1384,8 +1384,8 @@ struct {
 /**
  * Unparse the hx509 name in name into a string.
  *
- * @param name the name to print
- * @param str an allocated string returns the name in string form
+ * @param name the name to print.
+ * @param str an allocated string returns the name in string form.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -1408,9 +1408,9 @@ hx509_general_name_unparse(GeneralName *name, char **str)
 /**
  * Unparse the hx509 name in name into a string.
  *
- * @param context hx509 library context
- * @param name the name to print
- * @param str an allocated string returns the name in string form
+ * @param context hx509 library context.
+ * @param name the name to print.
+ * @param str an allocated string returns the name in string form.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *

--- a/lib/hx509/peer.c
+++ b/lib/hx509/peer.c
@@ -103,7 +103,7 @@ hx509_peer_info_free(hx509_peer_info peer)
 /**
  * Set the certificate that remote peer is using.
  *
- * @param peer peer info to update
+ * @param peer peer info to update.
  * @param cert cerificate of the remote peer.
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -125,8 +125,8 @@ hx509_peer_info_set_cert(hx509_peer_info peer,
  * Add an additional algorithm that the peer supports.
  *
  * @param context A hx509 context.
- * @param peer the peer to set the new algorithms for
- * @param val an AlgorithmsIdentier to add
+ * @param peer the peer to set the new algorithms for.
+ * @param val an AlgorithmsIdentier to add.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -159,8 +159,8 @@ hx509_peer_info_add_cms_alg(hx509_context context,
  * Set the algorithms that the peer supports.
  *
  * @param context A hx509 context.
- * @param peer the peer to set the new algorithms for
- * @param val array of supported AlgorithmsIdentiers
+ * @param peer the peer to set the new algorithms for.
+ * @param val array of supported AlgorithmsIdentiers.
  * @param len length of array val.
  *
  * @return An hx509 error code, see hx509_get_error_string().

--- a/lib/hx509/print.c
+++ b/lib/hx509/print.c
@@ -117,7 +117,7 @@ print_func(hx509_vprint_func func, void *ctx, const char *fmt, ...)
 /**
  * Print a oid to a string.
  *
- * @param oid oid to print
+ * @param oid oid to print.
  * @param str allocated string, free with hx509_xfree().
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -135,7 +135,7 @@ hx509_oid_sprint(const heim_oid *oid, char **str)
  * Print a oid using a hx509_vprint_func function. To print to stdout
  * use hx509_print_stdout().
  *
- * @param oid oid to print
+ * @param oid oid to print.
  * @param func hx509_vprint_func to print with.
  * @param ctx context variable to hx509_vprint_func function.
  *
@@ -906,7 +906,7 @@ struct {
  * @param context A hx509 context.
  * @param ctx a new allocated hx509 validation context, free with
  * hx509_validate_ctx_free().
-
+ *
  * @return An hx509 error code, see hx509_get_error_string().
  *
  * @ingroup hx509_print
@@ -981,7 +981,7 @@ hx509_validate_ctx_free(hx509_validate_ctx ctx)
  * @param context A hx509 context.
  * @param ctx A hx509 validation context.
  * @param cert the cerificate to validate/print.
-
+ *
  * @return An hx509 error code, see hx509_get_error_string().
  *
  * @ingroup hx509_print

--- a/lib/hx509/req.c
+++ b/lib/hx509/req.c
@@ -107,11 +107,11 @@ hx509_request_free(hx509_request *reqp)
 }
 
 /**
- * Make the CSR request a CA certificate
+ * Make the CSR request a CA certificate.
  *
  * @param context An hx509 context.
  * @param req The hx509_request to alter.
- * @param pathLenConstraint the pathLenConstraint for the BasicConstraints (optional)
+ * @param pathLenConstraint the pathLenConstraint for the BasicConstraints (optional).
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -134,7 +134,7 @@ hx509_request_set_cA(hx509_context context,
 }
 
 /**
- * Make the CSR request an EE (end-entity, i.e., not a CA) certificate
+ * Make the CSR request an EE (end-entity, i.e., not a CA) certificate.
  *
  * @param context An hx509 context.
  * @param req The hx509_request to alter.
@@ -314,7 +314,7 @@ hx509_request_add_eku(hx509_context context,
 /**
  * Add a GeneralName (Jabber ID) subject alternative name to a CSR.
  *
- * XXX Make this take a heim_octet_string, not a GeneralName*.
+ * @todo Make this take a heim_octet_string, not a GeneralName*.
  *
  * @param context An hx509 context.
  * @param req The hx509_request object.
@@ -995,7 +995,7 @@ out:
  * Parse an encoded CSR and verify its self-signature.
  *
  * @param context An hx509 context.
- * @param csr The name of a store containing the CSR ("PKCS10:/path/to/file")
+ * @param csr The name of a store containing the CSR ("PKCS10:/path/to/file").
  * @param req Where to put request object.
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -1037,9 +1037,9 @@ hx509_request_parse(hx509_context context,
  *
  * @param context An hx509 context.
  * @param req The hx509_request object.
- * @param idx The index of the EKU (0 for the first) to return
+ * @param idx The index of the EKU (0 for the first) to return.
  * @param out A pointer to a char * variable where the OID will be placed
- *            (caller must free with free())
+ *            (caller must free with free()).
  *
  * @return Zero on success, HX509_NO_ITEM if no such item exists (denoting
  *         iteration end), or an error.
@@ -1161,7 +1161,7 @@ reject_feat(hx509_request req, abitstring a, size_t n, int idx)
  * Authorize issuance of a CA certificate as requested.
  *
  * @param req The hx509_request object.
- * @param pathLenConstraint the pathLenConstraint for the BasicConstraints (optional)
+ * @param pathLenConstraint the pathLenConstraint for the BasicConstraints (optional).
  *
  * @return an hx509 or system error.
  *
@@ -1181,7 +1181,7 @@ hx509_request_authorize_cA(hx509_request req, unsigned *pathLenConstraint)
  * Filter the requested KeyUsage and mark it authorized.
  *
  * @param req The hx509_request object.
- * @param ku Permitted KeyUsage
+ * @param ku Permitted KeyUsage.
  *
  * @ingroup hx509_request
  */
@@ -1199,7 +1199,7 @@ hx509_request_authorize_ku(hx509_request req, KeyUsage ku)
  *
  * @param req The hx509_request object.
  * @param idx The index of an EKU that can be fetched with
- *            hx509_request_get_eku()
+ *            hx509_request_get_eku().
  *
  * @return Zero on success, an error otherwise.
  *
@@ -1216,7 +1216,7 @@ hx509_request_authorize_eku(hx509_request req, size_t idx)
  *
  * @param req The hx509_request object.
  * @param idx The index of an EKU that can be fetched with
- *            hx509_request_get_eku()
+ *            hx509_request_get_eku().
  *
  * @return Zero on success, an error otherwise.
  *
@@ -1233,7 +1233,7 @@ hx509_request_reject_eku(hx509_request req, size_t idx)
  *
  * @param req The hx509_request object.
  * @param idx The index of an EKU that can be fetched with
- *            hx509_request_get_eku()
+ *            hx509_request_get_eku().
  *
  * @return Non-zero if authorized, zero if not.
  *
@@ -1282,7 +1282,7 @@ hx509_request_reject_san(hx509_request req, size_t idx)
  *
  * @param req The hx509_request object.
  * @param idx The index of a SAN that can be fetched with
- *            hx509_request_get_san()
+ *            hx509_request_get_san().
  *
  * @return Non-zero if authorized, zero if not.
  *

--- a/lib/hx509/revoke.c
+++ b/lib/hx509/revoke.c
@@ -132,7 +132,7 @@ free_ocsp(struct revoke_ocsp *ocsp)
 /**
  * Free a hx509 revocation context.
  *
- * @param ctx context to be freed
+ * @param ctx context to be freed.
  *
  * @ingroup hx509_revoke
  */
@@ -392,8 +392,8 @@ load_ocsp(hx509_context context, struct revoke_ocsp *ocsp)
 /**
  * Add a OCSP file to the revocation context.
  *
- * @param context hx509 context
- * @param ctx hx509 revocation context
+ * @param context hx509 context.
+ * @param ctx hx509 revocation context.
  * @param path path to file that is going to be added to the context.
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -628,8 +628,8 @@ load_crl(hx509_context context, const char *path, time_t *t, CRLCertificateList 
 /**
  * Add a CRL file to the revocation context.
  *
- * @param context hx509 context
- * @param ctx hx509 revocation context
+ * @param context hx509 context.
+ * @param ctx hx509 revocation context.
  * @param path path to file that is going to be added to the context.
  *
  * @return An hx509 error code, see hx509_get_error_string().
@@ -695,12 +695,12 @@ hx509_revoke_add_crl(hx509_context context,
  * context. Also need the parent certificate to check the OCSP
  * parent identifier.
  *
- * @param context hx509 context
- * @param ctx hx509 revocation context
- * @param certs
- * @param now
- * @param cert
- * @param parent_cert
+ * @param context hx509 context.
+ * @param ctx hx509 revocation context.
+ * @param certs.
+ * @param now.
+ * @param cert.
+ * @param parent_cert.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -980,12 +980,12 @@ out:
 /**
  * Create an OCSP request for a set of certificates.
  *
- * @param context a hx509 context
- * @param reqcerts list of certificates to request ocsp data for
- * @param pool certificate pool to use when signing
- * @param signer certificate to use to sign the request
+ * @param context a hx509 context.
+ * @param reqcerts list of certificates to request ocsp data for.
+ * @param pool certificate pool to use when signing.
+ * @param signer certificate to use to sign the request.
  * @param digest the signing algorithm in the request, if NULL use the
- * default signature algorithm,
+ * default signature algorithm.
  * @param request the encoded request, free with free_heim_octet_string().
  * @param nonce nonce in the request, free with free_heim_octet_string().
  *
@@ -1232,9 +1232,9 @@ hx509_revoke_print(hx509_context context,
 /**
  * Print the OCSP reply stored in a file.
  *
- * @param context a hx509 context
- * @param path path to a file with a OCSP reply
- * @param out the out FILE descriptor to print the reply on
+ * @param context a hx509 context.
+ * @param path path to a file with a OCSP reply.
+ * @param out the out FILE descriptor to print the reply on.
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *
@@ -1273,12 +1273,12 @@ hx509_revoke_ocsp_print(hx509_context context, const char *path, FILE *out)
  * expired. Doesn't verify signature the OCSP reply or it's done by a
  * authorized sender, that is assumed to be already done.
  *
- * @param context a hx509 context
+ * @param context a hx509 context.
  * @param now the time right now, if 0, use the current time.
- * @param cert the certificate to verify
- * @param flags flags control the behavior
- * @param data pointer to the encode ocsp reply
- * @param length the length of the encode ocsp reply
+ * @param cert the certificate to verify.
+ * @param flags flags control the behavior.
+ * @param data pointer to the encode ocsp reply.
+ * @param length the length of the encode ocsp reply.
  * @param expiration return the time the OCSP will expire and need to
  * be rechecked.
  *
@@ -1441,7 +1441,7 @@ hx509_crl_add_revoked_certs(hx509_context context,
  * Set the lifetime of a CRL context.
  *
  * @param context a hx509 context.
- * @param crl a CRL context
+ * @param crl a CRL context.
  * @param delta delta time the certificate is valid, library adds the
  * current time to this.
  *
@@ -1515,10 +1515,10 @@ add_revoked(hx509_context context, void *ctx, hx509_cert cert)
  * Sign a CRL and return an encode certificate.
  *
  * @param context a hx509 context.
- * @param signer certificate to sign the CRL with
- * @param crl the CRL to sign
+ * @param signer certificate to sign the CRL with.
+ * @param crl the CRL to sign.
  * @param os return the signed and encoded CRL, free with
- * free_heim_octet_string()
+ * free_heim_octet_string().
  *
  * @return An hx509 error code, see hx509_get_error_string().
  *

--- a/lib/kadm5/common_glue.c
+++ b/lib/kadm5/common_glue.c
@@ -141,14 +141,14 @@ kadm5_get_principal(void *server_handle,
  * no-op for Heimdal because we fetch the entry with decrypted keys.
  * Sadly this is not fully a no-op, as we have to allocate a copy.
  *
- * @server_handle is the kadm5 handle
- * @entry is the HDB entry for the principal in question
- * @ktype is the enctype to get a key for, or -1 to get the first one
- * @stype is the salttype to get a key for, or -1 to get the first match
- * @kvno is the kvno to search for, or -1 to get the first match (highest kvno)
- * @keyblock is where the key will be placed
- * @keysalt, if not NULL, is where the salt will be placed
- * @kvnop, if not NULL, is where the selected kvno will be placed
+ * @param server_handle is the kadm5 handle.
+ * @param entry is the HDB entry for the principal in question.
+ * @param ktype is the enctype to get a key for, or -1 to get the first one.
+ * @param stype is the salttype to get a key for, or -1 to get the first match.
+ * @param kvno is the kvno to search for, or -1 to get the first match (highest kvno).
+ * @param keyblock is where the key will be placed.
+ * @param keysalt, if not NULL, is where the salt will be placed.
+ * @param kvnop, if not NULL, is where the selected kvno will be placed.
  */
 kadm5_ret_t
 kadm5_decrypt_key(void *server_handle,

--- a/lib/kafs/rxkad_kdf.c
+++ b/lib/kafs/rxkad_kdf.c
@@ -63,9 +63,9 @@ static int compress_parity_bits(void *, size_t *);
  * as traditional krb5 rxkad uses the ticket session key directly as the token
  * key.
  *
- * @param[in]  in      pointer to input key data
- * @param[in]  insize  length of input key data
- * @param[out] out     8-byte buffer to hold the derived key
+ * @param[in]  in      pointer to input key data.
+ * @param[in]  insize  length of input key data.
+ * @param[out] out     8-byte buffer to hold the derived key.
  *
  * @return Returns 0 to indicate success, or an error code.
  *
@@ -114,7 +114,7 @@ rxkad_derive_des_key(const void *in, size_t insize, char out[8])
  * rfc3961, converting blocks of 8 bytes to blocks of 7 bytes by distributing
  * the bits of each 8th byte as the lsb of the previous 7 bytes.
  *
- * @param[in,out]  buffer  Buffer containing the key to be converted
+ * @param[in,out]  buffer  Buffer containing the key to be converted.
  * @param[in,out]  bufsiz  Points to the size of the key data.  On
  * return, this is updated to reflect the size of the compressed data.
  *
@@ -153,10 +153,10 @@ compress_parity_bits(void *buffer, size_t *bufsiz)
  * If given a des key, use it directly; otherwise, perform any parity
  * fixup that may be needed and pass through to the hmad-md5 bits.
  *
- * @param[in]   enctype  Kerberos enctype of the input key
- * @param[in]   keydata  Input key data
- * @param[in]   keylen   Size of input key data
- * @param[out]  output   8-byte buffer to hold the derived key
+ * @param[in]   enctype  Kerberos enctype of the input key.
+ * @param[in]   keydata  Input key data.
+ * @param[in]   keylen   Size of input key data.
+ * @param[out]  output   8-byte buffer to hold the derived key.
  *
  * @return Returns 0 to indicate success, or an error code.
  *

--- a/lib/krb5/acl.c
+++ b/lib/krb5/acl.c
@@ -168,10 +168,10 @@ acl_match_acl(krb5_context context,
  *     string on error: the function will clean up and set the pointer
  *     to NULL.
  *
- * @param context Kerberos 5 context
- * @param string string to match with
- * @param format format to match
- * @param ... parameter to format string
+ * @param context Kerberos 5 context.
+ * @param string string to match with.
+ * @param format format to match.
+ * @param ... parameter to format string.
  *
  * @return Return an error code or 0.
  *

--- a/lib/krb5/addr_families.c
+++ b/lib/krb5/addr_families.c
@@ -846,8 +846,8 @@ find_atype(krb5_address_type atype)
  * krb5_sockaddr2address stores a address a "struct sockaddr" sa in
  * the krb5_address addr.
  *
- * @param context a Keberos context
- * @param sa a struct sockaddr to extract the address from
+ * @param context a Keberos context.
+ * @param sa a struct sockaddr to extract the address from.
  * @param addr an Kerberos 5 address to store the address in.
  *
  * @return Return an error code or 0.
@@ -873,8 +873,8 @@ krb5_sockaddr2address (krb5_context context,
  * krb5_sockaddr2port extracts a port (if possible) from a "struct
  * sockaddr.
  *
- * @param context a Keberos context
- * @param sa a struct sockaddr to extract the port from
+ * @param context a Keberos context.
+ * @param sa a struct sockaddr to extract the port from.
  * @param port a pointer to an int16_t store the port in.
  *
  * @return Return an error code or 0. Will return
@@ -905,9 +905,9 @@ krb5_sockaddr2port (krb5_context context,
  * the up to *sa_size will be stored, and then *sa_size will be set to
  * the required length.
  *
- * @param context a Keberos context
- * @param addr the address to copy the from
- * @param sa the struct sockaddr that will be filled in
+ * @param context a Keberos context.
+ * @param addr the address to copy the from.
+ * @param sa the struct sockaddr that will be filled in.
  * @param sa_size pointer to length of sa, and after the call, it will
  * contain the actual length of the address.
  * @param port set port in sa.
@@ -1003,11 +1003,11 @@ krb5_sockaddr_is_loopback(const struct sockaddr *sa)
  * of the sa, and after the call, it will contain the actual length of
  * the address.
  *
- * @param context a Keberos context
- * @param af addresses
- * @param addr address
- * @param sa returned struct sockaddr
- * @param sa_size size of sa
+ * @param context a Keberos context.
+ * @param af addresses.
+ * @param addr address.
+ * @param sa returned struct sockaddr.
+ * @param sa_size size of sa.
  * @param port port to set in sa.
  *
  * @return Return an error code or 0.
@@ -1036,8 +1036,8 @@ krb5_h_addr2sockaddr (krb5_context context,
  * krb5_h_addr2addr works like krb5_h_addr2sockaddr with the exception
  * that it operates on a krb5_address instead of a struct sockaddr.
  *
- * @param context a Keberos context
- * @param af address family
+ * @param context a Keberos context.
+ * @param af address family.
  * @param haddr host address from struct hostent.
  * @param addr returned krb5_address.
  *
@@ -1066,9 +1066,9 @@ krb5_h_addr2addr (krb5_context context,
  * of the sa, and after the call, it will contain the actual length
  * of the address.
  *
- * @param context a Keberos context
- * @param af address family
- * @param sa sockaddr
+ * @param context a Keberos context.
+ * @param af address family.
+ * @param sa sockaddr.
  * @param sa_size lenght of sa.
  * @param port for to fill into sa.
  *
@@ -1100,10 +1100,10 @@ krb5_anyaddr (krb5_context context,
  * krb5_print_address prints the address in addr to the string string
  * that have the length len. If ret_len is not NULL, it will be filled
  * with the length of the string if size were unlimited (not including
- * the final NUL) .
+ * the final NUL).
  *
- * @param addr address to be printed
- * @param str pointer string to print the address into
+ * @param addr address to be printed.
+ * @param str pointer string to print the address into.
  * @param len length that will fit into area pointed to by "str".
  * @param ret_len return length the str.
  *
@@ -1177,11 +1177,11 @@ _krb5_parse_address_no_lookup(krb5_context context,
 
 /**
  * krb5_parse_address returns the resolved hostname in string to the
- * krb5_addresses addresses .
+ * krb5_addresses addresses.
  *
- * @param context a Keberos context
- * @param string
- * @param addresses
+ * @param context a Keberos context..
+ * @param string.
+ * @param addresses.
  *
  * @return Return an error code or 0.
  *
@@ -1250,9 +1250,9 @@ krb5_parse_address(krb5_context context,
  * it can be used for sorting addresses. If the addresses are the same
  * address krb5_address_order will return 0. Behavies like memcmp(2).
  *
- * @param context a Keberos context
- * @param addr1 krb5_address to compare
- * @param addr2 krb5_address to compare
+ * @param context a Keberos context.
+ * @param addr1 krb5_address to compare.
+ * @param addr2 krb5_address to compare.
  *
  * @return < 0 if address addr1 in "less" then addr2. 0 if addr1 and
  * addr2 is the same address, > 0 if addr2 is "less" then addr1.
@@ -1300,9 +1300,9 @@ krb5_address_order(krb5_context context,
  * krb5_address_compare compares the addresses  addr1 and addr2.
  * Returns TRUE if the two addresses are the same.
  *
- * @param context a Keberos context
- * @param addr1 address to compare
- * @param addr2 address to compare
+ * @param context a Keberos context.
+ * @param addr1 address to compare.
+ * @param addr2 address to compare.
  *
  * @return Return an TRUE is the address are the same FALSE if not
  *
@@ -1319,7 +1319,7 @@ krb5_address_compare(krb5_context context,
 
 /**
  * krb5_address_search checks if the address addr is a member of the
- * address set list addrlist .
+ * address set list addrlist.
  *
  * @param context a Keberos context.
  * @param addr address to search for.
@@ -1347,7 +1347,7 @@ krb5_address_search(krb5_context context,
  * krb5_free_address frees the data stored in the address that is
  * alloced with any of the krb5_address functions.
  *
- * @param context a Keberos context
+ * @param context a Keberos context.
  * @param address addresss to be freed.
  *
  * @return Return an error code or 0.
@@ -1371,7 +1371,7 @@ krb5_free_address(krb5_context context,
  * krb5_free_addresses frees the data stored in the address that is
  * alloced with any of the krb5_address functions.
  *
- * @param context a Keberos context
+ * @param context a Keberos context.
  * @param addresses addressses to be freed.
  *
  * @return Return an error code or 0.
@@ -1391,9 +1391,9 @@ krb5_free_addresses(krb5_context context,
  * krb5_copy_address copies the content of address
  * inaddr to outaddr.
  *
- * @param context a Keberos context
- * @param inaddr pointer to source address
- * @param outaddr pointer to destination address
+ * @param context a Keberos context.
+ * @param inaddr pointer to source address.
+ * @param outaddr pointer to destination address.
  *
  * @return Return an error code or 0.
  *
@@ -1415,9 +1415,9 @@ krb5_copy_address(krb5_context context,
  * krb5_copy_addresses copies the content of addresses
  * inaddr to outaddr.
  *
- * @param context a Keberos context
- * @param inaddr pointer to source addresses
- * @param outaddr pointer to destination addresses
+ * @param context a Keberos context.
+ * @param inaddr pointer to source addresses.
+ * @param outaddr pointer to destination addresses.
  *
  * @return Return an error code or 0.
  *
@@ -1442,9 +1442,9 @@ krb5_copy_addresses(krb5_context context,
  * krb5_append_addresses adds the set of addresses in source to
  * dest. While copying the addresses, duplicates are also sorted out.
  *
- * @param context a Keberos context
- * @param dest destination of copy operation
- * @param source adresses that are going to be added to dest
+ * @param context a Keberos context.
+ * @param dest destination of copy operation.
+ * @param source adresses that are going to be added to dest.
  *
  * @return Return an error code or 0.
  *
@@ -1480,12 +1480,12 @@ krb5_append_addresses(krb5_context context,
 }
 
 /**
- * Create an address of type KRB5_ADDRESS_ADDRPORT from (addr, port)
+ * Create an address of type KRB5_ADDRESS_ADDRPORT from (addr, port).
  *
- * @param context a Keberos context
- * @param res built address from addr/port
- * @param addr address to use
- * @param port port to use
+ * @param context a Keberos context.
+ * @param res built address from addr/port.
+ * @param addr address to use.
+ * @param port port to use.
  *
  * @return Return an error code or 0.
  *
@@ -1545,11 +1545,11 @@ krb5_make_addrport (krb5_context context,
  * Calculate the boundary addresses of `inaddr'/`prefixlen' and store
  * them in `low' and `high'.
  *
- * @param context a Keberos context
- * @param inaddr address in prefixlen that the bondery searched
- * @param prefixlen width of boundery
- * @param low lowest address
- * @param high highest address
+ * @param context a Keberos context.
+ * @param inaddr address in prefixlen that the bondery searched.
+ * @param prefixlen width of boundery.
+ * @param low lowest address.
+ * @param high highest address.
  *
  * @return Return an error code or 0.
  *

--- a/lib/krb5/an2ln_plugin.h
+++ b/lib/krb5/an2ln_plugin.h
@@ -45,7 +45,7 @@ typedef krb5_error_code (KRB5_LIB_CALL *set_result_f)(void *, const char *);
 
 /** @struct krb5plugin_an2ln_ftable_desc
  *
- * @brief Description of the krb5_aname_to_lname(3) plugin facility.
+ * Description of the krb5_aname_to_lname(3) plugin facility.
  *
  * The krb5_aname_to_lname(3) function is pluggable.  The plugin is
  * named KRB5_PLUGIN_AN2LN ("an2ln"), with a single minor version,
@@ -55,13 +55,10 @@ typedef krb5_error_code (KRB5_LIB_CALL *set_result_f)(void *, const char *);
  * referencing a structure of type krb5plugin_an2ln_ftable, with four
  * fields:
  *
- * @param init          Plugin initialization function (see krb5-plugin(7))
- *
- * @param minor_version The plugin minor version number (0)
- *
- * @param fini          Plugin finalization function
- *
- * @param an2ln         Plugin aname_to_lname function
+ * @param init          Plugin initialization function (see krb5-plugin(7)).
+ * @param minor_version The plugin minor version number (0).
+ * @param fini          Plugin finalization function.
+ * @param an2ln         Plugin aname_to_lname function.
  *
  * The an2ln field is the plugin entry point that performs the
  * traditional aname_to_lname operation however the plugin desires.  It

--- a/lib/krb5/aname_to_localname.c
+++ b/lib/krb5/aname_to_localname.c
@@ -285,12 +285,10 @@ an2ln_default(krb5_context context,
  * Returns 0 on success, KRB5_NO_LOCALNAME if no mapping was found, or
  * some Kerberos or system error.
  *
- * Inputs:
- *
- * @param context    A krb5_context
- * @param aname      A principal name
- * @param lnsize     The size of the buffer into which the username will be written
- * @param lname      The buffer into which the username will be written
+ * @param[in] context    A krb5_context.
+ * @param[in] aname      A principal name.
+ * @param[in] lnsize     The size of the buffer into which the username will be written.
+ * @param[in] lname      The buffer into which the username will be written.
  *
  * @ingroup krb5_support
  */

--- a/lib/krb5/cache.c
+++ b/lib/krb5/cache.c
@@ -109,8 +109,8 @@ cc_get_prefix_ops(krb5_context context,
  * Add a new ccache type with operations `ops', overwriting any
  * existing one if `override'.
  *
- * @param context a Kerberos context
- * @param ops type of plugin symbol
+ * @param context a Kerberos context.
+ * @param ops type of plugin symbol.
  * @param override flag to select if the registration is to overide
  * an existing ops with the same name.
  *
@@ -461,7 +461,7 @@ krb5_cc_new_unique(krb5_context context, const char *type,
 }
 
 /**
- * Return the name of the ccache `id'
+ * Return the name of the ccache `id'.
  *
  * @ingroup krb5_ccache
  */
@@ -482,7 +482,7 @@ krb5_cc_get_name(krb5_context context,
 }
 
 /**
- * Return the name of the ccache collection associated with `id'
+ * Return the name of the ccache collection associated with `id'.
  *
  * @ingroup krb5_ccache
  */
@@ -502,7 +502,7 @@ krb5_cc_get_collection(krb5_context context, krb5_ccache id)
 }
 
 /**
- * Return the name of the subsidiary ccache of `id'
+ * Return the name of the subsidiary ccache of `id'.
  *
  * @ingroup krb5_ccache
  */
@@ -534,11 +534,11 @@ krb5_cc_get_type(krb5_context context,
 }
 
 /**
- * Return the complete resolvable name the cache
-
- * @param context a Kerberos context
- * @param id return pointer to a found credential cache
- * @param str the returned name of a credential cache, free with krb5_xfree()
+ * Return the complete resolvable name the cache.
+ *
+ * @param context a Kerberos context.
+ * @param id return pointer to a found credential cache.
+ * @param str the returned name of a credential cache, free with krb5_xfree().
  *
  * @return Returns 0 or an error (and then *str is set to NULL).
  *
@@ -665,7 +665,7 @@ krb5_cc_switch(krb5_context context, krb5_ccache id)
 }
 
 /**
- * Return true if the default credential cache support switch
+ * Return true if the default credential cache support switch.
  *
  * @ingroup krb5_ccache
  */
@@ -1093,12 +1093,12 @@ krb5_cc_store_cred(krb5_context context,
  * from `id' in `creds'. 'creds' must be free by the caller using
  * krb5_free_cred_contents.
  *
- * @param context A Kerberos 5 context
- * @param id a Kerberos 5 credential cache
+ * @param context A Kerberos 5 context.
+ * @param id a Kerberos 5 credential cache.
  * @param whichfields what fields to use for matching credentials, same
- *        flags as whichfields in krb5_compare_creds()
- * @param mcreds template credential to use for comparing
- * @param creds returned credential, free with krb5_free_cred_contents()
+ *        flags as whichfields in krb5_compare_creds().
+ * @param mcreds template credential to use for comparing.
+ * @param creds returned credential, free with krb5_free_cred_contents().
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -1323,7 +1323,7 @@ krb5_cc_copy_match_f(krb5_context context,
 /**
  * Just like krb5_cc_copy_match_f(), but copy everything.
  *
- * @ingroup @krb5_ccache
+ * @ingroup krb5_ccache
  */
 
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
@@ -1352,7 +1352,7 @@ krb5_cc_get_version(krb5_context context,
 }
 
 /**
- * Clear `mcreds' so it can be used with krb5_cc_retrieve_cred
+ * Clear `mcreds' so it can be used with krb5_cc_retrieve_cred.
  *
  * @ingroup krb5_ccache
  */
@@ -1449,8 +1449,8 @@ struct krb5_cc_cache_cursor_data {
 /**
  * Start iterating over all caches of specified type. See also
  * krb5_cccol_cursor_new().
-
- * @param context A Kerberos 5 context
+ *
+ * @param context A Kerberos 5 context.
  * @param type optional type to iterate over, if NULL, the default cache is used.
  * @param cursor cursor should be freed with krb5_cc_cache_end_seq_get().
  *
@@ -1505,9 +1505,9 @@ krb5_cc_cache_get_first (krb5_context context,
  * Retrieve the next cache pointed to by (`cursor') in `id'
  * and advance `cursor'.
  *
- * @param context A Kerberos 5 context
- * @param cursor the iterator cursor, returned by krb5_cc_cache_get_first()
- * @param id next ccache
+ * @param context A Kerberos 5 context.
+ * @param cursor the iterator cursor, returned by krb5_cc_cache_get_first().
+ * @param id next ccache.
  *
  * @return Return 0 or an error code. Returns KRB5_CC_END when the end
  *         of caches is reached, see krb5_get_error_message().
@@ -1549,9 +1549,9 @@ krb5_cc_cache_end_seq_get (krb5_context context,
  * `principal' as the default principal. On success, `id' needs to be
  * freed with krb5_cc_close() or krb5_cc_destroy().
  *
- * @param context A Kerberos 5 context
- * @param client The principal to search for
- * @param id the returned credential cache
+ * @param context A Kerberos 5 context.
+ * @param client The principal to search for.
+ * @param id the returned credential cache.
  *
  * @return On failure, error code is returned and `id' is set to NULL.
  *
@@ -1636,10 +1636,10 @@ krb5_cc_cache_match (krb5_context context,
  * Move the content from one credential cache to another. The
  * operation is an atomic switch.
  *
- * @param context a Kerberos context
- * @param from the credential cache to move the content from
- * @param to the credential cache to move the content to
-
+ * @param context a Kerberos context.
+ * @param from the credential cache to move the content from.
+ * @param to the credential cache to move the content to.
+ *
  * @return On sucess, from is destroyed and closed. On failure, error code is
  *         returned and from and to are both still allocated; see
  *         krb5_get_error_message().
@@ -1728,8 +1728,8 @@ build_conf_principals(krb5_context context, krb5_ccache id,
  * principal (generated part of krb5_cc_set_config()). Returns FALSE
  * (zero) if not a configuration principal.
  *
- * @param context a Kerberos context
- * @param principal principal to check if it a configuration principal
+ * @param context a Kerberos context.
+ * @param principal principal to check if it a configuration principal.
  *
  * @ingroup krb5_ccache
  */
@@ -1752,8 +1752,8 @@ krb5_is_config_principal(krb5_context context,
  * Store some configuration for the credential cache in the cache.
  * Existing configuration under the same name is over-written.
  *
- * @param context a Kerberos context
- * @param id the credential cache to store the data for
+ * @param context a Kerberos context.
+ * @param id the credential cache to store the data for.
  * @param principal configuration for a specific principal, if
  * NULL, global for the whole cache.
  * @param name name under which the configuraion is stored.
@@ -1800,12 +1800,13 @@ out:
 /**
  * Get some configuration for the credential cache in the cache.
  *
- * @param context a Kerberos context
- * @param id the credential cache to store the data for
+ * @param context a Kerberos context.
+ * @param id the credential cache to store the data for.
  * @param principal configuration for a specific principal, if
  * NULL, global for the whole cache.
  * @param name name under which the configuraion is stored.
- * @param data data to fetched, free with krb5_data_free()
+ * @param data data to fetched, free with krb5_data_free().
+ *
  * @return 0 on success, KRB5_CC_NOTFOUND or KRB5_CC_END if not found,
  *           or other system error.
  *
@@ -1853,7 +1854,7 @@ struct krb5_cccol_cursor_data {
  * Get a new cache interation cursor that will interate over all
  * credentials caches independent of type.
  *
- * @param context a Kerberos context
+ * @param context a Kerberos context.
  * @param cursor passed into krb5_cccol_cursor_next() and free with krb5_cccol_cursor_free().
  *
  * @return Returns 0 or and error code, see krb5_get_error_message().
@@ -1876,8 +1877,8 @@ krb5_cccol_cursor_new(krb5_context context, krb5_cccol_cursor *cursor)
 /**
  * Get next credential cache from the iteration.
  *
- * @param context A Kerberos 5 context
- * @param cursor the iteration cursor
+ * @param context A Kerberos 5 context.
+ * @param cursor the iteration cursor.
  * @param cache the returned cursor, pointer is set to NULL on failure
  *        and a cache on success. The returned cache needs to be freed
  *        with krb5_cc_close() or destroyed with krb5_cc_destroy().
@@ -1933,7 +1934,7 @@ krb5_cccol_cursor_next(krb5_context context, krb5_cccol_cursor cursor,
 /**
  * End an iteration and free all resources, can be done before end is reached.
  *
- * @param context A Kerberos 5 context
+ * @param context A Kerberos 5 context.
  * @param cursor the iteration cursor to be freed.
  *
  * @return Return 0 or and error, KRB5_CC_END is returned at the end
@@ -1959,10 +1960,10 @@ krb5_cccol_cursor_free(krb5_context context, krb5_cccol_cursor *cursor)
 /**
  * Return the last time the credential cache was modified.
  *
- * @param context A Kerberos 5 context
- * @param id The credential cache to probe
+ * @param context A Kerberos 5 context.
+ * @param id The credential cache to probe.
  * @param mtime the last modification time, set to 0 on error.
-
+ *
  * @return Return 0 or and error. See krb5_get_error_message().
  *
  * @ingroup krb5_ccache
@@ -1988,10 +1989,10 @@ krb5_cc_last_change_time(krb5_context context,
  * can be limited to a specific cache type. If the function return 0
  * and mtime is 0, there was no credentials in the caches.
  *
- * @param context A Kerberos 5 context
+ * @param context A Kerberos 5 context.
  * @param type The credential cache to probe, if NULL, all type are traversed.
  * @param mtime the last modification time, set to 0 on error.
-
+ *
  * @return Return 0 or and error. See krb5_get_error_message().
  *
  * @ingroup krb5_ccache
@@ -2088,14 +2089,14 @@ krb5_cc_set_friendly_name(krb5_context context,
 }
 
 /**
- * Get the lifetime of the initial ticket in the cache
+ * Get the lifetime of the initial ticket in the cache.
  *
  * Get the lifetime of the initial ticket in the cache, if the initial
  * ticket was not found, the error code KRB5_CC_END is returned.
  *
  * @param context A Kerberos 5 context.
- * @param id a credential cache
- * @param t the relative lifetime of the initial ticket
+ * @param id a credential cache.
+ * @param t the relative lifetime of the initial ticket.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -2178,13 +2179,13 @@ krb5_cc_get_lifetime(krb5_context context, krb5_ccache id, time_t *t)
 }
 
 /**
- * Set the time offset betwen the client and the KDC
+ * Set the time offset betwen the client and the KDC.
  *
  * If the backend doesn't support KDC offset, use the context global setting.
  *
  * @param context A Kerberos 5 context.
- * @param id a credential cache
- * @param offset the offset in seconds
+ * @param id a credential cache.
+ * @param offset the offset in seconds.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -2204,13 +2205,13 @@ krb5_cc_set_kdc_offset(krb5_context context, krb5_ccache id, krb5_deltat offset)
 }
 
 /**
- * Get the time offset betwen the client and the KDC
+ * Get the time offset betwen the client and the KDC.
  *
  * If the backend doesn't support KDC offset, use the context global setting.
  *
  * @param context A Kerberos 5 context.
- * @param id a credential cache
- * @param offset the offset in seconds
+ * @param id a credential cache.
+ * @param offset the offset in seconds.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *

--- a/lib/krb5/changepw.c
+++ b/lib/krb5/changepw.c
@@ -676,7 +676,7 @@ find_chpw_proto(const char *name)
 /**
  * Deprecated: krb5_change_password() is deprecated, use krb5_set_password().
  *
- * @param context a Keberos context
+ * @param context a Keberos context.
  * @param creds
  * @param newpw
  * @param result_code
@@ -684,8 +684,8 @@ find_chpw_proto(const char *name)
  * @param result_string
  *
  * @return On sucess password is changed.
-
- * @ingroup @krb5_deprecated
+ *
+ * @ingroup krb5_deprecated
  */
 
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
@@ -715,10 +715,10 @@ krb5_change_password (krb5_context	context,
 /**
  * Change password using creds.
  *
- * @param context a Keberos context
- * @param creds The initial kadmin/passwd for the principal or an admin principal
- * @param newpw The new password to set
- * @param targprinc if unset, the client principal from creds is used
+ * @param context a Keberos context.
+ * @param creds The initial kadmin/passwd for the principal or an admin principal.
+ * @param newpw The new password to set.
+ * @param targprinc if unset, the client principal from creds is used.
  * @param result_code Result code, KRB5_KPASSWD_SUCCESS is when password is changed.
  * @param result_code_string binary message from the server, contains
  * at least the result_code.
@@ -726,8 +726,8 @@ krb5_change_password (krb5_context	context,
  * library in human printable form. The string is NUL terminated.
  *
  * @return On sucess and *result_code is KRB5_KPASSWD_SUCCESS, the password is changed.
-
- * @ingroup @krb5
+ *
+ * @ingroup krb5
  */
 
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL

--- a/lib/krb5/config_file.c
+++ b/lib/krb5/config_file.c
@@ -49,8 +49,9 @@
  * into one resulting krb5_config_section by calling it repeatably.
  *
  * @param context a Kerberos 5 context.
- * @param dname a directory name to a Kerberos configuration file
+ * @param dname a directory name to a Kerberos configuration file.
  * @param res the returned result, must be free with krb5_free_config_files().
+ *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
  * @ingroup krb5_support
@@ -84,8 +85,9 @@ krb5_config_parse_dir_multi(krb5_context context,
  * resulting krb5_config_section by calling it repeatably.
  *
  * @param context a Kerberos 5 context.
- * @param fname a file name to a Kerberos configuration file
+ * @param fname a file name to a Kerberos configuration file.
  * @param res the returned result, must be free with krb5_free_config_files().
+ *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
  * @ingroup krb5_support
@@ -125,11 +127,11 @@ krb5_config_parse_file(krb5_context context,
  * Free configuration file section, the result of
  * krb5_config_parse_file() and krb5_config_parse_file_multi().
  *
- * @param context A Kerberos 5 context
- * @param s the configuration section to free
+ * @param context A Kerberos 5 context.
+ * @param s the configuration section to free.
  *
  * @return returns 0 on successes, otherwise an error code, see
- *          krb5_get_error_message()
+ *          krb5_get_error_message().
  *
  * @ingroup krb5_support
  */
@@ -223,13 +225,13 @@ _krb5_config_vget(krb5_context context,
 }
 
 /**
- * Get a list of configuration binding list for more processing
+ * Get a list of configuration binding list for more processing.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
- * @return NULL if configuration list is not found, a list otherwise
+ * @return NULL if configuration list is not found, a list otherwise.
  *
  * @ingroup krb5_support
  */
@@ -251,13 +253,13 @@ krb5_config_get_list(krb5_context context,
 }
 
 /**
- * Get a list of configuration binding list for more processing
+ * Get a list of configuration binding list for more processing.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
- * @return NULL if configuration list is not found, a list otherwise
+ * @return NULL if configuration list is not found, a list otherwise.
  *
  * @ingroup krb5_support
  */
@@ -282,10 +284,10 @@ krb5_config_vget_list(krb5_context context,
  * the string.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
- * @return NULL if configuration string not found, a string otherwise
+ * @return NULL if configuration string not found, a string otherwise.
  *
  * @ingroup krb5_support
  */
@@ -310,10 +312,10 @@ krb5_config_get_string(krb5_context context,
  * Like krb5_config_get_string(), but uses a va_list instead of ...
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
- * @return NULL if configuration string not found, a string otherwise
+ * @return NULL if configuration string not found, a string otherwise.
  *
  * @ingroup krb5_support
  */
@@ -333,12 +335,12 @@ krb5_config_vget_string(krb5_context context,
  * instead return a default value.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
- * @param args a va_list of arguments
+ * @param args a va_list of arguments.
  *
- * @return a configuration string
+ * @return a configuration string.
  *
  * @ingroup krb5_support
  */
@@ -359,12 +361,12 @@ krb5_config_vget_string_default(krb5_context context,
  * instead return a default value.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
  * @param ... a list of names, terminated with NULL.
  *
- * @return a configuration string
+ * @return a configuration string.
  *
  * @ingroup krb5_support
  */
@@ -391,8 +393,8 @@ krb5_config_get_string_default(krb5_context context,
  * krb5_config_free_strings().
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
  * @return TRUE or FALSE
  *
@@ -414,7 +416,7 @@ krb5_config_vget_strings(krb5_context context,
  * krb5_config_free_strings().
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
  * @return TRUE or FALSE
@@ -441,7 +443,7 @@ krb5_config_get_strings(krb5_context context,
  * Free the resulting strings from krb5_config-get_strings() and
  * krb5_config_vget_strings().
  *
- * @param strings strings to free
+ * @param strings strings to free.
  *
  * @ingroup krb5_support
  */
@@ -460,10 +462,10 @@ krb5_config_free_strings(char **strings)
  * non-zero number means TRUE and other value is FALSE.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
- * @param args a va_list of arguments
+ * @param args a va_list of arguments.
  *
  * @return TRUE or FALSE
  *
@@ -487,8 +489,8 @@ krb5_config_vget_bool_default(krb5_context context,
  * number means TRUE and other value is FALSE.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
  * @return TRUE or FALSE
  *
@@ -511,7 +513,7 @@ krb5_config_vget_bool(krb5_context context,
  * number means TRUE and other value is FALSE.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
  * @param ... a list of names, terminated with NULL.
@@ -545,7 +547,7 @@ krb5_config_get_bool_default(krb5_context context,
  * non-zero number means TRUE and other value is FALSE.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
  * @return TRUE or FALSE
@@ -573,12 +575,12 @@ krb5_config_get_bool (krb5_context context,
  * configuration selection.
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
- * @param args a va_list of arguments
+ * @param args a va_list of arguments.
  *
- * @return parsed the time (or def_value on parse error)
+ * @return parsed the time (or def_value on parse error).
  *
  * @ingroup krb5_support
  */
@@ -598,10 +600,10 @@ krb5_config_vget_time_default(krb5_context context,
  * Get the time from the configuration file using a relative time, for example: 1h30s
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
- * @param args a va_list of arguments
+ * @param c a configuration section, or NULL to use the section from context.
+ * @param args a va_list of arguments.
  *
- * @return parsed the time or -1 on error
+ * @return parsed the time or -1 on error.
  *
  * @ingroup krb5_support
  */
@@ -620,12 +622,12 @@ krb5_config_vget_time(krb5_context context,
  * Get the time from the configuration file using a relative time, for example: 1h30s
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param def_value the default value to return if no configuration
  *        found in the database.
  * @param ... a list of names, terminated with NULL.
  *
- * @return parsed the time (or def_value on parse error)
+ * @return parsed the time (or def_value on parse error).
  *
  * @ingroup krb5_support
  */
@@ -650,10 +652,10 @@ krb5_config_get_time_default(krb5_context context,
  * Get the time from the configuration file using a relative time, for example: 1h30s
  *
  * @param context A Kerberos 5 context.
- * @param c a configuration section, or NULL to use the section from context
+ * @param c a configuration section, or NULL to use the section from context.
  * @param ... a list of names, terminated with NULL.
  *
- * @return parsed the time or -1 on error
+ * @return parsed the time or -1 on error.
  *
  * @ingroup krb5_support
  */

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -446,7 +446,7 @@ init_context_once(void *ctx)
  * /etc/krb5.conf. The structure should be freed by calling
  * krb5_free_context() when it is no longer being used.
  *
- * @param context pointer to returned context
+ * @param context pointer to returned context.
  *
  * @return Returns 0 to indicate success.  Otherwise an errno code is
  * returned.  Failure means either that something bad happened during
@@ -567,7 +567,7 @@ copy_etypes (krb5_context context,
  * Make a copy for the Kerberos 5 context, the new krb5_context shoud
  * be freed with krb5_free_context().
  *
- * @param context the Kerberos context to copy
+ * @param context the Kerberos context to copy.
  * @param out the copy of the Kerberos, set to NULL error.
  *
  * @return Returns 0 to indicate success.  Otherwise an kerberos et
@@ -785,7 +785,7 @@ krb5_prepend_config_files(const char *filelist, char **pq, char ***ret_pp)
 /**
  * Prepend the filename to the global configuration list.
  *
- * @param filelist a filename to add to the default list of filename
+ * @param filelist a filename to add to the default list of filename.
  * @param pfilenames return array of filenames, should be freed with krb5_free_config_files().
  *
  * @return Returns 0 to indicate success.  Otherwise an kerberos et
@@ -983,7 +983,7 @@ krb5_set_default_in_tkt_etypes(krb5_context context,
  * with the KDC, clients and servers.
  *
  * @param context Kerberos 5 context.
- * @param pdu_type request type (AS, TGS or none)
+ * @param pdu_type request type (AS, TGS or none).
  * @param etypes Encryption types, array terminated with
  * ETYPE_NULL(0), caller should free array with krb5_xfree():
  *
@@ -1029,7 +1029,7 @@ krb5_get_default_in_tkt_etypes(krb5_context context,
 /**
  * Init the built-in ets in the Kerberos library.
  *
- * @param context kerberos context to add the ets too
+ * @param context kerberos context to add the ets too.
  *
  * @ingroup krb5
  */
@@ -1100,7 +1100,7 @@ krb5_get_use_admin_kdc (krb5_context context)
  * the client's address list when communicating with the KDC.
  *
  * @param context Kerberos 5 context.
- * @param addresses addreses to add
+ * @param addresses addreses to add.
  *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -1124,7 +1124,7 @@ krb5_add_extra_addresses(krb5_context context, krb5_addresses *addresses)
  * the client's address list when communicating with the KDC.
  *
  * @param context Kerberos 5 context.
- * @param addresses addreses to set
+ * @param addresses addreses to set.
  *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -1158,7 +1158,7 @@ krb5_set_extra_addresses(krb5_context context, const krb5_addresses *addresses)
  * the client's address list when communicating with the KDC.
  *
  * @param context Kerberos 5 context.
- * @param addresses addreses to set
+ * @param addresses addreses to set.
  *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -1181,7 +1181,7 @@ krb5_get_extra_addresses(krb5_context context, krb5_addresses *addresses)
  * underlaying operating system.
  *
  * @param context Kerberos 5 context.
- * @param addresses addreses to ignore
+ * @param addresses addreses to ignore.
  *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -1205,7 +1205,7 @@ krb5_add_ignore_addresses(krb5_context context, krb5_addresses *addresses)
  * underlaying operating system.
  *
  * @param context Kerberos 5 context.
- * @param addresses addreses to ignore
+ * @param addresses addreses to ignore.
  *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -1238,7 +1238,7 @@ krb5_set_ignore_addresses(krb5_context context, const krb5_addresses *addresses)
  * underlaying operating system.
  *
  * @param context Kerberos 5 context.
- * @param addresses list addreses ignored
+ * @param addresses list addreses ignored.
  *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -1354,7 +1354,7 @@ krb5_get_dns_canonicalize_hostname (krb5_context context)
  * @param sec seconds part of offset.
  * @param usec micro seconds part of offset.
  *
- * @return returns zero
+ * @return returns zero.
  *
  * @ingroup krb5
  */
@@ -1376,7 +1376,7 @@ krb5_get_kdc_sec_offset (krb5_context context, int32_t *sec, int32_t *usec)
  * @param sec seconds part of offset.
  * @param usec micro seconds part of offset.
  *
- * @return returns zero
+ * @return returns zero.
  *
  * @ingroup krb5
  */
@@ -1425,11 +1425,11 @@ krb5_set_max_time_skew (krb5_context context, time_t t)
  * Init encryption types in len, val with etypes.
  *
  * @param context Kerberos 5 context.
- * @param pdu_type type of pdu
+ * @param pdu_type type of pdu.
  * @param len output length of val.
  * @param val output array of enctypes.
  * @param etypes etypes to set val and len to, if NULL, use default enctypes.
-
+ *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
  *
@@ -1481,9 +1481,10 @@ _krb5_homedir_access(krb5_context context)
  * For home directory access to be allowed, both the global state and
  * the krb5_context state have to be allowed.
  *
- * @param context a Kerberos 5 context or NULL
- * @param allow allow if TRUE home directory
- * @return the old value
+ * @param context a Kerberos 5 context or NULL.
+ * @param allow allow if TRUE home directory.
+ *
+ * @return the old value.
  *
  * @ingroup krb5
  */

--- a/lib/krb5/convert_creds.c
+++ b/lib/krb5/convert_creds.c
@@ -42,8 +42,8 @@
  * gotten from the KDC and stored in the cred cache `ccache'.
  *
  * @param context Kerberos 5 context.
- * @param in_cred the credential to convert
- * @param v4creds the converted credential
+ * @param in_cred the credential to convert.
+ * @param v4creds the converted credential.
  *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -68,8 +68,8 @@ krb524_convert_creds_kdc(krb5_context context,
  *
  * @param context Kerberos 5 context.
  * @param ccache credential cache used to check for des-ticket.
- * @param in_cred the credential to convert
- * @param v4creds the converted credential
+ * @param in_cred the credential to convert.
+ * @param v4creds the converted credential.
  *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().

--- a/lib/krb5/creds.c
+++ b/lib/krb5/creds.c
@@ -268,9 +268,9 @@ krb5_compare_creds(krb5_context context, krb5_flags whichfields,
  * Returns the ticket flags for the credentials in creds.
  * See also krb5_ticket_get_flags().
  *
- * @param creds credential to get ticket flags from
+ * @param creds credential to get ticket flags from.
  *
- * @return ticket flags
+ * @return ticket flags.
  *
  * @ingroup krb5
  */

--- a/lib/krb5/crypto-rand.c
+++ b/lib/krb5/crypto-rand.c
@@ -90,7 +90,7 @@ seed_something(void)
  *
  * This function can fail, and callers must check the return value.
  *
- * @param buf a buffer to fill with randomness
+ * @param buf a buffer to fill with randomness.
  * @param len length of memory that buf points to.
  *
  * @return return 0 on success or HEIM_ERR_RANDOM_OFFLINE if the
@@ -136,7 +136,7 @@ krb5_generate_random(void *buf, size_t len)
  * will not fail once it have started to produce good output,
  * /dev/urandom behavies that way.
  *
- * @param buf a buffer to fill with randomness
+ * @param buf a buffer to fill with randomness.
  * @param len length of memory that buf points to.
  *
  * @ingroup krb5_crypto

--- a/lib/krb5/crypto.c
+++ b/lib/krb5/crypto.c
@@ -866,10 +866,11 @@ krb5_enctype_to_keytype(krb5_context context,
 /**
  * Check if a enctype is valid, return 0 if it is.
  *
- * @param context Kerberos context
- * @param etype enctype to check if its valid or not
+ * @param context Kerberos context.
+ * @param etype enctype to check if its valid or not.
  *
  * @return Return an error code for an failure or 0 on success (enctype valid).
+ *
  * @ingroup krb5_crypto
  */
 
@@ -895,12 +896,13 @@ krb5_enctype_valid(krb5_context context,
 /**
  * Return the coresponding encryption type for a checksum type.
  *
- * @param context Kerberos context
- * @param ctype The checksum type to get the result enctype for
+ * @param context Kerberos context.
+ * @param ctype The checksum type to get the result enctype for.
  * @param etype The returned encryption, when the matching etype is
  * not found, etype is set to ETYPE_NULL.
  *
  * @return Return an error code for an failure or 0 on success.
+ *
  * @ingroup krb5_crypto
  */
 
@@ -1626,16 +1628,17 @@ iov_pad_validate(const struct _krb5_encryption_type *et,
 }
 
 /**
- * Inline encrypt a kerberos message
+ * Inline encrypt a kerberos message.
  *
- * @param context Kerberos context
- * @param crypto Kerberos crypto context
- * @param usage Key usage for this buffer
- * @param data array of buffers to process
- * @param num_data length of array
- * @param ivec initial cbc/cts vector
+ * @param context Kerberos context.
+ * @param crypto Kerberos crypto context.
+ * @param usage Key usage for this buffer.
+ * @param data array of buffers to process.
+ * @param num_data length of array.
+ * @param ivec initial cbc/cts vector.
  *
  * @return Return an error code or 0.
+ *
  * @ingroup krb5_crypto
  *
  * Kerberos encrypted data look like this:
@@ -1826,14 +1829,15 @@ cleanup:
 /**
  * Inline decrypt a Kerberos message.
  *
- * @param context Kerberos context
- * @param crypto Kerberos crypto context
- * @param usage Key usage for this buffer
- * @param data array of buffers to process
- * @param num_data length of array
- * @param ivec initial cbc/cts vector
+ * @param context Kerberos context.
+ * @param crypto Kerberos crypto context.
+ * @param usage Key usage for this buffer.
+ * @param data array of buffers to process.
+ * @param num_data length of array.
+ * @param ivec initial cbc/cts vector.
  *
  * @return Return an error code or 0.
+ *
  * @ingroup krb5_crypto
  *
  * 1. KRB5_CRYPTO_TYPE_HEADER
@@ -1985,14 +1989,15 @@ cleanup:
 /**
  * Create a Kerberos message checksum.
  *
- * @param context Kerberos context
- * @param crypto Kerberos crypto context
- * @param usage Key usage for this buffer
- * @param data array of buffers to process
- * @param num_data length of array
- * @param type output data
+ * @param context Kerberos context.
+ * @param crypto Kerberos crypto context.
+ * @param usage Key usage for this buffer.
+ * @param data array of buffers to process.
+ * @param num_data length of array.
+ * @param type output data.
  *
  * @return Return an error code or 0.
+ *
  * @ingroup krb5_crypto
  */
 
@@ -2049,14 +2054,15 @@ krb5_create_checksum_iov(krb5_context context,
 /**
  * Verify a Kerberos message checksum.
  *
- * @param context Kerberos context
- * @param crypto Kerberos crypto context
- * @param usage Key usage for this buffer
- * @param data array of buffers to process
- * @param num_data length of array
- * @param type return checksum type if not NULL
+ * @param context Kerberos context.
+ * @param crypto Kerberos crypto context.
+ * @param usage Key usage for this buffer.
+ * @param data array of buffers to process.
+ * @param num_data length of array.
+ * @param type return checksum type if not NULL.
  *
  * @return Return an error code or 0.
+ *
  * @ingroup krb5_crypto
  */
 
@@ -2539,10 +2545,10 @@ _get_derived_key(krb5_context context,
  *
  * To free the crypto context, use krb5_crypto_destroy().
  *
- * @param context Kerberos context
- * @param key the key block information with all key data
- * @param etype the encryption type
- * @param crypto the resulting crypto context
+ * @param context Kerberos context.
+ * @param key the key block information with all key data.
+ * @param etype the encryption type.
+ * @param crypto the resulting crypto context.
  *
  * @return Return an error code or 0.
  *
@@ -2619,8 +2625,8 @@ free_key_usage(krb5_context context, struct _krb5_key_usage *ku,
 /**
  * Free a crypto context created by krb5_crypto_init().
  *
- * @param context Kerberos context
- * @param crypto crypto context to free
+ * @param context Kerberos context.
+ * @param crypto crypto context to free.
  *
  * @return Return an error code or 0.
  *
@@ -2649,11 +2655,11 @@ krb5_crypto_destroy(krb5_context context,
 }
 
 /**
- * Return the blocksize used algorithm referenced by the crypto context
+ * Return the blocksize used algorithm referenced by the crypto context.
  *
- * @param context Kerberos context
- * @param crypto crypto context to query
- * @param blocksize the resulting blocksize
+ * @param context Kerberos context.
+ * @param crypto crypto context to query.
+ * @param blocksize the resulting blocksize.
  *
  * @return Return an error code or 0.
  *
@@ -2670,11 +2676,11 @@ krb5_crypto_getblocksize(krb5_context context,
 }
 
 /**
- * Return the encryption type used by the crypto context
+ * Return the encryption type used by the crypto context.
  *
- * @param context Kerberos context
- * @param crypto crypto context to query
- * @param enctype the resulting encryption type
+ * @param context Kerberos context.
+ * @param crypto crypto context to query.
+ * @param enctype the resulting encryption type.
  *
  * @return Return an error code or 0.
  *
@@ -2691,11 +2697,11 @@ krb5_crypto_getenctype(krb5_context context,
 }
 
 /**
- * Return the padding size used by the crypto context
+ * Return the padding size used by the crypto context.
  *
- * @param context Kerberos context
- * @param crypto crypto context to query
- * @param padsize the return padding size
+ * @param context Kerberos context.
+ * @param crypto crypto context to query.
+ * @param padsize the return padding size.
  *
  * @return Return an error code or 0.
  *
@@ -2712,11 +2718,11 @@ krb5_crypto_getpadsize(krb5_context context,
 }
 
 /**
- * Return the confounder size used by the crypto context
+ * Return the confounder size used by the crypto context.
  *
- * @param context Kerberos context
- * @param crypto crypto context to query
- * @param confoundersize the returned confounder size
+ * @param context Kerberos context.
+ * @param crypto crypto context to query.
+ * @param confoundersize the returned confounder size.
  *
  * @return Return an error code or 0.
  *
@@ -2734,10 +2740,10 @@ krb5_crypto_getconfoundersize(krb5_context context,
 
 
 /**
- * Disable encryption type
+ * Disable encryption type.
  *
- * @param context Kerberos 5 context
- * @param enctype encryption type to disable
+ * @param context Kerberos 5 context.
+ * @param enctype encryption type to disable.
  *
  * @return Return an error code or 0.
  *
@@ -2761,10 +2767,10 @@ krb5_enctype_disable(krb5_context context,
 }
 
 /**
- * Enable encryption type
+ * Enable encryption type.
  *
- * @param context Kerberos 5 context
- * @param enctype encryption type to enable
+ * @param context Kerberos 5 context.
+ * @param enctype encryption type to enable.
  *
  * @return Return an error code or 0.
  *
@@ -2788,10 +2794,10 @@ krb5_enctype_enable(krb5_context context,
 }
 
 /**
- * Enable or disable all weak encryption types
+ * Enable or disable all weak encryption types.
  *
- * @param context Kerberos 5 context
- * @param enable true to enable, false to disable
+ * @param context Kerberos 5 context.
+ * @param enable true to enable, false to disable.
  *
  * @return Return an error code or 0.
  *
@@ -2815,10 +2821,10 @@ krb5_allow_weak_crypto(krb5_context context,
 }
 
 /**
- * Returns is the encryption is strong or weak
+ * Returns is the encryption is strong or weak.
  *
- * @param context Kerberos 5 context
- * @param enctype encryption type to probe
+ * @param context Kerberos 5 context.
+ * @param enctype encryption type to probe.
  *
  * @return Returns true if encryption type is weak or is not supported.
  *
@@ -2835,10 +2841,10 @@ krb5_is_enctype_weak(krb5_context context, krb5_enctype enctype)
 }
 
 /**
- * Returns whether the encryption type is new or old
+ * Returns whether the encryption type is new or old.
  *
- * @param context Kerberos 5 context
- * @param enctype encryption type to probe
+ * @param context Kerberos 5 context.
+ * @param enctype encryption type to probe.
  *
  * @return Returns true if encryption type is old or is not supported.
  *
@@ -2855,12 +2861,12 @@ krb5_is_enctype_old(krb5_context context, krb5_enctype enctype)
 }
 
 /**
- * Returns whether the encryption type should use randomly generated salts
+ * Returns whether the encryption type should use randomly generated salts.
  *
- * @param context Kerberos 5 context
- * @param enctype encryption type to probe
+ * @param context Kerberos 5 context.
+ * @param enctype encryption type to probe.
  *
- * @return Returns true if generated salts should have random component
+ * @return Returns true if generated salts should have random component.
  *
  * @ingroup krb5_crypto
  */
@@ -2973,11 +2979,11 @@ krb5_crypto_overhead (krb5_context context, krb5_crypto crypto)
  * the input string are equally random, even though the entropy
  * present in the random source may be limited.
  *
- * @param context Kerberos 5 context
- * @param type the enctype resulting key will be of
- * @param data input random data to convert to a key
- * @param size size of input random data, at least krb5_enctype_keysize() long
- * @param key key, output key, free with krb5_free_keyblock_contents()
+ * @param context Kerberos 5 context.
+ * @param type the enctype resulting key will be of.
+ * @param data input random data to convert to a key.
+ * @param size size of input random data, at least krb5_enctype_keysize() long.
+ * @param key key, output key, free with krb5_free_keyblock_contents().
  *
  * @return Return an error code or 0.
  *
@@ -3117,13 +3123,13 @@ krb5_crypto_prfplus(krb5_context context,
 /**
  * The FX-CF2 key derivation function, used in FAST and preauth framework.
  *
- * @param context Kerberos 5 context
- * @param crypto1 first key to combine
- * @param crypto2 second key to combine
- * @param pepper1 factor to combine with first key to guarantee uniqueness
- * @param pepper2 factor to combine with second key to guarantee uniqueness
- * @param enctype the encryption type of the resulting key
- * @param res allocated key, free with krb5_free_keyblock_contents()
+ * @param context Kerberos 5 context.
+ * @param crypto1 first key to combine.
+ * @param crypto2 second key to combine.
+ * @param pepper1 factor to combine with first key to guarantee uniqueness.
+ * @param pepper2 factor to combine with second key to guarantee uniqueness.
+ * @param enctype the encryption type of the resulting key.
+ * @param res allocated key, free with krb5_free_keyblock_contents().
  *
  * @return Return an error code or 0.
  *

--- a/lib/krb5/data.c
+++ b/lib/krb5/data.c
@@ -133,7 +133,7 @@ krb5_data_realloc(krb5_data *p, int len)
  * Copy the data of len into the krb5_data.
  *
  * @param p krb5_data to copy into.
- * @param data data to copy..
+ * @param data data to copy.
  * @param len new size.
  *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
@@ -189,8 +189,8 @@ krb5_copy_data(krb5_context context,
 /**
  * Compare to data.
  *
- * @param data1 krb5_data to compare
- * @param data2 krb5_data to compare
+ * @param data1 krb5_data to compare.
+ * @param data2 krb5_data to compare.
  *
  * @return return the same way as memcmp(), useful when sorting.
  *
@@ -209,10 +209,10 @@ krb5_data_cmp(const krb5_data *data1, const krb5_data *data2)
 }
 
 /**
- * Compare to data not exposing timing information from the checksum data
+ * Compare to data not exposing timing information from the checksum data.
  *
- * @param data1 krb5_data to compare
- * @param data2 krb5_data to compare
+ * @param data1 krb5_data to compare.
+ * @param data2 krb5_data to compare.
  *
  * @return returns zero for same data, otherwise non zero.
  *

--- a/lib/krb5/db_plugin.h
+++ b/lib/krb5/db_plugin.h
@@ -40,7 +40,7 @@
 
 /** @struct krb5plugin_db_ftable_desc
  *
- * @brief Description of the krb5 DB plugin facility.
+ * Description of the krb5 DB plugin facility.
  *
  * The krb5_aname_to_lname(3) function's DB rule is pluggable.  The
  * plugin is named KRB5_PLUGIN_DB ("krb5_db_plug"), with a single minor

--- a/lib/krb5/error_string.c
+++ b/lib/krb5/error_string.c
@@ -39,7 +39,7 @@
 /**
  * Clears the error message from the Kerberos 5 context.
  *
- * @param context The Kerberos 5 context to clear
+ * @param context The Kerberos 5 context to clear.
  *
  * @ingroup krb5_error
  */
@@ -56,9 +56,9 @@ krb5_clear_error_message(krb5_context context)
  *
  * The if context is NULL, no error string is stored.
  *
- * @param context Kerberos 5 context
- * @param ret The error code
- * @param fmt Error string for the error code
+ * @param context Kerberos 5 context.
+ * @param ret The error code.
+ * @param fmt Error string for the error code.
  * @param ... printf(3) style parameters.
  *
  * @ingroup krb5_error
@@ -81,9 +81,9 @@ krb5_set_error_message(krb5_context context, krb5_error_code ret,
  *
  * The if context is NULL, no error string is stored.
  *
- * @param context Kerberos 5 context
- * @param ret The error code
- * @param fmt Error string for the error code
+ * @param context Kerberos 5 context.
+ * @param ret The error code.
+ * @param fmt Error string for the error code.
  * @param args printf(3) style parameters.
  *
  * @ingroup krb5_error
@@ -114,9 +114,9 @@ krb5_vset_error_message(krb5_context context, krb5_error_code ret,
  *
  * The if context is NULL, no error string is stored.
  *
- * @param context Kerberos 5 context
- * @param ret The error code
- * @param fmt Error string for the error code
+ * @param context Kerberos 5 context.
+ * @param ret The error code.
+ * @param fmt Error string for the error code.
  * @param ... printf(3) style parameters.
  *
  * @ingroup krb5_error
@@ -139,9 +139,9 @@ krb5_prepend_error_message(krb5_context context, krb5_error_code ret,
  *
  * The if context is NULL, no error string is stored.
  *
- * @param context Kerberos 5 context
- * @param ret The error code
- * @param fmt Error string for the error code
+ * @param context Kerberos 5 context.
+ * @param ret The error code.
+ * @param fmt Error string for the error code.
  * @param args printf(3) style parameters.
  *
  * @ingroup krb5_error
@@ -160,8 +160,8 @@ krb5_vprepend_error_message(krb5_context context, krb5_error_code ret,
  * Return the error message for `code' in context. On memory
  * allocation error the function returns NULL.
  *
- * @param context Kerberos 5 context
- * @param code Error code related to the error
+ * @param context Kerberos 5 context.
+ * @param code Error code related to the error.
  *
  * @return an error string, needs to be freed with
  * krb5_free_error_message(). The functions return NULL on error.
@@ -200,7 +200,7 @@ krb5_get_error_message(krb5_context context, krb5_error_code code)
 /**
  * Free the error message returned by krb5_get_error_message().
  *
- * @param context Kerberos context
+ * @param context Kerberos context.
  * @param msg error message to free, returned byg
  *        krb5_get_error_message().
  *

--- a/lib/krb5/expand_hostname.c
+++ b/lib/krb5/expand_hostname.c
@@ -49,8 +49,8 @@ copy_hostname(krb5_context context,
  * krb5_expand_hostname() tries to make orig_hostname into a more
  * canonical one in the newly allocated space returned in
  * new_hostname.
-
- * @param context a Keberos context
+ *
+ * @param context a Keberos context.
  * @param orig_hostname hostname to canonicalise.
  * @param new_hostname output hostname, caller must free hostname with
  *        krb5_xfree().
@@ -122,7 +122,7 @@ vanilla_hostname (krb5_context context,
  * and return the realms new_hostname is believed to belong to in
  * realms.
  *
- * @param context a Keberos context
+ * @param context a Keberos context.
  * @param orig_hostname hostname to canonicalise.
  * @param new_hostname output hostname, caller must free hostname with
  *        krb5_xfree().

--- a/lib/krb5/free_host_realm.c
+++ b/lib/krb5/free_host_realm.c
@@ -34,10 +34,10 @@
 #include "krb5_locl.h"
 
 /**
- * Free all memory allocated by `realmlist'
+ * Free all memory allocated by `realmlist'.
  *
  * @param context A Kerberos 5 context.
- * @param realmlist realmlist to free, NULL is ok
+ * @param realmlist realmlist to free, NULL is ok.
  *
  * @return a Kerberos error code, always 0.
  *

--- a/lib/krb5/generate_subkey.c
+++ b/lib/krb5/generate_subkey.c
@@ -34,16 +34,16 @@
 #include "krb5_locl.h"
 
 /**
- * Generate subkey, from keyblock
+ * Generate subkey, from keyblock.
  *
- * @param context kerberos context
- * @param key session key
- * @param etype encryption type of subkey, if ETYPE_NULL, use key's enctype
+ * @param context kerberos context.
+ * @param key session key.
+ * @param etype encryption type of subkey, if ETYPE_NULL, use key's enctype.
  * @param subkey returned new, free with krb5_free_keyblock().
  *
- * @return 0 on success or a Kerberos 5 error code
+ * @return 0 on success or a Kerberos 5 error code.
  *
-* @ingroup krb5_crypto
+ * @ingroup krb5_crypto
  */
 
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL

--- a/lib/krb5/get_for_creds.c
+++ b/lib/krb5/get_for_creds.c
@@ -179,8 +179,8 @@ krb5_fwd_tgt_creds(krb5_context	context,
  *
  * @param context A kerberos 5 context.
  * @param auth_context the auth context with the key to encrypt the out_data.
- * @param ccache credential cache to use
- * @param flags the flags to control the resulting ticket flags
+ * @param ccache credential cache to use.
+ * @param flags the flags to control the resulting ticket flags.
  * @param hostname the host to forward the tickets too.
  * @param in_creds the in client and server ticket names.  The client
  * and server components forwarded to the remote host.
@@ -225,11 +225,11 @@ krb5_get_forwarded_creds (krb5_context	    context,
  * security penalty.
  *
  * @param context A kerberos 5 context.
- * @param ccache The credential cache to use
- * @param creds Creds with client and server principals
- * @param flags The flags to control the resulting ticket flags
- * @param hostname The hostname of server
- * @param out_creds The resulting credential
+ * @param ccache The credential cache to use.
+ * @param creds Creds with client and server principals.
+ * @param flags The flags to control the resulting ticket flags.
+ * @param hostname The hostname of server.
+ * @param out_creds The resulting credential.
  *
  * @return Return an error code or 0.
  */

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -315,7 +315,7 @@ report_expiration (krb5_context context,
  * use the prompter to print the warning.
  *
  * @param context A Kerberos 5 context.
- * @param options An GIC options structure
+ * @param options An GIC options structure.
  * @param ctx The krb5_init_creds_context check for expiration.
  */
 
@@ -367,6 +367,7 @@ krb5_process_last_request(krb5_context context,
  * @param ctx a krb5_init_creds_context context.
  *
  * @return 0 for success, or an Kerberos 5 error code, see krb5_get_error_message().
+ *
  * @ingroup krb5_credential
  */
 
@@ -2482,8 +2483,8 @@ capture_lkdc_domain(krb5_context context,
  * @param client The Kerberos principal to get the credential for, if
  *     NULL is given, the default principal is used as determined by
  *     krb5_get_default_principal().
- * @param prompter
- * @param prompter_data
+ * @param prompter.
+ * @param prompter_data.
  * @param start_time the time the ticket should start to be valid or 0 for now.
  * @param options a options structure, can be NULL for default options.
  * @param rctx A new allocated free with krb5_init_creds_free().
@@ -2550,9 +2551,10 @@ krb5_init_creds_init(krb5_context context,
  *
  * @param context a Kerberos 5 context.
  * @param ctx a krb5_init_creds_context context.
- * @param hostname the hostname for the KDC of realm
+ * @param hostname the hostname for the KDC of realm.
  *
  * @return 0 for success, or an Kerberos 5 error code, see krb5_get_error_message().
+ *
  * @ingroup krb5_credential
  */
 
@@ -2598,6 +2600,7 @@ krb5_init_creds_set_sitename(krb5_context context,
  *        realm is set.
  *
  * @return 0 for success, or an Kerberos 5 error code, see krb5_get_error_message().
+ *
  * @ingroup krb5_credential
  */
 
@@ -2653,6 +2656,7 @@ krb5_init_creds_set_service(krb5_context context,
  * @param password the password to use.
  *
  * @return 0 for success, or an Kerberos 5 error code, see krb5_get_error_message().
+ *
  * @ingroup krb5_credential
  */
 
@@ -2719,6 +2723,7 @@ keytab_key_proc(krb5_context context, krb5_enctype enctype,
  * @param keytab the keytab to read the key from.
  *
  * @return 0 for success, or an Kerberos 5 error code, see krb5_get_error_message().
+ *
  * @ingroup krb5_credential
  */
 
@@ -3438,7 +3443,7 @@ init_creds_step(krb5_context context,
  * @param context a Kerberos 5 context.
  * @param ctx ctx krb5_init_creds_context context.
  * @param in input data from KDC, first round it should be reset by krb5_data_zero().
- * @param out reply to KDC. The caller needs to call krb5_data_free()
+ * @param out reply to KDC. The caller needs to call krb5_data_free().
  * @param out_realm the destination realm for 'out', free with krb5_xfree()
  * @param flags status of the round, if
  *        KRB5_INIT_CREDS_STEP_FLAG_CONTINUE is set, continue one more round.
@@ -3489,7 +3494,7 @@ krb5_init_creds_step(krb5_context context,
  * context.
  *
  * @param context A Kerberos 5 context.
- * @param ctx
+ * @param ctx.
  * @param cred credentials, free with krb5_free_cred_contents().
  *
  * @return 0 for sucess or An Kerberos error code, see krb5_get_error_message().
@@ -3547,7 +3552,7 @@ _krb5_init_creds_get_cred_client(krb5_context context, krb5_init_creds_context c
 /**
  * Get the last error from the transaction.
  *
- * @return Returns 0 or an error code
+ * @return Returns 0 or an error code.
  *
  * @ingroup krb5_credential
  */
@@ -3567,13 +3572,13 @@ krb5_init_creds_get_error(krb5_context context,
 }
 
 /**
- * Store config
+ * Store config.
  *
  * @param context A Kerberos 5 context.
  * @param ctx The krb5_init_creds_context to free.
- * @param id store
+ * @param id store.
  *
- * @return Returns 0 or an error code
+ * @return Returns 0 or an error code.
  *
  * @ingroup krb5_credential
  */

--- a/lib/krb5/keyblock.c
+++ b/lib/krb5/keyblock.c
@@ -36,7 +36,7 @@
 /**
  * Zero out a keyblock
  *
- * @param keyblock keyblock to zero out
+ * @param keyblock keyblock to zero out.
  *
  * @ingroup krb5_crypto
  */
@@ -51,8 +51,8 @@ krb5_keyblock_zero(krb5_keyblock *keyblock)
 /**
  * Free a keyblock's content, also zero out the content of the keyblock.
  *
- * @param context a Kerberos 5 context
- * @param keyblock keyblock content to free, NULL is valid argument
+ * @param context a Kerberos 5 context.
+ * @param keyblock keyblock content to free, NULL is valid argument.
  *
  * @ingroup krb5_crypto
  */
@@ -74,8 +74,8 @@ krb5_free_keyblock_contents(krb5_context context,
  * Free a keyblock, also zero out the content of the keyblock, uses
  * krb5_free_keyblock_contents() to free the content.
  *
- * @param context a Kerberos 5 context
- * @param keyblock keyblock to free, NULL is valid argument
+ * @param context a Kerberos 5 context.
+ * @param keyblock keyblock to free, NULL is valid argument.
  *
  * @ingroup krb5_crypto
  */
@@ -94,11 +94,11 @@ krb5_free_keyblock(krb5_context context,
  * Copy a keyblock, free the output keyblock with
  * krb5_free_keyblock_contents().
  *
- * @param context a Kerberos 5 context
- * @param inblock the key to copy
+ * @param context a Kerberos 5 context.
+ * @param inblock the key to copy.
  * @param to the output key.
  *
- * @return 0 on success or a Kerberos 5 error code
+ * @return 0 on success or a Kerberos 5 error code.
  *
  * @ingroup krb5_crypto
  */
@@ -115,11 +115,11 @@ krb5_copy_keyblock_contents (krb5_context context,
  * Copy a keyblock, free the output keyblock with
  * krb5_free_keyblock().
  *
- * @param context a Kerberos 5 context
- * @param inblock the key to copy
+ * @param context a Kerberos 5 context.
+ * @param inblock the key to copy.
  * @param to the output key.
  *
- * @return 0 on success or a Kerberos 5 error code
+ * @return 0 on success or a Kerberos 5 error code.
  *
  * @ingroup krb5_crypto
  */
@@ -164,7 +164,7 @@ krb5_keyblock_get_enctype(const krb5_keyblock *block)
  * Fill in `key' with key data of type `enctype' from `data' of length
  * `size'. Key should be freed using krb5_free_keyblock_contents().
  *
- * @return 0 on success or a Kerberos 5 error code
+ * @return 0 on success or a Kerberos 5 error code.
  *
  * @ingroup krb5_crypto
  */

--- a/lib/krb5/keytab.c
+++ b/lib/krb5/keytab.c
@@ -195,7 +195,7 @@ keytab_name(const char *name, const char **type, size_t *type_len)
  * into a keytab in `id'.
  *
  * @param context a Keberos context.
- * @param name name to resolve
+ * @param name name to resolve.
  * @param id resulting keytab, free with krb5_kt_close().
  *
  * @return Return an error code or 0, see krb5_get_error_message().
@@ -260,8 +260,8 @@ static const char *default_ktname(krb5_context context)
  * copy the name of the default keytab into `name'.
  *
  * @param context a Keberos context.
- * @param name buffer where the name will be written
- * @param namesize length of name
+ * @param name buffer where the name will be written.
+ * @param namesize length of name.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -282,8 +282,8 @@ krb5_kt_default_name(krb5_context context, char *name, size_t namesize)
  * Copy the name of the default modify keytab into `name'.
  *
  * @param context a Keberos context.
- * @param name buffer where the name will be written
- * @param namesize length of name
+ * @param name buffer where the name will be written.
+ * @param namesize length of name.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -339,11 +339,11 @@ krb5_kt_default(krb5_context context, krb5_keytab *id)
  * keytab in `keyprocarg' (the default if == NULL) into `*key'.
  *
  * @param context a Keberos context.
- * @param keyprocarg
- * @param principal
- * @param vno
- * @param enctype
- * @param key
+ * @param keyprocarg.
+ * @param principal.
+ * @param vno.
+ * @param enctype.
+ * @param key.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -385,9 +385,9 @@ krb5_kt_read_service_key(krb5_context context,
  * `prefixsize'.
  *
  * @param context a Keberos context.
- * @param keytab the keytab to get the prefix for
- * @param prefix prefix buffer
- * @param prefixsize length of prefix buffer
+ * @param keytab the keytab to get the prefix for.
+ * @param prefix prefix buffer.
+ * @param prefixsize length of prefix buffer.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -759,7 +759,7 @@ krb5_kt_copy_entry_contents(krb5_context context,
  * Free the contents of `entry'.
  *
  * @param context a Keberos context.
- * @param entry the entry to free
+ * @param entry the entry to free.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -865,7 +865,7 @@ krb5_kt_end_seq_get(krb5_context context,
  *
  * @param context a Keberos context.
  * @param id a keytab.
- * @param entry the entry to add
+ * @param entry the entry to add.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -894,7 +894,7 @@ krb5_kt_add_entry(krb5_context context,
 
  * @param context a Keberos context.
  * @param id a keytab.
- * @param entry the entry to remove
+ * @param entry the entry to remove.
  *
  * @return Return an error code or 0, see krb5_get_error_message().
  *
@@ -916,7 +916,7 @@ krb5_kt_remove_entry(krb5_context context,
 }
 
 /**
- * Return true if the keytab exists and have entries
+ * Return true if the keytab exists and have entries.
  *
  * @param context a Keberos context.
  * @param id a keytab.

--- a/lib/krb5/kuserok.c
+++ b/lib/krb5/kuserok.c
@@ -102,14 +102,14 @@ reg_def_plugins_once(void *ctx)
  *
  * Inputs:
  *
- * @param context            A krb5_context
- * @param filename	     Name of item to introspection
+ * @param context            A krb5_context.
+ * @param filename	     Name of item to introspection.
  * @param is_system_location TRUE if the dir/file are system locations or
- *                     	     FALSE if they are user home directory locations
- * @param dir                Directory (optional)
- * @param dirlstat           A pointer to struct stat for the directory (optional)
- * @param file               File (optional)
- * @param owner              Name of user that is expected to own the file
+ *                     	     FALSE if they are user home directory locations.
+ * @param dir                Directory (optional).
+ * @param dirlstat           A pointer to struct stat for the directory (optional).
+ * @param file               File (optional).
+ * @param owner              Name of user that is expected to own the file.
  */
 
 static krb5_error_code
@@ -438,8 +438,8 @@ out:
  * ie luser@@LOCAL-REALMS-IN-CONFIGURATION-FILES.
  *
  * @param context Kerberos 5 context.
- * @param principal principal to check if allowed to login
- * @param luser local user id
+ * @param principal principal to check if allowed to login.
+ * @param luser local user id.
  *
  * @return returns TRUE if access should be granted, FALSE otherwise.
  *

--- a/lib/krb5/kuserok_plugin.h
+++ b/lib/krb5/kuserok_plugin.h
@@ -39,7 +39,7 @@
 
 /** @struct krb5plugin_kuserok_ftable_desc
  *
- * @brief Description of the krb5_kuserok(3) plugin facility.
+ * Description of the krb5_kuserok(3) plugin facility.
  *
  * The krb5_kuserok(3) function is pluggable.  The plugin is named
  * KRB5_PLUGIN_KUSEROK ("krb5_plugin_kuserok"), with a single minor
@@ -48,13 +48,10 @@
  * The plugin for krb5_kuserok(3) consists of a data symbol referencing
  * a structure of type krb5plugin_kuserok_ftable, with four fields:
  *
- * @param init          Plugin initialization function (see krb5-plugin(7))
- *
- * @param minor_version The plugin minor version number (0)
- *
- * @param fini          Plugin finalization function
- *
- * @param kuserok       Plugin kuserok function
+ * @param init          Plugin initialization function (see krb5-plugin(7)).
+ * @param minor_version The plugin minor version number (0).
+ * @param fini          Plugin finalization function.
+ * @param kuserok       Plugin kuserok function.
  *
  * The kuserok field is the plugin entry point that performs the
  * traditional kuserok operation however the plugin desires.  It is

--- a/lib/krb5/kx509.c
+++ b/lib/krb5/kx509.c
@@ -111,8 +111,8 @@ struct krb5_kx509_req_ctx_data {
 /**
  * Create a kx509 request context.
  *
- * @param context The Kerberos library context
- * @param out Where to place the kx509 request context
+ * @param context The Kerberos library context.
+ * @param out Where to place the kx509 request context.
  *
  * @return A krb5 error code.
  */
@@ -151,8 +151,8 @@ krb5_kx509_ctx_init(krb5_context context, krb5_kx509_req_ctx *out)
 /**
  * Free a kx509 request context.
  *
- * @param context The Kerberos library context
- * @param ctxp Pointer to krb5 request context to free
+ * @param context The Kerberos library context.
+ * @param ctxp Pointer to krb5 request context to free.
  *
  * @return A krb5 error code.
  */
@@ -178,9 +178,9 @@ krb5_kx509_ctx_free(krb5_context context, krb5_kx509_req_ctx *ctxp)
 /**
  * Set a realm to send kx509 request to, if different from the client's.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param realm Realm name
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param realm Realm name.
  *
  * @return A krb5 error code.
  */
@@ -200,9 +200,9 @@ krb5_kx509_ctx_set_realm(krb5_context context,
  * automatically.  If a CSR is given then kx509 will use it instead of
  * generating one.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param csr_der A DER-encoded PKCS#10 CSR
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param csr_der A DER-encoded PKCS#10 CSR.
  *
  * @return A krb5 error code.
  */
@@ -219,9 +219,9 @@ krb5_kx509_ctx_set_csr_der(krb5_context context,
  * Adds an EKU as an additional desired Certificate Extension or in the CSR if
  * the caller does not set a CSR.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param oids A string representation of an OID
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param oids A string representation of an OID.
  *
  * @return A krb5 error code.
  */
@@ -244,9 +244,9 @@ krb5_kx509_ctx_add_eku(krb5_context context,
  * Adds a dNSName SAN (domainname, hostname) as an additional desired
  * Certificate Extension or in the CSR if the caller does not set a CSR.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param dname A string containing a DNS domainname
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param dname A string containing a DNS domainname.
  *
  * @return A krb5 error code.
  */
@@ -263,9 +263,9 @@ krb5_kx509_ctx_add_san_dns_name(krb5_context context,
  * Adds an xmppAddr SAN (jabber address) as an additional desired Certificate
  * Extension or in the CSR if the caller does not set a CSR.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param jid A string containing a Jabber address
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param jid A string containing a Jabber address.
  *
  * @return A krb5 error code.
  */
@@ -281,9 +281,9 @@ krb5_kx509_ctx_add_san_xmpp(krb5_context context,
  * Adds an rfc822Name SAN (e-mail address) as an additional desired Certificate
  * Extension or in the CSR if the caller does not set a CSR.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param email A string containing an e-mail address
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param email A string containing an e-mail address.
  *
  * @return A krb5 error code.
  */
@@ -299,10 +299,10 @@ krb5_kx509_ctx_add_san_rfc822Name(krb5_context context,
  * Adds an pkinit SAN (Kerberos principal name) as an additional desired
  * Certificate Extension or in the CSR if the caller does not set a CSR.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
  * @param pname A string containing a representation of a Kerberos principal
- *              name
+ *              name.
  *
  * @return A krb5 error code.
  */
@@ -318,9 +318,9 @@ krb5_kx509_ctx_add_san_pkinit(krb5_context context,
  * Adds a Microsoft-style UPN (user principal name) as an additional desired
  * Certificate Extension or in the CSR if the caller does not set a CSR.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param upn A string containing a representation of a UPN
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param upn A string containing a representation of a UPN.
  *
  * @return A krb5 error code.
  */
@@ -337,9 +337,9 @@ krb5_kx509_ctx_add_san_ms_upn(krb5_context context,
  * Adds an registeredID SAN (OID) as an additional desired Certificate
  * Extension or in the CSR if the caller does not set a CSR.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param oids A string representation of an OID
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param oids A string representation of an OID.
  *
  * @return A krb5 error code.
  */
@@ -390,9 +390,9 @@ load_priv_key(krb5_context context,
 /**
  * Set a private key.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param store The name of a PKIX credential store
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param store The name of a PKIX credential store.
  *
  * @return A krb5 error code.
  */
@@ -459,10 +459,10 @@ gen_priv_key(krb5_context context,
 /**
  * Generate a private key.
  *
- * @param context The Kerberos library context
- * @param ctx The kx509 request context
- * @param gen_type The type of key (default: rsa)
- * @param gen_bits The size of the key (for non-ECC, really, for RSA)
+ * @param context The Kerberos library context.
+ * @param ctx The kx509 request context.
+ * @param gen_type The type of key (default: rsa).
+ * @param gen_bits The size of the key (for non-ECC, really, for RSA).
  *
  * @return A krb5 error code.
  */
@@ -1181,13 +1181,13 @@ kx509_core(krb5_context context,
  * payload of a "cc config" named "kx509cert", while the key will be stored as
  * a DER-encoded PKCS#8 PrivateKeyInfo in a cc config named "kx509key".
  *
- * @param context The Kerberos library context
- * @param kx509_ctx A kx509 request context
- * @param incc A credential cache (if NULL use default ccache)
+ * @param context The Kerberos library context.
+ * @param kx509_ctx A kx509 request context.
+ * @param incc A credential cache (if NULL use default ccache).
  * @param hx509_store An PKIX credential store into which to store the private
- *                    key and certificate (e.g, "PEM-FILE:/path/to/file.pem")
+ *                    key and certificate (e.g, "PEM-FILE:/path/to/file.pem").
  * @param outcc A ccache into which to store the private key and certificate
- *              (mandatory)
+ *              (mandatory).
  *
  * @return A krb5 error code.
  */
@@ -1251,10 +1251,10 @@ krb5_kx509_ext(krb5_context context,
  *
  * XXX NOTE: Dicey feature here...  Review carefully!
  *
- * @param context The Kerberos library context
- * @param cc A credential cache
+ * @param context The Kerberos library context.
+ * @param cc A credential cache.
  * @param realm A realm from which to get the certificate (uses the client
- *              principal's realm if NULL)
+ *              principal's realm if NULL).
  *
  * @return A krb5 error code.
  */

--- a/lib/krb5/pac.c
+++ b/lib/krb5/pac.c
@@ -446,10 +446,10 @@ krb5_pac_init(krb5_context context, krb5_pac *pac)
 /**
  * Add a PAC buffer `nd' of type `type' to the pac `p'.
  *
- * @param context
- * @param p
- * @param type
- * @param nd
+ * @param context.
+ * @param p.
+ * @param type.
+ * @param nd.
  *
  * @return 0 on success or a Kerberos or system error.
  */
@@ -550,7 +550,7 @@ krb5_pac_add_buffer(krb5_context context, krb5_pac p,
  *
  * @param context Kerberos 5 context.
  * @param p the pac structure returned by krb5_pac_parse().
- * @param type type of buffer to get
+ * @param type type of buffer to get.
  * @param data return data, free with krb5_data_free().
  *
  * @return Returns 0 to indicate success, ENOENT to indicate that a buffer of
@@ -1331,7 +1331,7 @@ build_attributes_info(krb5_context context,
  * @param principal the principal to verify.
  * @param server The service key, most always be given.
  * @param privsvr The KDC key, may be given.
-
+ *
  * @return Returns 0 to indicate success. Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
  *

--- a/lib/krb5/plugin.c
+++ b/lib/krb5/plugin.c
@@ -61,10 +61,12 @@
 
 /**
  * Register a plugin symbol name of specific type.
- * @param context a Keberos context
- * @param type type of plugin symbol
- * @param name name of plugin symbol
- * @param symbol a pointer to the named symbol
+ *
+ * @param context a Keberos context.
+ * @param type type of plugin symbol.
+ * @param name name of plugin symbol.
+ * @param symbol a pointer to the named symbol.
+ *
  * @return In case of error a non zero error com_err error is returned
  * and the Kerberos error string is set.
  *
@@ -95,11 +97,9 @@ krb5_plugin_register(krb5_context context,
  * Load plugins (new system) for the given module @name (typically
  * "krb5") from the given directory @paths.
  *
- * Inputs:
- *
- * @context A krb5_context
- * @name    Name of plugin module (typically "krb5")
- * @paths   Array of directory paths where to look
+ * @param[in]  context A krb5_context.
+ * @param[in]  name    Name of plugin module (typically "krb5").
+ * @param[in]  paths   Array of directory paths where to look.
  */
 KRB5_LIB_FUNCTION void KRB5_LIB_CALL
 _krb5_load_plugins(krb5_context context, const char *name, const char **paths)
@@ -160,14 +160,9 @@ _krb5_plugin_run_f(krb5_context context,
 /**
  * Return a cookie identifying this instance of a library.
  *
- * Inputs:
- *
- * @context     A krb5_context
- * @module      Our library name or a library we depend on
- *
- * Outputs:	The instance cookie
- *
- * @ingroup	krb5_support
+ * @param[in]   context     A krb5_context
+ * @param[in]   module      Our library name or a library we depend on
+ * @param[out]  ingroup	krb5_support
  */
 
 #ifdef WIN32

--- a/lib/krb5/principal.c
+++ b/lib/krb5/principal.c
@@ -111,11 +111,11 @@ krb5_free_principal(krb5_context context,
 }
 
 /**
- * Set the type of the principal
+ * Set the type of the principal.
  *
  * @param context A Kerberos context.
- * @param principal principal to set the type for
- * @param type the new type
+ * @param principal principal to set the type for.
+ * @param type the new type.
  *
  * @return An krb5 error code, see krb5_get_error_message().
  *
@@ -131,12 +131,12 @@ krb5_principal_set_type(krb5_context context,
 }
 
 /**
- * Get the type of the principal
+ * Get the type of the principal.
  *
  * @param context A Kerberos context.
- * @param principal principal to get the type for
+ * @param principal principal to get the type for.
  *
- * @return the type of principal
+ * @return the type of principal.
  *
  * @ingroup krb5_principal
  */
@@ -149,12 +149,12 @@ krb5_principal_get_type(krb5_context context,
 }
 
 /**
- * Get the realm of the principal
+ * Get the realm of the principal.
  *
  * @param context A Kerberos context.
- * @param principal principal to get the realm for
+ * @param principal principal to get the realm for.
  *
- * @return realm of the principal, don't free or use after krb5_principal is freed
+ * @return realm of the principal, don't free or use after krb5_principal is freed.
  *
  * @ingroup krb5_principal
  */
@@ -179,10 +179,10 @@ krb5_principal_get_comp_string(krb5_context context,
 /**
  * Get number of component is principal.
  *
- * @param context Kerberos 5 context
- * @param principal principal to query
+ * @param context Kerberos 5 context.
+ * @param principal principal to query.
  *
- * @return number of components in string
+ * @return number of components in string.
  *
  * @ingroup krb5_principal
  */
@@ -197,9 +197,9 @@ krb5_principal_get_num_comp(krb5_context context,
 /**
  * Parse a name into a krb5_principal structure, flags controls the behavior.
  *
- * @param context Kerberos 5 context
- * @param name name to parse into a Kerberos principal
- * @param flags flags to control the behavior
+ * @param context Kerberos 5 context.
+ * @param name name to parse into a Kerberos principal.
+ * @param flags flags to control the behavior.
  * @param principal returned principal, free with krb5_free_principal().
  *
  * @return An krb5 error code, see krb5_get_error_message().
@@ -402,10 +402,10 @@ exit:
 }
 
 /**
- * Parse a name into a krb5_principal structure
+ * Parse a name into a krb5_principal structure.
  *
- * @param context Kerberos 5 context
- * @param name name to parse into a Kerberos principal
+ * @param context Kerberos 5 context.
+ * @param name name to parse into a Kerberos principal.
  * @param principal returned principal, free with krb5_free_principal().
  *
  * @return An krb5 error code, see krb5_get_error_message().
@@ -517,12 +517,12 @@ unparse_name_fixed(krb5_context context,
 }
 
 /**
- * Unparse the principal name to a fixed buffer
+ * Unparse the principal name to a fixed buffer.
  *
  * @param context A Kerberos context.
- * @param principal principal to unparse
- * @param name buffer to write name to
- * @param len length of buffer
+ * @param principal principal to unparse.
+ * @param name buffer to write name to.
+ * @param len length of buffer.
  *
  * @return An krb5 error code, see krb5_get_error_message().
  *
@@ -543,9 +543,9 @@ krb5_unparse_name_fixed(krb5_context context,
  * if its a default realm.
  *
  * @param context A Kerberos context.
- * @param principal principal to unparse
- * @param name buffer to write name to
- * @param len length of buffer
+ * @param principal principal to unparse.
+ * @param name buffer to write name to.
+ * @param len length of buffer.
  *
  * @return An krb5 error code, see krb5_get_error_message().
  *
@@ -566,10 +566,10 @@ krb5_unparse_name_fixed_short(krb5_context context,
  * Unparse the principal name with unparse flags to a fixed buffer.
  *
  * @param context A Kerberos context.
- * @param principal principal to unparse
- * @param flags unparse flags
- * @param name buffer to write name to
- * @param len length of buffer
+ * @param principal principal to unparse.
+ * @param flags unparse flags.
+ * @param name buffer to write name to.
+ * @param len length of buffer.
  *
  * @return An krb5 error code, see krb5_get_error_message().
  *
@@ -626,11 +626,11 @@ unparse_name(krb5_context context,
 }
 
 /**
- * Unparse the Kerberos name into a string
+ * Unparse the Kerberos name into a string.
  *
- * @param context Kerberos 5 context
- * @param principal principal to query
- * @param name resulting string, free with krb5_xfree()
+ * @param context Kerberos 5 context.
+ * @param principal principal to query.
+ * @param name resulting string, free with krb5_xfree().
  *
  * @return An krb5 error code, see krb5_get_error_message().
  *
@@ -646,12 +646,12 @@ krb5_unparse_name(krb5_context context,
 }
 
 /**
- * Unparse the Kerberos name into a string
+ * Unparse the Kerberos name into a string.
  *
- * @param context Kerberos 5 context
- * @param principal principal to query
- * @param flags flag to determine the behavior
- * @param name resulting string, free with krb5_xfree()
+ * @param context Kerberos 5 context.
+ * @param principal principal to query.
+ * @param flags flag to determine the behavior.
+ * @param name resulting string, free with krb5_xfree().
  *
  * @return An krb5 error code, see krb5_get_error_message().
  *
@@ -672,8 +672,8 @@ krb5_unparse_name_flags(krb5_context context,
  * skipped if its a default realm.
  *
  * @param context A Kerberos context.
- * @param principal principal to unparse
- * @param name returned buffer, free with krb5_xfree()
+ * @param principal principal to unparse.
+ * @param name returned buffer, free with krb5_xfree().
  *
  * @return An krb5 error code, see krb5_get_error_message().
  *
@@ -693,8 +693,8 @@ krb5_unparse_name_short(krb5_context context,
  * previous realm.
  *
  * @param context A Kerberos context.
- * @param principal principal set the realm for
- * @param realm the new realm to set
+ * @param principal principal set the realm for.
+ * @param realm the new realm to set.
  *
  * @return An krb5 error code, see krb5_get_error_message().
  *
@@ -737,12 +737,12 @@ krb5_principal_set_comp_string(krb5_context context,
 
 #ifndef HEIMDAL_SMALLER
 /**
- * Build a principal using vararg style building
+ * Build a principal using vararg style building.
  *
  * @param context A Kerberos context.
- * @param principal returned principal
- * @param rlen length of realm
- * @param realm realm name
+ * @param principal returned principal.
+ * @param rlen length of realm.
+ * @param realm realm name.
  * @param ... a list of components ended with NULL.
  *
  * @return An krb5 error code, see krb5_get_error_message().
@@ -767,11 +767,11 @@ krb5_build_principal(krb5_context context,
 #endif
 
 /**
- * Build a principal using vararg style building
+ * Build a principal using vararg style building.
  *
  * @param context A Kerberos context.
- * @param principal returned principal
- * @param realm realm name
+ * @param principal returned principal.
+ * @param realm realm name.
  * @param ... a list of components ended with NULL.
  *
  * @return An krb5 error code, see krb5_get_error_message().
@@ -929,11 +929,11 @@ krb5_build_principal_ext(krb5_context context,
 }
 
 /**
- * Copy a principal
+ * Copy a principal.
  *
  * @param context A Kerberos context.
- * @param inprinc principal to copy
- * @param outprinc copied principal, free with krb5_free_principal()
+ * @param inprinc principal to copy.
+ * @param outprinc copied principal, free with krb5_free_principal().
  *
  * @return An krb5 error code, see krb5_get_error_message().
  *
@@ -965,13 +965,13 @@ krb5_copy_principal(krb5_context context,
 }
 
 /**
- * Return TRUE iff princ1 == princ2 (without considering the realm)
+ * Return TRUE iff princ1 == princ2 (without considering the realm).
  *
- * @param context Kerberos 5 context
- * @param princ1 first principal to compare
- * @param princ2 second principal to compare
+ * @param context Kerberos 5 context.
+ * @param princ1 first principal to compare.
+ * @param princ2 second principal to compare.
  *
- * @return non zero if equal, 0 if not
+ * @return non zero if equal, 0 if not.
  *
  * @ingroup krb5_principal
  * @see krb5_principal_compare()
@@ -1013,17 +1013,15 @@ _krb5_principal_compare_PrincipalName(krb5_context context,
  * Compares the two principals, including realm of the principals and returns
  * TRUE if they are the same and FALSE if not.
  *
- * @param context Kerberos 5 context
- * @param princ1 first principal to compare
- * @param princ2 second principal to compare
+ * @param context Kerberos 5 context.
+ * @param princ1 first principal to compare.
+ * @param princ2 second principal to compare.
+ *
+ * @return TRUE iff princ1 == princ2
  *
  * @ingroup krb5_principal
  * @see krb5_principal_compare_any_realm()
  * @see krb5_realm_compare()
- */
-
-/*
- * return TRUE iff princ1 == princ2
  */
 
 KRB5_LIB_FUNCTION krb5_boolean KRB5_LIB_CALL
@@ -1037,11 +1035,13 @@ krb5_principal_compare(krb5_context context,
 }
 
 /**
- * return TRUE iff realm(princ1) == realm(princ2)
+ * Compares the realms of two principals returning TRUE if they are the same.
  *
- * @param context Kerberos 5 context
- * @param princ1 first principal to compare
- * @param princ2 second principal to compare
+ * @param context Kerberos 5 context.
+ * @param princ1 first principal to compare.
+ * @param princ2 second principal to compare.
+ *
+ * @return TRUE iff realm(princ1) == realm(princ2).
  *
  * @ingroup krb5_principal
  * @see krb5_principal_compare_any_realm()
@@ -1057,7 +1057,7 @@ krb5_realm_compare(krb5_context context,
 }
 
 /**
- * return TRUE iff princ matches pattern
+ * Return TRUE iff princ matches pattern.
  *
  * @ingroup krb5_principal
  */
@@ -1165,7 +1165,7 @@ static const struct {
 };
 
 /**
- * Parse nametype string and return a nametype integer
+ * Parse nametype string and return a nametype integer.
  *
  * @ingroup krb5_principal
  */
@@ -1187,7 +1187,7 @@ krb5_parse_nametype(krb5_context context, const char *str, int32_t *nametype)
 }
 
 /**
- * Returns true if name is Kerberos NULL name
+ * Returns true if name is Kerberos NULL name.
  *
  * @ingroup krb5_principal
  */
@@ -1207,7 +1207,7 @@ const char _krb5_wellknown_lkdc[] = "WELLKNOWN:COM.APPLE.LKDC";
 static const char lkdc_prefix[] = "LKDC:";
 
 /**
- * Returns true if name is Kerberos an LKDC realm
+ * Returns true if name is Kerberos an LKDC realm.
  *
  * @ingroup krb5_principal
  */
@@ -1221,7 +1221,7 @@ krb5_realm_is_lkdc(const char *realm)
 }
 
 /**
- * Returns true if name is Kerberos an LKDC realm
+ * Returns true if name is Kerberos an LKDC realm.
  *
  * @ingroup krb5_principal
  */
@@ -1233,7 +1233,7 @@ krb5_principal_is_lkdc(krb5_context context, krb5_const_principal principal)
 }
 
 /**
- * Returns true if name is Kerberos an LKDC realm
+ * Returns true if name is Kerberos an LKDC realm.
  *
  * @ingroup krb5_principal
  */
@@ -1245,7 +1245,7 @@ krb5_principal_is_pku2u(krb5_context context, krb5_const_principal principal)
 }
 
 /**
- * Check if the cname part of the principal is a krbtgt principal
+ * Check if the cname part of the principal is a krbtgt principal.
  *
  * @ingroup krb5_principal
  */
@@ -1258,7 +1258,7 @@ krb5_principal_is_krbtgt(krb5_context context, krb5_const_principal p)
 }
 
 /**
- * Returns true iff name is an WELLKNOWN:ORG.H5L.HOSTBASED-SERVICE
+ * Returns true iff name is an WELLKNOWN:ORG.H5L.HOSTBASED-SERVICE.
  *
  * @ingroup krb5_principal
  */
@@ -1277,7 +1277,7 @@ krb5_principal_is_gss_hostbased_service(krb5_context context,
 }
 
 /**
- * Check if the cname part of the principal is a initial or renewed krbtgt principal
+ * Check if the cname part of the principal is a initial or renewed krbtgt principal.
  *
  * @ingroup krb5_principal
  */
@@ -1291,7 +1291,7 @@ krb5_principal_is_root_krbtgt(krb5_context context, krb5_const_principal p)
 }
 
 /**
- * Returns true iff name is WELLKNOWN/ANONYMOUS
+ * Returns true iff name is WELLKNOWN/ANONYMOUS.
  *
  * @ingroup krb5_principal
  */
@@ -1341,7 +1341,7 @@ krb5_principal_is_anonymous(krb5_context context,
 }
 
 /**
- * Returns true iff name is WELLKNOWN/FEDERATED
+ * Returns true iff name is WELLKNOWN/FEDERATED.
  *
  * @ingroup krb5_principal
  */
@@ -1414,8 +1414,8 @@ struct krb5_name_canon_rule_data {
  * host lookup by name (i.e., DNS).
  *
  * @param context A Kerberos context.
- * @param hostname hostname to use
- * @param sname Service name to use
+ * @param hostname hostname to use.
+ * @param sname Service name to use.
  * @param type name type of principal, use KRB5_NT_SRV_HST or KRB5_NT_UNKNOWN.
  * @param ret_princ return principal, free with krb5_free_principal().
  *
@@ -2035,7 +2035,7 @@ out:
 }
 
 /**
- * Free name canonicalization rules
+ * Free name canonicalization rules.
  */
 KRB5_LIB_FUNCTION void
 _krb5_free_name_canon_rules(krb5_context context, krb5_name_canon_rule rules)
@@ -2067,9 +2067,9 @@ struct krb5_name_canon_iterator_data {
 /**
  * Initialize name canonicalization iterator.
  *
- * @param context   Kerberos context
- * @param in_princ  principal name to be canonicalized OR
- * @param iter	    output iterator object
+ * @param context   Kerberos context.
+ * @param in_princ  principal name to be canonicalized OR.
+ * @param iter	    output iterator object.
  */
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_name_canon_iterator_start(krb5_context context,
@@ -2167,10 +2167,10 @@ name_canon_iterate(krb5_context context,
  * return or when an error is returned.  Callers must free the iterator
  * if they abandon it mid-way.
  *
- * @param context   Kerberos context
- * @param iter	    name canon rule iterator (input/output)
- * @param try_princ output principal name
- * @param rule_opts output rule options
+ * @param context   Kerberos context.
+ * @param iter	    name canon rule iterator (input/output).
+ * @param try_princ output principal name.
+ * @param rule_opts output rule options.
  */
 KRB5_LIB_FUNCTION krb5_error_code KRB5_LIB_CALL
 krb5_name_canon_iterate(krb5_context context,

--- a/lib/krb5/rd_req.c
+++ b/lib/krb5/rd_req.c
@@ -571,7 +571,7 @@ krb5_rd_req_in_set_keytab(krb5_context context,
 }
 
 /**
- * Set if krb5_rq_red() is going to check the Windows PAC or not
+ * Set if krb5_rq_red() is going to check the Windows PAC or not.
  *
  * @param context Keberos 5 context.
  * @param in krb5_rd_req_in_ctx to check the option on.
@@ -824,18 +824,17 @@ get_key_from_keytab(krb5_context context,
  * @param context Keberos 5 context.
  * @param auth_context the authentication context, can be NULL, then
  *        default values for the authentication context will used.
- * @param inbuf the (AP-REQ) authentication buffer
- *
+ * @param inbuf the (AP-REQ) authentication buffer.
  * @param server the server to authenticate to. If NULL the function
  *        will try to find any available credential in the keytab
  *        that will verify the reply. The function will prefer the
  *        server specified in the AP-REQ, but if
  *        there is no mach, it will try all keytab entries for a
  *        match. This has serious performance issues for large keytabs.
- *
  * @param inctx control the behavior of the function, if NULL, the
  *        default behavior is used.
  * @param outctx the return outctx, free with krb5_rd_req_out_ctx_free().
+ *
  * @return Kerberos 5 error code, see krb5_get_error_message().
  *
  * @ingroup krb5_auth

--- a/lib/krb5/sp800-108-kdf.c
+++ b/lib/krb5/sp800-108-kdf.c
@@ -36,9 +36,9 @@
  */
 
 /**
- * As described in SP800-108 5.1 (for HMAC)
+ * As described in SP800-108 5.1 (for HMAC).
  *
- * @param context	Kerberos 5 context
+ * @param context	Kerberos 5 context.
  * @param kdf_K1	Base key material.
  * @param kdf_label	A string that identifies the purpose for the derived key.
  * @param kdf_context   A binary string containing parties, nonce, etc.
@@ -46,6 +46,7 @@
  * @param kdf_K0	Derived key data.
  *
  * @return Return an error code for an failure or 0 on success.
+ *
  * @ingroup krb5_crypto
  */
 krb5_error_code

--- a/lib/krb5/store.c
+++ b/lib/krb5/store.c
@@ -44,8 +44,8 @@
 /**
  * Add the flags on a storage buffer by or-ing in the flags to the buffer.
  *
- * @param sp the storage buffer to set the flags on
- * @param flags the flags to set
+ * @param sp the storage buffer to set the flags on.
+ * @param flags the flags to set.
  *
  * @ingroup krb5_storage
  */
@@ -57,10 +57,10 @@ krb5_storage_set_flags(krb5_storage *sp, krb5_flags flags)
 }
 
 /**
- * Clear the flags on a storage buffer
+ * Clear the flags on a storage buffer.
  *
- * @param sp the storage buffer to clear the flags on
- * @param flags the flags to clear
+ * @param sp the storage buffer to clear the flags on.
+ * @param flags the flags to clear.
  *
  * @ingroup krb5_storage
  */
@@ -75,8 +75,8 @@ krb5_storage_clear_flags(krb5_storage *sp, krb5_flags flags)
  * Return true or false depending on if the storage flags is set or
  * not. NB testing for the flag 0 always return true.
  *
- * @param sp the storage buffer to check flags on
- * @param flags The flags to test for
+ * @param sp the storage buffer to check flags on.
+ * @param flags The flags to test for.
  *
  * @return true if all the flags are set, false if not.
  *
@@ -121,10 +121,10 @@ krb5_storage_get_byteorder(krb5_storage *sp)
 }
 
 /**
- * Set the max alloc value
+ * Set the max alloc value.
  *
- * @param sp the storage buffer set the max allow for
- * @param size maximum size to allocate, use 0 to remove limit
+ * @param sp the storage buffer set the max allow for.
+ * @param size maximum size to allocate, use 0 to remove limit.
  *
  * @ingroup krb5_storage
  */
@@ -159,11 +159,11 @@ size_too_large_num(krb5_storage *sp, size_t count, size_t size)
  * Seek to a new offset.
  *
  * @param sp the storage buffer to seek in.
- * @param offset the offset to seek
- * @param whence relateive searching, SEEK_CUR from the current
+ * @param offset the offset to seek.
+ * @param whence relateive searching, SEEK_CUR from the current.
  * position, SEEK_END from the end, SEEK_SET absolute from the start.
  *
- * @return The new current offset
+ * @return The new current offset.
  *
  * @ingroup krb5_storage
  */
@@ -195,9 +195,9 @@ krb5_storage_truncate(krb5_storage *sp, off_t offset)
  * Sync the storage buffer to its backing store.  If there is no
  * backing store this function will return success.
  *
- * @param sp the storage buffer to sync
+ * @param sp the storage buffer to sync.
  *
- * @return A Kerberos 5 error code
+ * @return A Kerberos 5 error code.
  *
  * @ingroup krb5_storage
  */
@@ -213,9 +213,9 @@ krb5_storage_fsync(krb5_storage *sp)
 /**
  * Read to the storage buffer.
  *
- * @param sp the storage buffer to read from
- * @param buf the buffer to store the data in
- * @param len the length to read
+ * @param sp the storage buffer to read from.
+ * @param buf the buffer to store the data in.
+ * @param len the length to read.
  *
  * @return The length of data read (can be shorter then len), or negative on error.
  *
@@ -231,9 +231,9 @@ krb5_storage_read(krb5_storage *sp, void *buf, size_t len)
 /**
  * Write to the storage buffer.
  *
- * @param sp the storage buffer to write to
- * @param buf the buffer to write to the storage buffer
- * @param len the length to write
+ * @param sp the storage buffer to write to.
+ * @param buf the buffer to write to the storage buffer.
+ * @param len the length to write.
  *
  * @return The length of data written (can be shorter then len), or negative on error.
  *
@@ -249,8 +249,8 @@ krb5_storage_write(krb5_storage *sp, const void *buf, size_t len)
 /**
  * Set the return code that will be used when end of storage is reached.
  *
- * @param sp the storage
- * @param code the error code to return on end of storage
+ * @param sp the storage.
+ * @param code the error code to return on end of storage.
  *
  * @ingroup krb5_storage
  */
@@ -264,9 +264,9 @@ krb5_storage_set_eof_code(krb5_storage *sp, int code)
 /**
  * Get the return code that will be used when end of storage is reached.
  *
- * @param sp the storage
+ * @param sp the storage.
  *
- * @return storage error code
+ * @return storage error code.
  *
  * @ingroup krb5_storage
  */
@@ -302,8 +302,8 @@ krb5_storage_free(krb5_storage *sp)
 /**
  * Copy the content of storage to a krb5_data.
  *
- * @param sp the storage to copy to a data
- * @param data the copied data, free with krb5_data_free()
+ * @param sp the storage to copy to a data.
+ * @param data the copied data, free with krb5_data_free().
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -440,8 +440,8 @@ krb5_store_int(krb5_storage *sp,
  * Store a int32 to storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value to store
+ * @param sp the storage to write to.
+ * @param value the value to store.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -463,8 +463,8 @@ krb5_store_int32(krb5_storage *sp,
  * Store a int64 to storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value to store
+ * @param sp the storage to write to.
+ * @param value the value to store.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -490,8 +490,8 @@ krb5_store_int64(krb5_storage *sp,
  * Store a uint32 to storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value to store
+ * @param sp the storage to write to.
+ * @param value the value to store.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -509,8 +509,8 @@ krb5_store_uint32(krb5_storage *sp,
  * Store a uint64 to storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value to store
+ * @param sp the storage to write to.
+ * @param value the value to store.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -570,8 +570,8 @@ krb5_ret_int(krb5_storage *sp,
  * Read a int64 from storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value read from the buffer
+ * @param sp the storage to write to.
+ * @param value the value read from the buffer.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -600,8 +600,8 @@ krb5_ret_int64(krb5_storage *sp,
  * Read a uint64 from storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value read from the buffer
+ * @param sp the storage to write to.
+ * @param value the value read from the buffer.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -626,8 +626,8 @@ krb5_ret_uint64(krb5_storage *sp,
  * Read a int32 from storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value read from the buffer
+ * @param sp the storage to write to.
+ * @param value the value read from the buffer.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -655,8 +655,8 @@ krb5_ret_int32(krb5_storage *sp,
  * Read a uint32 from storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value read from the buffer
+ * @param sp the storage to write to.
+ * @param value the value read from the buffer.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -680,8 +680,8 @@ krb5_ret_uint32(krb5_storage *sp, uint32_t *value)
  * Store a int16 to storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value to store
+ * @param sp the storage to write to.
+ * @param value the value to store.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -703,8 +703,8 @@ krb5_store_int16(krb5_storage *sp,
  * Store a uint16 to storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value to store
+ * @param sp the storage to write to.
+ * @param value the value to store.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -722,8 +722,8 @@ krb5_store_uint16(krb5_storage *sp,
  * Read a int16 from storage, byte order is controlled by the settings
  * on the storage, see krb5_storage_set_byteorder().
  *
- * @param sp the storage to write to
- * @param value the value read from the buffer
+ * @param sp the storage to write to.
+ * @param value the value read from the buffer.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -776,8 +776,8 @@ krb5_ret_uint16(krb5_storage *sp,
 /**
  * Store a int8 to storage.
  *
- * @param sp the storage to write to
- * @param value the value to store
+ * @param sp the storage to write to.
+ * @param value the value to store.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -799,8 +799,8 @@ krb5_store_int8(krb5_storage *sp,
 /**
  * Store a uint8 to storage.
  *
- * @param sp the storage to write to
- * @param value the value to store
+ * @param sp the storage to write to.
+ * @param value the value to store.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -815,10 +815,10 @@ krb5_store_uint8(krb5_storage *sp,
 }
 
 /**
- * Read a int8 from storage
+ * Read a int8 from storage.
  *
- * @param sp the storage to write to
- * @param value the value read from the buffer
+ * @param sp the storage to write to.
+ * @param value the value read from the buffer.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -838,10 +838,10 @@ krb5_ret_int8(krb5_storage *sp,
 }
 
 /**
- * Read a uint8 from storage
+ * Read a uint8 from storage.
  *
- * @param sp the storage to write to
- * @param value the value read from the buffer
+ * @param sp the storage to write to.
+ * @param value the value read from the buffer.
  *
  * @return 0 for success, or a Kerberos 5 error code on failure.
  *
@@ -866,7 +866,7 @@ krb5_ret_uint8(krb5_storage *sp,
  * Store a data to the storage. The data is stored with an int32 as
  * lenght plus the data (not padded).
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param data the buffer to store.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -895,7 +895,7 @@ krb5_store_data(krb5_storage *sp,
  * length plus the data (not padded).  This function only differs from
  * krb5_store_data() insofar as it takes a void * and a length as parameters.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param s the string to store.
  * @param len length of the string to be stored.
  *
@@ -915,7 +915,7 @@ krb5_store_datalen(krb5_storage *sp, const void *d, size_t len)
 /**
  * Store a data blob to the storage. The data is stored without a length.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param s the string to store.
  * @param len length of the string to be stored.
  *
@@ -938,8 +938,8 @@ krb5_store_bytes(krb5_storage *sp, const void *d, size_t len)
 /**
  * Parse a data from the storage.
  *
- * @param sp the storage buffer to read from
- * @param data the parsed data
+ * @param sp the storage buffer to read from.
+ * @param data the parsed data.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -978,7 +978,7 @@ krb5_ret_data(krb5_storage *sp,
  * Store a string to the buffer. The data is formated as an len:uint32
  * plus the string itself (not padded).
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param s the string to store.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -1002,8 +1002,8 @@ krb5_store_string(krb5_storage *sp, const char *s)
 /**
  * Parse a string from the storage.
  *
- * @param sp the storage buffer to read from
- * @param string the parsed string
+ * @param sp the storage buffer to read from.
+ * @param string the parsed string.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1035,7 +1035,7 @@ krb5_ret_string(krb5_storage *sp,
  * Store a zero terminated string to the buffer. The data is stored
  * one character at a time until a NUL is stored.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param s the string to store.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -1064,8 +1064,8 @@ krb5_store_stringz(krb5_storage *sp, const char *s)
 /**
  * Parse zero terminated string from the storage.
  *
- * @param sp the storage buffer to read from
- * @param string the parsed string
+ * @param sp the storage buffer to read from.
+ * @param string the parsed string.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1192,7 +1192,7 @@ krb5_ret_stringnl(krb5_storage *sp,
 /**
  * Write a principal block to storage.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param p the principal block to write.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -1229,8 +1229,8 @@ krb5_store_principal(krb5_storage *sp,
 /**
  * Parse principal from the storage.
  *
- * @param sp the storage buffer to read from
- * @param princ the parsed principal
+ * @param sp the storage buffer to read from.
+ * @param princ the parsed principal.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1302,8 +1302,8 @@ krb5_ret_principal(krb5_storage *sp,
 /**
  * Store a keyblock to the storage.
  *
- * @param sp the storage buffer to write to
- * @param p the keyblock to write
+ * @param sp the storage buffer to write to.
+ * @param p the keyblock to write.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1331,8 +1331,8 @@ krb5_store_keyblock(krb5_storage *sp, krb5_keyblock p)
 /**
  * Read a keyblock from the storage.
  *
- * @param sp the storage buffer to write to
- * @param p the keyblock read from storage, free using krb5_free_keyblock()
+ * @param sp the storage buffer to write to.
+ * @param p the keyblock read from storage, free using krb5_free_keyblock().
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1361,7 +1361,7 @@ krb5_ret_keyblock(krb5_storage *sp, krb5_keyblock *p)
 /**
  * Write a times block to storage.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param times the times block to write.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -1386,8 +1386,8 @@ krb5_store_times(krb5_storage *sp, krb5_times times)
 /**
  * Read a times block from the storage.
  *
- * @param sp the storage buffer to write to
- * @param times the times block read from storage
+ * @param sp the storage buffer to write to.
+ * @param times the times block read from storage.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1418,7 +1418,7 @@ krb5_ret_times(krb5_storage *sp, krb5_times *times)
 /**
  * Write a address block to storage.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param p the address block to write.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -1439,8 +1439,8 @@ krb5_store_address(krb5_storage *sp, krb5_address p)
 /**
  * Read a address block from the storage.
  *
- * @param sp the storage buffer to write to
- * @param adr the address block read from storage
+ * @param sp the storage buffer to write to.
+ * @param adr the address block read from storage.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1462,7 +1462,7 @@ krb5_ret_address(krb5_storage *sp, krb5_address *adr)
 /**
  * Write a addresses block to storage.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param p the addresses block to write.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -1487,8 +1487,8 @@ krb5_store_addrs(krb5_storage *sp, krb5_addresses p)
 /**
  * Read a addresses block from the storage.
  *
- * @param sp the storage buffer to write to
- * @param adr the addresses block read from storage
+ * @param sp the storage buffer to write to.
+ * @param adr the addresses block read from storage.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1520,7 +1520,7 @@ krb5_ret_addrs(krb5_storage *sp, krb5_addresses *adr)
 /**
  * Write a auth data block to storage.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param auth the auth data block to write.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -1547,8 +1547,8 @@ krb5_store_authdata(krb5_storage *sp, krb5_authdata auth)
 /**
  * Read a auth data from the storage.
  *
- * @param sp the storage buffer to write to
- * @param auth the auth data block read from storage
+ * @param sp the storage buffer to write to.
+ * @param auth the auth data block read from storage.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1594,7 +1594,7 @@ bitswap32(int32_t b)
 /**
  * Write a credentials block to storage.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param creds the creds block to write.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -1641,8 +1641,8 @@ krb5_store_creds(krb5_storage *sp, krb5_creds *creds)
 /**
  * Read a credentials block from the storage.
  *
- * @param sp the storage buffer to write to
- * @param creds the credentials block read from storage
+ * @param sp the storage buffer to write to.
+ * @param creds the credentials block read from storage.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *
@@ -1697,7 +1697,7 @@ cleanup:
 /**
  * Write a tagged credentials block to storage.
  *
- * @param sp the storage buffer to write to
+ * @param sp the storage buffer to write to.
  * @param creds the creds block to write.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
@@ -1789,8 +1789,8 @@ krb5_store_creds_tag(krb5_storage *sp, krb5_creds *creds)
 /**
  * Read a tagged credentials block from the storage.
  *
- * @param sp the storage buffer to write to
- * @param creds the credentials block read from storage
+ * @param sp the storage buffer to write to.
+ * @param creds the credentials block read from storage.
  *
  * @return 0 on success, a Kerberos 5 error code on failure.
  *

--- a/lib/krb5/store_mem.c
+++ b/lib/krb5/store_mem.c
@@ -110,7 +110,7 @@ mem_no_trunc(krb5_storage *sp, off_t offset)
 }
 
 /**
- * Create a fixed size memory storage block
+ * Create a fixed size memory storage block.
  *
  * @return A krb5_storage on success, or NULL on out of memory error.
  *
@@ -152,7 +152,7 @@ krb5_storage_from_mem(void *buf, size_t len)
 }
 
 /**
- * Create a fixed size memory storage block
+ * Create a fixed size memory storage block.
  *
  * @return A krb5_storage on success, or NULL on out of memory error.
  *
@@ -171,7 +171,7 @@ krb5_storage_from_data(krb5_data *data)
 }
 
 /**
- * Create a fixed size memory storage block that is read only
+ * Create a fixed size memory storage block that is read only.
  *
  * @return A krb5_storage on success, or NULL on out of memory error.
  *

--- a/lib/krb5/ticket.c
+++ b/lib/krb5/ticket.c
@@ -36,10 +36,10 @@
 #include "krb5_locl.h"
 
 /**
- * Free ticket and content
+ * Free ticket and content.
  *
- * @param context a Kerberos 5 context
- * @param ticket ticket to free
+ * @param context a Kerberos 5 context.
+ * @param ticket ticket to free.
  *
  * @return Returns 0 to indicate success.  Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -59,11 +59,11 @@ krb5_free_ticket(krb5_context context,
 }
 
 /**
- * Copy ticket and content
+ * Copy ticket and content.
  *
- * @param context a Kerberos 5 context
- * @param from ticket to copy
- * @param to new copy of ticket, free with krb5_free_ticket()
+ * @param context a Kerberos 5 context.
+ * @param from ticket to copy.
+ * @param to new copy of ticket, free with krb5_free_ticket().
  *
  * @return Returns 0 to indicate success.  Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -105,11 +105,11 @@ krb5_copy_ticket(krb5_context context,
 }
 
 /**
- * Return client principal in ticket
+ * Return client principal in ticket.
  *
- * @param context a Kerberos 5 context
- * @param ticket ticket to copy
- * @param client client principal, free with krb5_free_principal()
+ * @param context a Kerberos 5 context.
+ * @param ticket ticket to copy.
+ * @param client client principal, free with krb5_free_principal().
  *
  * @return Returns 0 to indicate success.  Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -126,11 +126,11 @@ krb5_ticket_get_client(krb5_context context,
 }
 
 /**
- * Return server principal in ticket
+ * Return server principal in ticket.
  *
- * @param context a Kerberos 5 context
- * @param ticket ticket to copy
- * @param server server principal, free with krb5_free_principal()
+ * @param context a Kerberos 5 context.
+ * @param ticket ticket to copy.
+ * @param server server principal, free with krb5_free_principal().
  *
  * @return Returns 0 to indicate success.  Otherwise an kerberos et
  * error code is returned, see krb5_get_error_message().
@@ -147,12 +147,12 @@ krb5_ticket_get_server(krb5_context context,
 }
 
 /**
- * Return end time of a ticket
+ * Return end time of a ticket.
  *
- * @param context a Kerberos 5 context
- * @param ticket ticket to copy
+ * @param context a Kerberos 5 context.
+ * @param ticket ticket to copy.
  *
- * @return end time of ticket
+ * @return end time of ticket.
  *
  * @ingroup krb5
  */
@@ -165,11 +165,11 @@ krb5_ticket_get_endtime(krb5_context context,
 }
 
 /**
- * Return authentication, start, end, and renew limit times of a ticket
+ * Return authentication, start, end, and renew limit times of a ticket.
  *
- * @param context a Kerberos 5 context
- * @param ticket ticket to copy
- * @param t pointer to krb5_times structure
+ * @param context a Kerberos 5 context.
+ * @param ticket ticket to copy.
+ * @param t pointer to krb5_times structure.
  *
  * @ingroup krb5
  */
@@ -188,12 +188,12 @@ krb5_ticket_get_times(krb5_context context,
 }
 
 /**
- * Get the flags from the Kerberos ticket
+ * Get the flags from the Kerberos ticket.
  *
- * @param context Kerberos context
- * @param ticket Kerberos ticket
+ * @param context Kerberos context.
+ * @param ticket Kerberos ticket.
  *
- * @return ticket flags
+ * @return ticket flags.
  *
  * @ingroup krb5_ticket
  */
@@ -416,10 +416,10 @@ _krb5_get_ad(krb5_context context,
  * the field in data. This function is to use for kerberos
  * applications.
  *
- * @param context a Kerberos 5 context
- * @param ticket Kerberos ticket
- * @param type type to fetch
- * @param data returned data, free with krb5_data_free()
+ * @param context a Kerberos 5 context.
+ * @param ticket Kerberos ticket.
+ * @param type type to fetch.
+ * @param data returned data, free with krb5_data_free().
  *
  * @ingroup krb5
  */

--- a/lib/krb5/time.c
+++ b/lib/krb5/time.c
@@ -39,9 +39,9 @@
  * KDC time and local system time.
  *
  * @param context Keberos 5 context.
- * @param sec The applications new of "now" in seconds
- * @param usec The applications new of "now" in micro seconds
-
+ * @param sec The applications new of "now" in seconds.
+ * @param usec The applications new of "now" in micro seconds.
+ *
  * @return Kerberos 5 error code, see krb5_get_error_message().
  *
  * @ingroup krb5

--- a/lib/krb5/verify_init.c
+++ b/lib/krb5/verify_init.c
@@ -203,10 +203,10 @@ cleanup:
 /**
  * Validate the newly fetch credential, see also krb5_verify_init_creds().
  *
- * @param context a Kerberos 5 context
- * @param creds the credentials to verify
- * @param client the client name to match up
- * @param ccache the credential cache to use
+ * @param context a Kerberos 5 context.
+ * @param creds the credentials to verify.
+ * @param client the client name to match up.
+ * @param ccache the credential cache to use.
  * @param service a service name to use, used with
  *        krb5_sname_to_principal() to build a hostname to use to
  *        verify.

--- a/lib/krb5/warn.c
+++ b/lib/krb5/warn.c
@@ -67,9 +67,9 @@ _warnerr(krb5_context context, int do_errtext,
  * the last failure.
  *
  * @param context A Kerberos 5 context.
- * @param code error code of the last error
- * @param fmt message to print
- * @param ap arguments
+ * @param code error code of the last error.
+ * @param fmt message to print.
+ * @param ap arguments.
  *
  * @ingroup krb5_error
  */
@@ -87,8 +87,8 @@ krb5_vwarn(krb5_context context, krb5_error_code code,
  * the last failure.
  *
  * @param context A Kerberos 5 context.
- * @param code error code of the last error
- * @param fmt message to print
+ * @param code error code of the last error.
+ * @param fmt message to print.
  *
  * @ingroup krb5_error
  */
@@ -110,8 +110,8 @@ krb5_warn(krb5_context context, krb5_error_code code, const char *fmt, ...)
  * Log a warning to the log, default stderr.
  *
  * @param context A Kerberos 5 context.
- * @param fmt message to print
- * @param ap arguments
+ * @param fmt message to print.
+ * @param ap arguments.
  *
  * @ingroup krb5_error
  */
@@ -127,7 +127,7 @@ krb5_vwarnx(krb5_context context, const char *fmt, va_list ap)
  * Log a warning to the log, default stderr.
  *
  * @param context A Kerberos 5 context.
- * @param fmt message to print
+ * @param fmt message to print.
  *
  * @ingroup krb5_error
  */
@@ -149,11 +149,11 @@ krb5_warnx(krb5_context context, const char *fmt, ...)
  * Log a warning to the log, default stderr, include bthe error from
  * the last failure and then exit.
  *
- * @param context A Kerberos 5 context
- * @param eval the exit code to exit with
- * @param code error code of the last error
- * @param fmt message to print
- * @param ap arguments
+ * @param context A Kerberos 5 context.
+ * @param eval the exit code to exit with.
+ * @param code error code of the last error.
+ * @param fmt message to print.
+ * @param ap arguments.
  *
  * @ingroup krb5_error
  */
@@ -172,10 +172,10 @@ krb5_verr(krb5_context context, int eval, krb5_error_code code,
  * Log a warning to the log, default stderr, include bthe error from
  * the last failure and then exit.
  *
- * @param context A Kerberos 5 context
- * @param eval the exit code to exit with
- * @param code error code of the last error
- * @param fmt message to print
+ * @param context A Kerberos 5 context.
+ * @param eval the exit code to exit with.
+ * @param code error code of the last error.
+ * @param fmt message to print.
  *
  * @ingroup krb5_error
  */
@@ -193,10 +193,10 @@ krb5_err(krb5_context context, int eval, krb5_error_code code,
 /**
  * Log a warning to the log, default stderr, and then exit.
  *
- * @param context A Kerberos 5 context
- * @param eval the exit code to exit with
- * @param fmt message to print
- * @param ap arguments
+ * @param context A Kerberos 5 context.
+ * @param eval the exit code to exit with.
+ * @param fmt message to print.
+ * @param ap arguments.
  *
  * @ingroup krb5_error
  */
@@ -213,9 +213,9 @@ krb5_verrx(krb5_context context, int eval, const char *fmt, va_list ap)
 /**
  * Log a warning to the log, default stderr, and then exit.
  *
- * @param context A Kerberos 5 context
- * @param eval the exit code to exit with
- * @param fmt message to print
+ * @param context A Kerberos 5 context.
+ * @param eval the exit code to exit with.
+ * @param fmt message to print.
  *
  * @ingroup krb5_error
  */
@@ -233,10 +233,10 @@ krb5_errx(krb5_context context, int eval, const char *fmt, ...)
  * Log a warning to the log, default stderr, include bthe error from
  * the last failure and then abort.
  *
- * @param context A Kerberos 5 context
- * @param code error code of the last error
- * @param fmt message to print
- * @param ap arguments
+ * @param context A Kerberos 5 context.
+ * @param code error code of the last error.
+ * @param fmt message to print.
+ * @param ap arguments.
  *
  * @ingroup krb5_error
  */
@@ -255,10 +255,10 @@ krb5_vabort(krb5_context context, krb5_error_code code,
  * Log a warning to the log, default stderr, include the error from
  * the last failure and then abort.
  *
- * @param context A Kerberos 5 context
- * @param code error code of the last error
- * @param fmt message to print
- * @param ... arguments for format string
+ * @param context A Kerberos 5 context.
+ * @param code error code of the last error.
+ * @param fmt message to print.
+ * @param ... arguments for format string.
  *
  * @ingroup krb5_error
  */
@@ -284,9 +284,9 @@ krb5_vabortx(krb5_context context, const char *fmt, va_list ap)
 /**
  * Log a warning to the log, default stderr, and then abort.
  *
- * @param context A Kerberos 5 context
- * @param fmt printf format string of message to print
- * @param ... arguments for format string
+ * @param context A Kerberos 5 context.
+ * @param fmt printf format string of message to print.
+ * @param ... arguments for format string.
  *
  * @ingroup krb5_error
  */
@@ -303,7 +303,7 @@ krb5_abortx(krb5_context context, const char *fmt, ...)
 /**
  * Set the default logging facility.
  *
- * @param context A Kerberos 5 context
+ * @param context A Kerberos 5 context.
  * @param fac Facility to use for logging.
  *
  * @ingroup krb5_error
@@ -318,7 +318,7 @@ krb5_set_warn_dest(krb5_context context, krb5_log_facility *fac)
 /**
  * Get the default logging facility.
  *
- * @param context A Kerberos 5 context
+ * @param context A Kerberos 5 context.
  *
  * @ingroup krb5_error
  */

--- a/lib/ntlm/digest.c
+++ b/lib/ntlm/digest.c
@@ -868,7 +868,7 @@ heim_digest_verify(heim_digest_t context, char **response)
  * Create a rspauth= response.
  * Assumes that the A1hash/password serverNonce, clientNC, clientNonce, clientQOP is set.
  *
- * @return the rspauth string (including rspauth), return key are stored in serverReply and will be invalid after another call to heim_digest_*
+ * @return the rspauth string (including rspauth), return key are stored in serverReply and will be invalid after another call to heim_digest_*.
  */
 
 const char *

--- a/lib/ntlm/ntlm.c
+++ b/lib/ntlm/ntlm.c
@@ -186,9 +186,9 @@ heim_ntlm_unparse_flags(uint32_t flags, char *s, size_t len)
 
 
 /**
- * heim_ntlm_free_buf frees the ntlm buffer
+ * heim_ntlm_free_buf frees the ntlm buffer.
  *
- * @param p buffer to be freed
+ * @param p buffer to be freed.
  *
  * @ingroup ntlm_core
  */
@@ -433,9 +433,9 @@ out:
 }
 
 /**
- * Frees the ntlm_targetinfo message
+ * Frees the ntlm_targetinfo message.
  *
- * @param ti targetinfo to be freed
+ * @param ti targetinfo to be freed.
  *
  * @ingroup ntlm_core
  */
@@ -468,7 +468,7 @@ out:
  * Encodes a ntlm_targetinfo message.
  *
  * @param ti the ntlm_targetinfo message to encode.
- * @param ucs2 ignored
+ * @param ucs2 ignored.
  * @param data is the return buffer with the encoded message, should be
  * freed with heim_ntlm_free_buf().
  *
@@ -541,9 +541,9 @@ out:
 }
 
 /**
- * Decodes an NTLM targetinfo message
+ * Decodes an NTLM targetinfo message.
  *
- * @param data input data buffer with the encode NTLM targetinfo message
+ * @param data input data buffer with the encode NTLM targetinfo message.
  * @param ucs2 if the strings should be encoded with ucs2 (selected by flag in message).
  * @param ti the decoded target info, should be freed with heim_ntlm_free_targetinfo().
  *
@@ -645,9 +645,9 @@ encode_os_version(krb5_storage *out)
 }
 
 /**
- * Frees the ntlm_type1 message
+ * Frees the ntlm_type1 message.
  *
- * @param data message to be freed
+ * @param data message to be freed.
  *
  * @ingroup ntlm_core
  */
@@ -808,9 +808,9 @@ out:
 }
 
 /**
- * Frees the ntlm_type2 message
+ * Frees the ntlm_type2 message.
  *
- * @param data message to be freed
+ * @param data message to be freed.
  *
  * @ingroup ntlm_core
  */
@@ -952,9 +952,9 @@ out:
 }
 
 /**
- * Frees the ntlm_type3 message
+ * Frees the ntlm_type3 message.
  *
- * @param data message to be freed
+ * @param data message to be freed.
  *
  * @ingroup ntlm_core
  */
@@ -1053,7 +1053,7 @@ out:
  * Encodes an ntlm_type3 message.
  *
  * @param type3 the ntlm_type3 message to encode.
- * @param data is the return buffer with the encoded message, should be
+ * @param data is the return buffer with the encoded message, should be.
  * @param[out] mic_offset offset of message integrity code
  * freed with heim_ntlm_free_buf().
  *
@@ -1242,11 +1242,11 @@ heim_ntlm_nt_key(const char *password, struct ntlm_buf *key)
 }
 
 /**
- * Calculate NTLMv1 response hash
+ * Calculate NTLMv1 response hash.
  *
- * @param key the ntlm v1 key
- * @param len length of key
- * @param challenge sent by the server
+ * @param key the ntlm v1 key.
+ * @param len length of key.
+ * @param challenge sent by the server.
  * @param answer calculated answer, should be freed with heim_ntlm_free_buf().
  *
  * @return In case of success 0 is return, an errors, a errno in what
@@ -1390,8 +1390,8 @@ heim_ntlm_keyex_wrap(struct ntlm_buf *base_session,
 /**
  * Generates an NTLMv1 session random with assosited session master key.
  *
- * @param key the ntlm v1 key
- * @param len length of key
+ * @param key the ntlm v1 key.
+ * @param len length of key.
  * @param session generated session nonce, should be freed with heim_ntlm_free_buf().
  * @param master calculated session master key, should be freed with heim_ntlm_free_buf().
  *
@@ -1422,9 +1422,9 @@ heim_ntlm_build_ntlm1_master(void *key, size_t len,
 /**
  * Generates an NTLMv2 session random with associated session master key.
  *
- * @param key the NTLMv2 key
- * @param len length of key
- * @param blob the NTLMv2 "blob"
+ * @param key the NTLMv2 key.
+ * @param len length of key.
+ * @param blob the NTLMv2 "blob".
  * @param session generated session nonce, should be freed with heim_ntlm_free_buf().
  * @param master calculated session master key, should be freed with heim_ntlm_free_buf().
  *
@@ -1455,9 +1455,9 @@ heim_ntlm_build_ntlm2_master(void *key, size_t len,
 }
 
 /**
- * Given a key and encrypted session, unwrap the session key
+ * Given a key and encrypted session, unwrap the session key.
  *
- * @param baseKey the sessionBaseKey
+ * @param baseKey the sessionBaseKey.
  * @param encryptedSession encrypted session, type3.session field.
  * @param session generated session nonce, should be freed with heim_ntlm_free_buf().
  *
@@ -1505,12 +1505,12 @@ heim_ntlm_keyex_unwrap(struct ntlm_buf *baseKey,
 /**
  * Generates an NTLMv2 session key.
  *
- * @param key the ntlm key
- * @param len length of key
+ * @param key the ntlm key.
+ * @param len length of key.
  * @param username name of the user, as sent in the message, assumed to be in UTF8.
  * @param target the name of the target, assumed to be in UTF8.
- * @param upper_case_target upper case the target, should not be used only for legacy systems
- * @param ntlmv2 the ntlmv2 session key
+ * @param upper_case_target upper case the target, should not be used only for legacy systems.
+ * @param ntlmv2 the ntlmv2 session key.
  *
  * @return 0 on success, or an error code on failure.
  *
@@ -1578,14 +1578,14 @@ heim_ntlm_ts2unixtime(uint64_t t)
 }
 
 /**
- * Calculate LMv2 response
+ * Calculate LMv2 response.
  *
- * @param key the ntlm key
- * @param len length of key
+ * @param key the ntlm key.
+ * @param len length of key.
  * @param username name of the user, as sent in the message, assumed to be in UTF8.
  * @param target the name of the target, assumed to be in UTF8.
  * @param serverchallenge challenge as sent by the server in the type2 message.
- * @param ntlmv2 calculated session key
+ * @param ntlmv2 calculated session key.
  * @param answer ntlm response answer, should be freed with heim_ntlm_free_buf().
  *
  * @return In case of success 0 is return, an errors, a errno in what
@@ -1627,15 +1627,15 @@ heim_ntlm_calculate_lm2(const void *key, size_t len,
 
 
 /**
- * Calculate NTLMv2 response
+ * Calculate NTLMv2 response.
  *
- * @param key the ntlm key
- * @param len length of key
+ * @param key the ntlm key.
+ * @param len length of key.
  * @param username name of the user, as sent in the message, assumed to be in UTF8.
  * @param target the name of the target, assumed to be in UTF8.
  * @param serverchallenge challenge as sent by the server in the type2 message.
  * @param infotarget infotarget as sent by the server in the type2 message.
- * @param ntlmv2 calculated session key
+ * @param ntlmv2 calculated session key.
  * @param answer ntlm response answer, should be freed with heim_ntlm_free_buf().
  *
  * @return In case of success 0 is return, an errors, a errno in what
@@ -1841,15 +1841,15 @@ out:
 /**
  * Verify NTLMv2 response.
  *
- * @param key the ntlm key
- * @param len length of key
+ * @param key the ntlm key.
+ * @param len length of key.
  * @param username name of the user, as sent in the message, assumed to be in UTF8.
  * @param target the name of the target, assumed to be in UTF8.
- * @param now the time now (0 if the library should pick it up itself)
+ * @param now the time now (0 if the library should pick it up itself).
  * @param serverchallenge challenge as sent by the server in the type2 message.
  * @param answer ntlm response answer, should be freed with heim_ntlm_free_buf().
  * @param infotarget infotarget as sent by the server in the type2 message.
- * @param ntlmv2 calculated session key
+ * @param ntlmv2 calculated session key.
  *
  * @return In case of success 0 is return, an errors, a errno in what
  * went wrong.
@@ -1894,11 +1894,11 @@ heim_ntlm_verify_ntlm2(const void *key, size_t len,
 }
 
 /*
- * Calculate the NTLM2 Session Response
+ * Calculate the NTLM2 Session Response.
  *
- * @param clnt_nonce client nonce
- * @param svr_chal server challage
- * @param ntlm2_hash ntlm hash
+ * @param clnt_nonce client nonce.
+ * @param svr_chal server challage.
+ * @param ntlm2_hash ntlm hash.
  * @param lm The LM response, should be freed with heim_ntlm_free_buf().
  * @param ntlm The NTLM response, should be freed with heim_ntlm_free_buf().
  *
@@ -1956,11 +1956,11 @@ heim_ntlm_calculate_ntlm2_sess(const unsigned char clnt_nonce[8],
 
 
 /*
- * Calculate the NTLM2 Session "Verifier"
+ * Calculate the NTLM2 Session "Verifier".
  *
- * @param clnt_nonce client nonce
- * @param svr_chal server challage
- * @param hash The NTLM session verifier
+ * @param clnt_nonce client nonce.
+ * @param svr_chal server challage.
+ * @param hash The NTLM session verifier.
  *
  * @return In case of success 0 is return, an errors, a errno in what
  * went wrong.
@@ -1993,12 +1993,12 @@ heim_ntlm_calculate_ntlm2_sess_hash(const unsigned char clnt_nonce[8],
 
 
 /*
- * Derive a NTLM2 session key
+ * Derive a NTLM2 session key.
  *
- * @param sessionkey session key from domain controller
- * @param clnt_nonce client nonce
- * @param svr_chal server challenge
- * @param derivedkey salted session key
+ * @param sessionkey session key from domain controller.
+ * @param clnt_nonce client nonce.
+ * @param svr_chal server challenge.
+ * @param derivedkey salted session key.
  *
  * @return In case of success 0 is return, an errors, a errno in what
  * went wrong.

--- a/lib/roken/ct.c
+++ b/lib/roken/ct.c
@@ -48,11 +48,11 @@
  * because in some GCC versions there is a bug which can be worked
  * around by doing this.
  *
- * @param p1 memory region 1 to compare
- * @param p2 memory region 2 to compare
- * @param len length of memory
+ * @param p1 memory region 1 to compare.
+ * @param p2 memory region 2 to compare.
+ * @param len length of memory.
  *
- * @return 0 when the memory regions are equal, non zero if not
+ * @return 0 when the memory regions are equal, non zero if not.
  *
  * @ingroup roken
  */

--- a/lib/roken/mini_inetd.c
+++ b/lib/roken/mini_inetd.c
@@ -68,7 +68,7 @@ accept_it (rk_socket_t s, rk_socket_t *ret_socket)
 }
 
 /**
- * Listen on a specified addresses
+ * Listen on a specified addresses.
  *
  * Listens on the specified addresses for incoming connections.  If
  * the \a ret_socket parameter is \a NULL, on return STDIN and STDOUT
@@ -80,7 +80,7 @@ accept_it (rk_socket_t s, rk_socket_t *ret_socket)
  * This function does not return if there is an error or if no
  * connection is established.
  *
- * @param[in] ai Addresses to listen on
+ * @param[in] ai Addresses to listen on.
  * @param[out] ret_socket If non-NULL receives the accepted socket.
  *
  * @see mini_inetd()
@@ -156,7 +156,7 @@ mini_inetd_addrinfo (struct addrinfo *ai, rk_socket_t *ret_socket)
 }
 
 /**
- * Listen on a specified port
+ * Listen on a specified port.
  *
  * Listens on the specified port for incoming connections.  If the \a
  * ret_socket parameter is \a NULL, on return STDIN and STDOUT will be
@@ -167,7 +167,7 @@ mini_inetd_addrinfo (struct addrinfo *ai, rk_socket_t *ret_socket)
  * This function does not return if there is an error or if no
  * connection is established.
  *
- * @param[in] port Port to listen on
+ * @param[in] port Port to listen on.
  * @param[out] ret_socket If non-NULL receives the accepted socket.
  *
  * @see mini_inetd_addrinfo()

--- a/lib/roken/sendmsg.c
+++ b/lib/roken/sendmsg.c
@@ -101,7 +101,7 @@ sendmsg(rk_socket_t s, const struct msghdr *msg, int flags)
  **********************************************************************/
 
 /**
- * Implementation of sendmsg() for WIN32
+ * Implementation of sendmsg() for WIN32.
  *
  * We are using a contrived definition of msghdr which actually uses
  * an array of ::_WSABUF structures instead of ::iovec .  This allows
@@ -116,9 +116,9 @@ sendmsg(rk_socket_t s, const struct msghdr *msg, int flags)
  *   ::MSG_PARTIAL.
  *
  * @param[in] s The socket to use.
- * @param[in] msg The message
+ * @param[in] msg The message.
  * @param[in] flags Flags.  A combination of ::MSG_DONTROUTE,
- *  ::MSG_OOB and ::MSG_PARTIAL
+ *  ::MSG_OOB and ::MSG_PARTIAL.
  *
  * @return The number of bytes sent, on success.  Or -1 on error.
  */

--- a/lib/roken/simple_exec_w32.c
+++ b/lib/roken/simple_exec_w32.c
@@ -42,8 +42,7 @@
  * wait_for_process_timed waits for a process to terminate or until a
  * specified timeout occurs.
  *
- * @param[in] pid Process id for the monitored process
-
+ * @param[in] pid Process id for the monitored process.
  * @param[in] func Timeout callback function.  When the wait times out,
  *     the callback function is called.  The possible return values
  *     from the callback function are:
@@ -53,16 +52,15 @@
  * - 0             Don't timeout again
  * - n             Seconds to next timeout
  *
- * @param[in] ptr Optional parameter for func()
- *
+ * @param[in] ptr Optional parameter for func().
  * @param[in] timeout Seconds to first timeout.
  *
- * @retval SE_E_UNSPECIFIED   Unspecified system error
- * @retval SE_E_FORKFAILED    Fork failure (not applicable for _WIN32 targets)
- * @retval SE_E_WAITPIDFAILED waitpid errors
- * @retval SE_E_EXECTIMEOUT   exec timeout
- * @retval 0 <= Return value  from subprocess
- * @retval SE_E_NOTFOUND      The program coudln't be found
+ * @retval SE_E_UNSPECIFIED   Unspecified system error.
+ * @retval SE_E_FORKFAILED    Fork failure (not applicable for _WIN32 targets).
+ * @retval SE_E_WAITPIDFAILED waitpid errors.
+ * @retval SE_E_EXECTIMEOUT   exec timeout.
+ * @retval 0 <= Return value  from subprocess.
+ * @retval SE_E_NOTFOUND      The program coudln't be found.
  * @retval 128- The signal that killed the subprocess +128.
  */
 ROKEN_LIB_FUNCTION int ROKEN_LIB_CALL

--- a/lib/sl/sl.c
+++ b/lib/sl/sl.c
@@ -476,8 +476,8 @@ osad(const char *s1, const char *s2)
  * Will propose a list of command that are almost matching the command
  * used, if there is no matching, will ask the user to use "help".
  *
- * @param cmds command array to use for matching
- * @param match the command that didn't exists
+ * @param cmds command array to use for matching.
+ * @param match the command that didn't exists.
  */
 
 void

--- a/lib/wind/punycode.c
+++ b/lib/wind/punycode.c
@@ -73,7 +73,7 @@ adapt(unsigned delta, unsigned numpoints, int first)
  * Convert an UCS4 string to a puny-coded DNS label string suitable
  * when combined with delimiters and other labels for DNS lookup.
  *
- * @param in an UCS4 string to convert
+ * @param in an UCS4 string to convert.
  * @param in_len the length of in.
  * @param out the resulting puny-coded string. The string is not NUL
  * terminatied.
@@ -81,7 +81,8 @@ adapt(unsigned delta, unsigned numpoints, int first)
  * the out variable, after processing it will be the length of the out
  * string.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 

--- a/lib/wind/stringprep.c
+++ b/lib/wind/stringprep.c
@@ -42,13 +42,14 @@
 /**
  * Process a input UCS4 string according a string-prep profile.
  *
- * @param in input UCS4 string to process
- * @param in_len length of the input string
- * @param out output UCS4 string
+ * @param in input UCS4 string to process.
+ * @param in_len length of the input string.
+ * @param out output UCS4 string.
  * @param out_len length of the output string.
  * @param flags stringprep profile.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -126,7 +127,8 @@ static const struct {
  * @param name name of the profile.
  * @param flags the resulting profile.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 

--- a/lib/wind/utf8.c
+++ b/lib/wind/utf8.c
@@ -124,7 +124,8 @@ utf8toutf32(const unsigned char **pp, uint32_t *out)
  * the out variable, after processing it will be the length of the out
  * string.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -160,7 +161,8 @@ wind_utf8ucs4(const char *in, uint32_t *out, size_t *out_len)
  * @param in an UTF-8 string to convert.
  * @param out_len the length of the resulting UCS4 string.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -178,17 +180,16 @@ static const char first_char[4] =
  *
  * @param in an UCS4 string to convert.
  * @param in_len the length input array.
-
  * @param out the resulting UTF-8 string, must be at least
  * wind_ucs4utf8_length() + 1 long (the extra char for the NUL).  If
  * out is NULL, the function will calculate the needed space for the
  * out variable (just like wind_ucs4utf8_length()).
-
  * @param out_len before processing out_len should be the length of
  * the out variable, after processing it will be the length of the out
  * string.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -256,7 +257,8 @@ wind_ucs4utf8(const uint32_t *in, size_t in_len, char *out, size_t *out_len)
  * @param in_len the length of UCS4 string to convert.
  * @param out_len the length of the resulting UTF-8 string.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -273,9 +275,10 @@ wind_ucs4utf8_length(const uint32_t *in, size_t in_len, size_t *out_len)
  * @param len the length of the input buffer.
  * @param flags Flags to control the behavior of the function.
  * @param out the output UCS2, the array must be at least out/2 long.
- * @param out_len the output length
+ * @param out_len the output length.
  *
  * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -338,9 +341,10 @@ wind_ucs2read(const void *ptr, size_t len, unsigned int *flags,
  * @param flags Flags to control the behavior of the function.
  * @param ptr The input buffer to write to, the array must be at least
  * (in + 1) * 2 bytes long.
- * @param out_len the output length
+ * @param out_len the output length.
  *
  * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -411,7 +415,8 @@ wind_ucs2write(const uint16_t *in, size_t in_len, unsigned int *flags,
  * the out variable, after processing it will be the length of the out
  * string.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -465,7 +470,8 @@ wind_utf8ucs2(const char *in, uint16_t *out, size_t *out_len)
  * @param in an UTF-8 string to convert.
  * @param out_len the length of the resulting UCS2 string.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -488,7 +494,8 @@ wind_utf8ucs2_length(const char *in, size_t *out_len)
  * the out variable, after processing it will be the length of the out
  * string.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 
@@ -580,7 +587,8 @@ wind_ucs2utf8(const uint16_t *in, size_t in_len, char *out, size_t *out_len)
  * @param in_len an UCS2 string length to convert.
  * @param out_len the length of the resulting UTF-8 string.
  *
- * @return returns 0 on success, an wind error code otherwise
+ * @return returns 0 on success, an wind error code otherwise.
+ *
  * @ingroup wind
  */
 


### PR DESCRIPTION
- This commit focuses on structure. It does not change the numerous typos or spelling mistakes.
- Consistently rely on "autobrief" feature: Remove `@brief`.
- Replace `@value` with `@param`.
- Replace `XXX` with `@todo`.
- Replace unstructured `Inputs:` text with `@param[in]` and `Outputs:` with `@param[out]`.