### PR TITLE
krb5/fast.c: fix copying source/dest for copy_KrbFastArmor

### DIFF
--- a/lib/krb5/fast.c
+++ b/lib/krb5/fast.c
@@ -271,7 +271,7 @@ make_fast_ap_fxarmor(krb5_context context,
 	if (ret)
 	    goto out;
 
-	ret = copy_KrbFastArmor(fxarmor, &msg.armor);
+	ret = copy_KrbFastArmor(&msg.armor, fxarmor);
 	if (ret) {
 	    free_KERB_ARMOR_SERVICE_REPLY(&msg);
 	    goto out;


### PR DESCRIPTION
if using armoring service.

(The source and destination is exchanged in the call, which makes the "value" part (fxarmor.armor_value) not filled up, so the armored ticket request will not be encrypted correctly and will fail.)