### PR TITLE
Allow GSS_C_CHANNEL_BOUND_FLAG on the client

### DIFF
--- a/lib/gssapi/krb5/8003.c
+++ b/lib/gssapi/krb5/8003.c
@@ -87,6 +87,11 @@ _gsskrb5_create_8003_checksum (
 {
     u_char *p;
 
+#define _GSS_C_NON_8003_WIRE_FLAGS \
+	GSS_C_CHANNEL_BOUND_FLAG
+
+    flags &= ~_GSS_C_NON_8003_WIRE_FLAGS;
+
     /*
      * see rfc1964 (section 1.1.1 (Initial Token), and the checksum value
      * field's format) */

--- a/lib/gssapi/krb5/init_sec_context.c
+++ b/lib/gssapi/krb5/init_sec_context.c
@@ -498,6 +498,7 @@ init_auth_restart
     krb5_data fwd_data, timedata;
     int32_t offset = 0, oldoffset = 0;
     uint32_t flagmask;
+    krb5_boolean channel_bound = FALSE;
 
     krb5_data_zero(&outbuf);
     krb5_data_zero(&fwd_data);
@@ -587,6 +588,11 @@ init_auth_restart
     }
     flags |= GSS_C_TRANS_FLAG;
 
+    if (req_flags & GSS_C_CHANNEL_BOUND_FLAG) {
+	flags |= GSS_C_CHANNEL_BOUND_FLAG;
+	channel_bound = TRUE;
+    }
+
     if (ret_flags)
 	*ret_flags = flags;
     ctx->flags = flags;
@@ -626,6 +632,7 @@ init_auth_restart
 				     enctype,
 				     ctx->kcred,
 				     &cksum,
+				     channel_bound,
 				     &authenticator,
 				     KRB5_KU_AP_REQ_AUTH);
 

--- a/lib/gssapi/test_context.c
+++ b/lib/gssapi/test_context.c
@@ -82,6 +82,7 @@ static int token_split  = 0;
 static int version_flag = 0;
 static int verbose_flag = 0;
 static int help_flag	= 0;
+static int i_channel_bound = 0;
 static char *i_channel_bindings = NULL;
 static char *a_channel_bindings = NULL;
 
