### PR TITLE
kdc: APPLE disable enable-pkinit by default as documented

### DIFF
--- a/kdc/default_config.c
+++ b/kdc/default_config.c
@@ -413,21 +413,18 @@ KDC_LIB_FUNCTION krb5_error_code KDC_LIB_CALL
 krb5_kdc_pkinit_config(krb5_context context, krb5_kdc_configuration *config)
 {
 #ifdef PKINIT
+    if (config->enable_pkinit) {
 #ifdef __APPLE__
-    config->enable_pkinit = 1;
-
-    if (config->pkinit_kdc_identity == NULL) {
-	if (config->pkinit_kdc_friendly_name == NULL)
-	    config->pkinit_kdc_friendly_name =
-		strdup("O=System Identity,CN=com.apple.kerberos.kdc");
-	config->pkinit_kdc_identity = strdup("KEYCHAIN:");
-    }
-    if (config->pkinit_kdc_anchors == NULL)
-	config->pkinit_kdc_anchors = strdup("KEYCHAIN:");
-
+	if (config->pkinit_kdc_identity == NULL) {
+	    if (config->pkinit_kdc_friendly_name == NULL)
+		config->pkinit_kdc_friendly_name =
+		    strdup("O=System Identity,CN=com.apple.kerberos.kdc");
+	    config->pkinit_kdc_identity = strdup("KEYCHAIN:");
+	}
+	if (config->pkinit_kdc_anchors == NULL)
+	    config->pkinit_kdc_anchors = strdup("KEYCHAIN:");
 #endif /* __APPLE__ */
 
-    if (config->enable_pkinit) {
 	if (config->pkinit_kdc_identity == NULL)
 	    krb5_errx(context, 1, "pkinit enabled but no identity");
 


### PR DESCRIPTION
commit 4d48b172ab06692e9f23b24c120b61465f43c94b ("add pkinit configration for btmm") introduced automatic configuration of the 'pkinit_kdc_identity' and 'pkinit_kdc_friendly_name' on macOS but also modified the default for the 'enable_pkinit' setting such that pkinit is enabled on all __APPLE__ platforms overriding the [kdc] enable-pkinit setting obtained from the configuration.

This change modifies the enable-pkinit behavior on __APPLE__ platforms to match those on every other platform.