### PR TITLE
Clock skew fixes

### DIFF
--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -694,10 +694,14 @@ _krb5_fast_unwrap_error(krb5_context context,
     idx = 0;
     pa = krb5_find_padata(md->val, md->len, KRB5_PADATA_FX_FAST, &idx);
     if (pa == NULL) {
-	ret = KRB5_KDCREP_MODIFIED;
-	krb5_set_error_message(context, ret,
-			       N_("FAST fast response is missing FX-FAST", ""));
-	goto out;
+	/*
+	 * Typically _krb5_fast_wrap_req() has set KRB5_FAST_EXPECTED, which
+	 * means check_fast() will complain and return KRB5KRB_AP_ERR_MODIFIED.
+	 *
+	 * But for TGS-REP init_tgs_req() clears KRB5_FAST_EXPECTED and we'll
+	 * ignore a missing KRB5_PADATA_FX_FAST.
+	 */
+	return check_fast(context, state);
     }
 
     ret = unwrap_fast_rep(context, state, pa, &fastrep);

--- a/lib/krb5/mcache.c
+++ b/lib/krb5/mcache.c
@@ -233,7 +233,7 @@ mcc_initialize(krb5_context context,
      */
     mcc_destroy_internal(context, m);
     m->dead = 0;
-    m->kdc_offset = 0;
+    m->kdc_offset = context->kdc_sec_offset;
     m->mtime = time(NULL);
     ret = krb5_copy_principal (context,
 			       primary_principal,


### PR DESCRIPTION
Fix two clock skew related issues:
- failing TGS-REP due to a clock skew error is reported as "missing FAST" to the caller
- implement/fix clock skew offset adjustment in the memory cache, this ensures a TGS-REQ uses the clock skew time offset from the AS-REP