@@ -287,6 +288,8 @@ loop(gss_OID mechoid,
 	flags |= GSS_C_DELEG_FLAG;
     if (policy_deleg_flag)
 	flags |= GSS_C_DELEG_POLICY_FLAG;
+    if (i_channel_bound)
+	flags |= GSS_C_CHANNEL_BOUND_FLAG;
 
     input_token.value = rk_UNCONST(target);
     input_token.length = strlen(target);
@@ -904,6 +907,7 @@ static struct getargs args[] = {
     {"client-name", 0,  arg_string,     &client_name, "client name", NULL },
     {"client-password", 0,  arg_string, &client_password, "client password", NULL },
     {"anonymous", 0,	arg_flag,	&anon_flag, "anonymous auth", NULL },
+    {"i-channel-bound",0, arg_flag,	&i_channel_bound, "initiator channel bound", NULL },
     {"i-channel-bindings", 0, arg_string, &i_channel_bindings, "initiator channel binding data", NULL },
     {"a-channel-bindings", 0, arg_string, &a_channel_bindings, "acceptor channel binding data", NULL },
     {"limit-enctype",0,	arg_string,	&limit_enctype_string, "enctype", NULL },

--- a/lib/krb5/build_auth.c
+++ b/lib/krb5/build_auth.c
@@ -86,6 +86,7 @@ add_etypelist(krb5_context context,
 
 static krb5_error_code
 add_ap_options(krb5_context context,
+	       krb5_boolean channel_bound,
 	       krb5_authdata *auth_data)
 {
     krb5_error_code ret;
@@ -97,6 +98,9 @@ add_ap_options(krb5_context context,
 					      "libdefaults",
 					      "client_aware_channel_bindings",
 					      NULL);
+
+    if (channel_bound)
+	require_cb = TRUE;
 
     if (!require_cb)
 	return 0;
@@ -117,6 +121,7 @@ add_ap_options(krb5_context context,
 
 static krb5_error_code
 make_ap_authdata(krb5_context context,
+                 krb5_boolean channel_bound,
                  krb5_authdata **auth_data)
 {
     krb5_error_code ret;
@@ -136,7 +141,7 @@ make_ap_authdata(krb5_context context,
      * in the AP authenticator when looking for AD-AP-OPTIONS. Make sure to
      * bundle it together with etypes.
      */
-    ret = add_ap_options(context, &ad);
+    ret = add_ap_options(context, channel_bound, &ad);
     if (ret) {
 	free_AuthorizationData(&ad);
 	return ret;
@@ -165,6 +170,7 @@ _krb5_build_authenticator (krb5_context context,
 			   krb5_enctype enctype,
 			   krb5_creds *cred,
 			   Checksum *cksum,
+			   krb5_boolean channel_bound,
 			   krb5_data *result,
 			   krb5_key_usage usage)
 {
@@ -221,7 +227,9 @@ _krb5_build_authenticator (krb5_context context,
 	     * This is not GSS-API specific, we only enable it for
 	     * GSS for now
 	     */
-	    ret = make_ap_authdata(context, &auth.authorization_data);
+	    ret = make_ap_authdata(context,
+				   channel_bound,
+				   &auth.authorization_data);
 	    if (ret)
 		goto fail;
 	}

--- a/lib/krb5/mk_req_ext.c
+++ b/lib/krb5/mk_req_ext.c
@@ -117,6 +117,7 @@ _krb5_mk_req_internal(krb5_context context,
 				    ac->keyblock->keytype,
 				    in_creds,
 				    c_opt,
+				    FALSE, /* channel_bound */
 				    &authenticator,
 				    encrypt_usage);
     if (c_opt)

--- a/tests/gss/check-context.in
+++ b/tests/gss/check-context.in
@@ -389,6 +389,41 @@ for mech in krb5 spnego; do
 		--mech-type=$mech host@lucid.test.h5l.se 2>/dev/null && \
 		{ eval "$testfailed"; }
 
+	echo "${mech}: initiator null bindings bound (client-aware-flag)" ; > messages.log
+	${context} -v --i-channel-bound \
+		--mech-type=$mech host@lucid.test.h5l.se > cbinding.log || \
+		{ eval "$testfailed"; }
+	grep "sflags:" cbinding.log | grep "channel-bound" > /dev/null && \
+		{ echo "channel-bound flag unexpected"; eval "$testfailed"; }
+
+	echo "${mech}: initiator only bindings (client-aware-flag)" ; > messages.log
+	${context} -v --i-channel-bound \
+		--i-channel-bindings=abc \
+		--mech-type=$mech host@lucid.test.h5l.se > cbinding.log || \
+		{ eval "$testfailed"; }
+	grep "sflags:" cbinding.log | grep "channel-bound" > /dev/null && \
+		{ echo "channel-bound flag unexpected"; eval "$testfailed"; }
+
+	echo "${mech}: acceptor only bindings (client-aware-flag)" ; > messages.log
+	${context} -v --i-channel-bound \
+		--a-channel-bindings=abc \
+		--mech-type=$mech host@lucid.test.h5l.se 2>/dev/null && \
+		{ eval "$testfailed"; }
+
+	echo "${mech}: matching bindings (client-aware-flag)" ; > messages.log
+	${context} -v --i-channel-bound \
+		--i-channel-bindings=abc --a-channel-bindings=abc \
+		--mech-type=$mech host@lucid.test.h5l.se > cbinding.log || \
+		{ eval "$testfailed"; }
+	grep "sflags:" cbinding.log | grep "channel-bound" > /dev/null || \
+		{ echo "no channel-bound flag"; eval "$testfailed"; }
+
+	echo "${mech}: non matching bindings (client-aware-flag)" ; > messages.log
+	${context} -v --i-channel-bound \
+		--i-channel-bindings=abc --a-channel-bindings=xyz \
+		--mech-type=$mech host@lucid.test.h5l.se 2>/dev/null && \
+		{ eval "$testfailed"; }
+
 done
 
 #echo "sasl-digest-md5"


### PR DESCRIPTION
Allow an application to provide GSS_C_CHANNEL_BOUND_FLAG on the client side and
force KERB_AP_OPTIONS_CBT.

See https://github.com/krb5/krb5/pull/1329