### PR TITLE
Added kadm_log_init_recover

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,7 @@ on:
       branches:
          - 'master'
          - 'heimdal-7-1-branch'
+         - 'heimdal-7-8-branch'
       paths:
          - '!docs/**'
          - '!**.md'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,7 +89,7 @@ jobs:
                 /bin/sh ./autogen.sh
                 mkdir build
                 cd build
-                ../configure --srcdir=`dirname "$PWD"` --enable-maintainer-mode --enable-developer --with-ldap $CONFIGURE_OPTS --prefix=$HOME/inst CFLAGS="${{ matrix.cflags }} -Wno-error=shadow -Wno-error=bad-function-cast -Wno-error=unused-function -Wno-error=unused-result -Wno-error=deprecated-declarations"
+                ../configure --srcdir=`dirname "$PWD"` --enable-maintainer-mode --enable-developer --disable-afs-support --with-ldap $CONFIGURE_OPTS --prefix=$HOME/inst CFLAGS="${{ matrix.cflags }} -Wno-error=shadow -Wno-error=bad-function-cast -Wno-error=unused-function -Wno-error=unused-result -Wno-error=deprecated-declarations"
                 make -j4
             - name: Test
               env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,11 +58,11 @@ jobs:
                 name: [linux-clang, linux-gcc]
                 include:
                     - name: linux-clang
-                      os: ubuntu-18.04
+                      os: ubuntu-20.04
                       compiler: clang
                       cflags: ''
                     - name: linux-gcc
-                      os: ubuntu-18.04
+                      os: ubuntu-20.04
                       compiler: gcc
                       cflags: '-Wnonnull'
         steps:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -6,6 +6,7 @@ on:
          - 'master'
          - 'osx-build'
          - 'heimdal-7-1-branch'
+         - 'heimdal-7-8-branch'
       paths:
          - '!docs/**'
          - '!**.md'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,7 @@ on:
          - 'master'
          - 'windows-build'
          - 'heimdal-7-1-branch'
+         - 'heimdal-7-8-branch'
       paths:
          - '!docs/**'
          - '!**.md'

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+Release Notes - Heimdal - Version Heimdal 7.8.1
+
+ Bug fixes
+
+ - CVE-2022-42898 PAC parse integer overflows (fix had been missing in 7.8.0)
+
+ - Fix crash in ipropd-slave when started with pending log recovery
+
 Release Notes - Heimdal - Version Heimdal 7.8
 
  Bug fixes

--- a/cf/Makefile.am.common
+++ b/cf/Makefile.am.common
@@ -147,7 +147,7 @@ SUFFIXES += .x .z .hx
 # clang-format styles is to sort includes, but in many cases in-tree we really
 # don't want to do that.
 .x.c:
-	@if [ -z "$(CLANG_FORMAT)" ]; then \
+	@if [ -z "$(CLANG_FORMAT)" -o "$(CLANG_FORMAT)" = "no" ]; then \
 	    cmp -s $< $@ 2> /dev/null || cp $< $@; \
 	else \
 	    cp $< $@.tmp.c; \

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_REVISION($Revision$)
 AC_PREREQ(2.62)
 test -z "$CFLAGS" && CFLAGS="-g"
