### PR TITLE
Fix handling of FILE ccache removed creds

### DIFF
--- a/lib/krb5/fcache.c
+++ b/lib/krb5/fcache.c
@@ -1088,6 +1088,9 @@ cred_delete(krb5_context context,
      */
     cred->times.endtime = 0;
 
+    /* For compatibility with MIT d3b39a8bac6206b5ea78b0bf6a2958c1df0b0dd5 */
+    cred->times.authtime = -1;
+
     /* ...except for config creds because we don't check their endtimes */
     if (srealm && strcmp(srealm, "X-CACHECONF:") == 0) {
 	ret = krb5_principal_set_realm(context, cred->server, "X-RMED-CONF:");

--- a/lib/krb5/fcache.c
+++ b/lib/krb5/fcache.c
@@ -997,15 +997,25 @@ fcc_get_next (krb5_context context,
     if (FCC_CURSOR(*cursor) == NULL)
         return krb5_einval(context, 3);
 
-    FCC_CURSOR(*cursor)->cred_start =
-        krb5_storage_seek(FCC_CURSOR(*cursor)->sp, 0, SEEK_CUR);
+    while (1) {
+	FCC_CURSOR(*cursor)->cred_start =
+	    krb5_storage_seek(FCC_CURSOR(*cursor)->sp, 0, SEEK_CUR);
 
-    ret = krb5_ret_creds(FCC_CURSOR(*cursor)->sp, creds);
-    if (ret)
-	krb5_clear_error_message(context);
+	ret = krb5_ret_creds(FCC_CURSOR(*cursor)->sp, creds);
 
-    FCC_CURSOR(*cursor)->cred_end =
-        krb5_storage_seek(FCC_CURSOR(*cursor)->sp, 0, SEEK_CUR);
+	FCC_CURSOR(*cursor)->cred_end =
+	    krb5_storage_seek(FCC_CURSOR(*cursor)->sp, 0, SEEK_CUR);
+
+	if (ret) {
+	    krb5_clear_error_message(context);
+	    break;
+	}
+
+	if (creds->times.endtime != 0)
+	    break;
+
+	krb5_free_cred_contents(context, creds);
+    }
 
     return ret;
 }


### PR DESCRIPTION
For compatibility with MIT both endtime and authtime must be modified in order for the cred to be ignored when iterating the ccache contents.

Heimdal fcc_next_cred() must ignore removed credentials when iterating and not pass them back to the application.    Returning a cred with endtime < authtime violates the spirit of RFC4120 which requires that a KDC not return a cred with an endtime < the starttime or authtime.
