### PR TITLE
lib/gssapi/krb5: don't ignore _gsskrb5_decapsulate() result in init_s…

### DIFF
--- a/lib/gssapi/krb5/init_sec_context.c
+++ b/lib/gssapi/krb5/init_sec_context.c
@@ -787,6 +787,9 @@ repl_mutual
 		return GSS_S_FAILURE;
 	    }
 	}
+	if (ret != GSS_S_COMPLETE) {
+		return ret;
+	}
 	kret = krb5_rd_rep (context,
 			    ctx->auth_context,
 			    &indata,


### PR DESCRIPTION
…ec_context responses

BUG: https://bugzilla.samba.org/show_bug.cgi?id=15603