### PR TITLE
Prevent network leaks of reverse DNS lookups with [libdefaults] block_dns = yes.

### DIFF
--- a/appl/gssmask/gssmask.c
+++ b/appl/gssmask/gssmask.c
@@ -1117,7 +1117,7 @@ create_client(krb5_socket_t sock, int port, const char *moniker)
 
 	getnameinfo((struct sockaddr *)&c->sa, c->salen,
 		    c->servername, sizeof(c->servername),
-		    NULL, 0, NI_NUMERICHOST);
+		    NULL, 0, NI_NUMERICHOST|NI_NUMERICSERV|NI_NUMERICSCOPE);
     }
 
     c->sock = krb5_storage_from_socket(sock);

--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -85,7 +85,8 @@ connect_to_master (krb5_context context, const char *master,
     for (a = ai; a != NULL; a = a->ai_next) {
 	char node[NI_MAXHOST];
 	error = getnameinfo(a->ai_addr, a->ai_addrlen,
-			    node, sizeof(node), NULL, 0, NI_NUMERICHOST);
+			    node, sizeof(node), NULL, 0,
+			    NI_NUMERICHOST|NI_NUMERICSERV|NI_NUMERICSCOPE);
 	if (error)
 	    strlcpy(node, "[unknown-addr]", sizeof(node));
 

--- a/lib/krb5/krbhst.c
+++ b/lib/krb5/krbhst.c
@@ -656,7 +656,7 @@ add_locate(void *ctx, int type, struct sockaddr *addr)
     portnum = socket_get_port(addr);
 
     ret = getnameinfo(addr, socklen, host, sizeof(host), port, sizeof(port),
-		      NI_NUMERICHOST|NI_NUMERICSERV);
+		      NI_NUMERICHOST|NI_NUMERICSERV|NI_NUMERICSCOPE);
     if (ret != 0)
 	return 0;
 

--- a/lib/krb5/send_to_kdc.c
+++ b/lib/krb5/send_to_kdc.c
@@ -369,7 +369,8 @@ debug_host(krb5_context context, int level, struct host *host, const char *fmt, 
 	proto = "udp";
 
     if (getnameinfo(host->ai->ai_addr, host->ai->ai_addrlen,
-		    name, sizeof(name), port, sizeof(port), NI_NUMERICHOST) != 0)
+		    name, sizeof(name), port, sizeof(port),
+		    NI_NUMERICHOST|NI_NUMERICSERV|NI_NUMERICSCOPE) != 0)
 	name[0] = '\0';
 
     switch (host->state) {

--- a/lib/krb5/sock_principal.c
+++ b/lib/krb5/sock_principal.c
@@ -46,6 +46,14 @@ krb5_sock_to_principal (krb5_context context,
     socklen_t salen = sizeof(__ss);
     char hostname[NI_MAXHOST];
 
+    if (krb5_config_get_bool(context, NULL, "libdefaults", "block_dns",
+	    NULL)) {
+	ret = HEIM_EAI_FAIL;
+	krb5_set_error_message (context, ret,
+				"krb5_sock_to_principal: block_dns enabled");
+	return ret;
+    }
+
     if (getsockname (sock, sa, &salen) < 0) {
 	ret = errno;
 	krb5_set_error_message (context, ret, "getsockname: %s", strerror(ret));

--- a/lib/roken/roken-common.h
+++ b/lib/roken/roken-common.h
@@ -252,6 +252,14 @@
 #endif
 
 /*
+ * NI_NUMERICSCOPE is still missing from glibc as of 2024:
+ * https://sourceware.org/bugzilla/show_bug.cgi?id=14102
+ */
+#ifndef	NI_NUMERICSCOPE
+#define	NI_NUMERICSCOPE		0
+#endif
+
+/*
  * constants for getnameinfo
  */
 


### PR DESCRIPTION
1. Unconditionally pass NI_NUMERICHOST|NI_NUMERICSERV|NI_NUMERICSCOPE to most getnameinfo calls.
2. Predicate the remaining call, in krb5_sock_to_principal, on block_dns = no.
3. Add getnameinfo and gethostbyaddr stubs to auditdns.c to help check for leaks.

While here: tidy up the minor issues left over from https://github.com/heimdal/heimdal/pull/1213 (https://github.com/heimdal/heimdal/pull/1213#pullrequestreview-1811770450, https://github.com/heimdal/heimdal/pull/1213#pullrequestreview-1811778956, and a harmless stray semicolon).

fix https://github.com/heimdal/heimdal/issues/1214