-AC_INIT([Heimdal],[7.8.0],[https://github.com/heimdal/heimdal/issues])
+AC_INIT([Heimdal],[7.8.1],[https://github.com/heimdal/heimdal/issues])
 AC_CONFIG_SRCDIR([kuser/kinit.c])
 AC_CONFIG_HEADERS(include/config.h)
 AC_CONFIG_MACRO_DIR([cf])

--- a/kadmin/load.c
+++ b/kadmin/load.c
@@ -436,7 +436,7 @@ doit(const char *filename, int mergep)
      * If we're merging, first recover unconfirmed records in the existing log.
      */
     if (mergep)
-        ret = kadm5_log_init(kadm_handle);
+        ret = kadm5_log_init_recover(kadm_handle);
     if (ret == 0)
         ret = kadm5_log_reinit(kadm_handle, 0);
     if (ret) {

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -991,7 +991,7 @@ renew_func(void *ptr)
      * for some reason...
      */
 
-    if (expire < 1) {
+    if (ret || expire < 1) {
 	/*
 	 * We can't ask to keep spamming stderr but not syslog, so we warn
 	 * only once.

--- a/lib/hcrypto/test_cipher.c
+++ b/lib/hcrypto/test_cipher.c
@@ -86,31 +86,6 @@ struct tests aes_cfb_tests[] = {
 };
 
 
-struct tests rc2_tests[] = {
-    { "rc2",
-      "\x88\xbc\xa9\x0e\x90\x87\x5a\x7f\x0f\x79\xc3\x84\x62\x7b\xaf\xb2",
-      16,
-      "\x00\x00\x00\x00\x00\x00\x00\x00",
-      8,
-      "\x00\x00\x00\x00\x00\x00\x00\x00",
-      "\x22\x69\x55\x2a\xb0\xf8\x5c\xa6",
-      NULL
-    }
-};
-
-
-struct tests rc2_40_tests[] = {
-    { "rc2-40",
-      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-      16,
-      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-      16,
-      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-      "\xc0\xb8\xff\xa5\xd6\xeb\xc9\x62\xcc\x52\x5f\xfe\x9a\x3c\x97\xe6",
-      NULL
-    }
-};
-
 struct tests des_ede3_tests[] = {
     { "des-ede3",
       "\x19\x17\xff\xe6\xbb\x77\x2e\xfc"
@@ -354,10 +329,6 @@ main(int argc, char **argv)
 	ret += test_cipher(i, EVP_hcrypto_aes_256_cbc(), &aes_tests[i]);
     for (i = 0; i < sizeof(aes_cfb_tests)/sizeof(aes_cfb_tests[0]); i++)
 	ret += test_cipher(i, EVP_hcrypto_aes_128_cfb8(), &aes_cfb_tests[i]);
-    for (i = 0; i < sizeof(rc2_tests)/sizeof(rc2_tests[0]); i++)
-	ret += test_cipher(i, EVP_hcrypto_rc2_cbc(), &rc2_tests[i]);
-    for (i = 0; i < sizeof(rc2_40_tests)/sizeof(rc2_40_tests[0]); i++)
-	ret += test_cipher(i, EVP_hcrypto_rc2_40_cbc(), &rc2_40_tests[i]);
     for (i = 0; i < sizeof(des_ede3_tests)/sizeof(des_ede3_tests[0]); i++)
 	ret += test_cipher(i, EVP_hcrypto_des_ede3_cbc(), &des_ede3_tests[i]);
     for (i = 0; i < sizeof(camellia128_tests)/sizeof(camellia128_tests[0]); i++)
@@ -372,8 +343,6 @@ main(int argc, char **argv)
 	ret += test_cipher(i, EVP_cc_aes_256_cbc(), &aes_tests[i]);
     for (i = 0; i < sizeof(aes_cfb_tests)/sizeof(aes_cfb_tests[0]); i++)
 	ret += test_cipher(i, EVP_cc_aes_128_cfb8(), &aes_cfb_tests[i]);
-    for (i = 0; i < sizeof(rc2_40_tests)/sizeof(rc2_40_tests[0]); i++)
-	ret += test_cipher(i, EVP_cc_rc2_40_cbc(), &rc2_40_tests[i]);
     for (i = 0; i < sizeof(des_ede3_tests)/sizeof(des_ede3_tests[0]); i++)
 	ret += test_cipher(i, EVP_cc_des_ede3_cbc(), &des_ede3_tests[i]);
     for (i = 0; i < sizeof(camellia128_tests)/sizeof(camellia128_tests[0]); i++)
@@ -389,10 +358,6 @@ main(int argc, char **argv)
 	ret += test_cipher(i, EVP_w32crypto_aes_256_cbc(), &aes_tests[i]);
     for (i = 0; i < sizeof(aes_cfb_tests)/sizeof(aes_cfb_tests[0]); i++)
 	ret += test_cipher(i, EVP_w32crypto_aes_128_cfb8(), &aes_cfb_tests[i]);
-    for (i = 0; i < sizeof(rc2_tests)/sizeof(rc2_tests[0]); i++)
-	ret += test_cipher(i, EVP_w32crypto_rc2_cbc(), &rc2_tests[i]);
-    for (i = 0; i < sizeof(rc2_40_tests)/sizeof(rc2_40_tests[0]); i++)
-	ret += test_cipher(i, EVP_w32crypto_rc2_40_cbc(), &rc2_40_tests[i]);
     for (i = 0; i < sizeof(des_ede3_tests)/sizeof(des_ede3_tests[0]); i++)
 	ret += test_cipher(i, EVP_w32crypto_des_ede3_cbc(), &des_ede3_tests[i]);
     for (i = 0; i < sizeof(rc4_tests)/sizeof(rc4_tests[0]); i++)
@@ -405,10 +370,6 @@ main(int argc, char **argv)
 	ret += test_cipher(i, EVP_pkcs11_aes_256_cbc(), &aes_tests[i]);
     for (i = 0; i < sizeof(aes_cfb_tests)/sizeof(aes_cfb_tests[0]); i++)
 	ret += test_cipher(i, EVP_pkcs11_aes_128_cfb8(), &aes_cfb_tests[i]);
-    for (i = 0; i < sizeof(rc2_tests)/sizeof(rc2_tests[0]); i++)
-	ret += test_cipher(i, EVP_pkcs11_rc2_cbc(), &rc2_tests[i]);
-    for (i = 0; i < sizeof(rc2_40_tests)/sizeof(rc2_40_tests[0]); i++)
-	ret += test_cipher(i, EVP_pkcs11_rc2_40_cbc(), &rc2_40_tests[i]);
     for (i = 0; i < sizeof(des_ede3_tests)/sizeof(des_ede3_tests[0]); i++)
 	ret += test_cipher(i, EVP_pkcs11_des_ede3_cbc(), &des_ede3_tests[i]);
     for (i = 0; i < sizeof(rc4_tests)/sizeof(rc4_tests[0]); i++)
@@ -421,10 +382,6 @@ main(int argc, char **argv)
 	ret += test_cipher(i, EVP_ossl_aes_256_cbc(), &aes_tests[i]);
     for (i = 0; i < sizeof(aes_cfb_tests)/sizeof(aes_cfb_tests[0]); i++)
 	ret += test_cipher(i, EVP_ossl_aes_128_cfb8(), &aes_cfb_tests[i]);
-    for (i = 0; i < sizeof(rc2_tests)/sizeof(rc2_tests[0]); i++)
-	ret += test_cipher(i, EVP_ossl_rc2_cbc(), &rc2_tests[i]);
-    for (i = 0; i < sizeof(rc2_40_tests)/sizeof(rc2_40_tests[0]); i++)
-	ret += test_cipher(i, EVP_ossl_rc2_40_cbc(), &rc2_40_tests[i]);
     for (i = 0; i < sizeof(des_ede3_tests)/sizeof(des_ede3_tests[0]); i++)
 	ret += test_cipher(i, EVP_ossl_des_ede3_cbc(), &des_ede3_tests[i]);
     for (i = 0; i < sizeof(rc4_tests)/sizeof(rc4_tests[0]); i++)

--- a/lib/ipc/server.c
+++ b/lib/ipc/server.c
@@ -125,18 +125,16 @@ mach_complete_sync(heim_sipc_call ctx, int returnvalue, heim_idata *reply)
     mach_msg_type_number_t replyinCnt;
     heim_ipc_message_outband_t replyout;
     mach_msg_type_number_t replyoutCnt;
-    kern_return_t kr;
+    kern_return_t kr = KERN_SUCCESS;
 
     if (returnvalue) {
 	/* on error, no reply */
 	replyinCnt = 0;
 	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else if (reply->length < 2048) {
 	replyinCnt = reply->length;
 	memcpy(replyin, reply->data, replyinCnt);
 	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else {
 	replyinCnt = 0;
 	kr = vm_read(mach_task_self(),
@@ -144,9 +142,12 @@ mach_complete_sync(heim_sipc_call ctx, int returnvalue, heim_idata *reply)
 		     (vm_address_t *)&replyout, &replyoutCnt);
     }
 
+    if (kr == KERN_SUCCESS)
+        returnvalue = kr;
+
     mheim_ripc_call_reply(s->reply_port, returnvalue,
-			  replyin, replyinCnt,
-			  replyout, replyoutCnt);
+                          replyin, replyinCnt,
+                          replyout, replyoutCnt);
 
     heim_ipc_free_cred(s->cred);
     free(s->req.data);
@@ -162,18 +163,16 @@ mach_complete_async(heim_sipc_call ctx, int returnvalue, heim_idata *reply)
     mach_msg_type_number_t replyinCnt;
     heim_ipc_message_outband_t replyout;
     mach_msg_type_number_t replyoutCnt;
-    kern_return_t kr;
+    kern_return_t kr = KERN_SUCCESS;
 
     if (returnvalue) {
 	/* on error, no reply */
 	replyinCnt = 0;
 	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else if (reply->length < 2048) {
 	replyinCnt = reply->length;
 	memcpy(replyin, reply->data, replyinCnt);
 	replyout = 0; replyoutCnt = 0;
-	kr = KERN_SUCCESS;
     } else {
 	replyinCnt = 0;
 	kr = vm_read(mach_task_self(),
@@ -181,9 +180,12 @@ mach_complete_async(heim_sipc_call ctx, int returnvalue, heim_idata *reply)
 		     (vm_address_t *)&replyout, &replyoutCnt);
     }
 
-    kr = mheim_aipc_acall_reply(s->reply_port, returnvalue,
-				replyin, replyinCnt,
-				replyout, replyoutCnt);
+    if (kr == KERN_SUCCESS)
+        returnvalue = kr;
+
+    mheim_aipc_acall_reply(s->reply_port, returnvalue,
+                           replyin, replyinCnt,
+                           replyout, replyoutCnt);
     heim_ipc_free_cred(s->cred);
     free(s->req.data);
     free(s);

--- a/lib/kadm5/iprop-log.c
+++ b/lib/kadm5/iprop-log.c
@@ -377,13 +377,13 @@ iprop_truncate(struct truncate_options *opt, int argc, char **argv)
 
     if (opt->reset_flag) {
         /* First recover unconfirmed records */
-        ret = kadm5_log_init(server_context);
+        ret = kadm5_log_init_recover(server_context);
         if (ret == 0)
             ret = kadm5_log_reinit(server_context, 0);
     } else {
-        ret = kadm5_log_init(server_context);
+        ret = kadm5_log_init_recover(server_context);
         if (ret)
-            krb5_err(context, 1, ret, "kadm5_log_init");
+            krb5_err(context, 1, ret, "kadm5_log_init_recover");
         ret = kadm5_log_truncate(server_context, opt->keep_entries_integer,
                                  opt->max_bytes_integer);
     }

--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -800,19 +800,9 @@ main(int argc, char **argv)
 
     slave_status(context, status_file, "creating log file");
 
-    ret = server_context->db->hdb_open(context,
-                                       server_context->db,
-                                       O_RDWR | O_CREAT, 0600);
+    ret = kadm5_log_init_recover(server_context);
     if (ret)
-	krb5_err (context, 1, ret, "db->open");
-
-    ret = kadm5_log_init (server_context);
-    if (ret)
-	krb5_err (context, 1, ret, "kadm5_log_init");
-
-    ret = server_context->db->hdb_close (context, server_context->db);
-    if (ret)
-	krb5_err (context, 1, ret, "db->close");
+	krb5_err (context, 1, ret, "kadm5_log_init_recover");
 
     get_creds(context, keytab_str, &ccache, master);
 
@@ -979,20 +969,11 @@ main(int argc, char **argv)
                 continue;
             }
 
-	    ret = server_context->db->hdb_open(context,
-					       server_context->db,
-					       O_RDWR | O_CREAT, 0600);
-	    if (ret)
-		krb5_err (context, 1, ret, "db->open");
-
-            ret = kadm5_log_init(server_context);
+            ret = kadm5_log_init_recover(server_context);
             if (ret) {
-                krb5_err(context, IPROPD_RESTART, ret, "kadm5_log_init while "
-                         "handling a message from the master");
+                krb5_err(context, IPROPD_RESTART, ret, "kadm5_log_init_recover"
+                         " while handling a message from the master");
             }
-	    ret = server_context->db->hdb_close (context, server_context->db);
-	    if (ret)
-		krb5_err (context, 1, ret, "db->close");
 
 	    switch (tmp) {
 	    case FOR_YOU :

--- a/lib/kadm5/libkadm5srv-exports.def
+++ b/lib/kadm5/libkadm5srv-exports.def
@@ -75,6 +75,7 @@ EXPORTS
 	kadm5_log_init
 	kadm5_log_init_nb
 	kadm5_log_init_nolock
+	kadm5_log_init_recover
 	kadm5_log_init_sharedlock
 	kadm5_log_next
 	kadm5_log_nop

--- a/lib/kadm5/log.c
+++ b/lib/kadm5/log.c
@@ -682,6 +682,27 @@ kadm5_log_init(kadm5_server_context *server_context)
     return log_init(server_context, LOCK_EX);
 }
 
+/* Open the log for possible replay */
+kadm5_ret_t
+kadm5_log_init_recover(kadm5_server_context *server_context)
+{
+    int ret;
+    int ret2;
+
+    /* Replay needs an open database handle */
+    ret = server_context->db->hdb_open(server_context->context,
+                                       server_context->db,
+                                       O_RDWR | O_CREAT, 0600);
+    if (ret)
+        return ret;
+    ret = log_init(server_context, LOCK_EX);
+    ret2 = server_context->db->hdb_close(server_context->context,
+                                         server_context->db);
+    if (ret != 0)
+        return ret;
+    return ret2;
+}
+
 /* Open the log with an exclusive non-blocking lock */
 kadm5_ret_t
 kadm5_log_init_nb(kadm5_server_context *server_context)

--- a/lib/kadm5/version-script.map
+++ b/lib/kadm5/version-script.map
@@ -77,6 +77,7 @@ HEIMDAL_KAMD5_SERVER_1.0 {
 		kadm5_log_init;
 		kadm5_log_init_nb;
 		kadm5_log_init_nolock;
+		kadm5_log_init_recover;
 		kadm5_log_init_sharedlock;
 		kadm5_log_next;
 		kadm5_log_nop;

--- a/lib/krb5/store-int.c
+++ b/lib/krb5/store-int.c
@@ -49,7 +49,7 @@ KRB5_LIB_FUNCTION krb5_ssize_t KRB5_LIB_CALL
 _krb5_get_int64(void *buffer, uint64_t *value, size_t size)
 {
     unsigned char *p = buffer;
-    unsigned long v = 0;
+    uint64_t v = 0;
     size_t i;
     for (i = 0; i < size; i++)
 	v = (v << 8) + p[i];

--- a/windows/NTMakefile.version
+++ b/windows/NTMakefile.version
@@ -8,7 +8,7 @@ VER_PACKAGE_COMPANY=www.h5l.org
 
 VER_PRODUCT_MAJOR=7
 VER_PRODUCT_MINOR=8
-VER_PRODUCT_AUX=0
+VER_PRODUCT_AUX=1
 VER_PRODUCT_PATCH=0
 
 # ------------------------------------------------------------


### PR DESCRIPTION
This takes care of opening and closing the database for use with log possible recovery, without immediate intent to keep the database open for one or more changes.  This simplifies code in kadmin/load.c and lib/kadm5/ipropd_slave.c.