### PR TITLE
appl/tests: auditdns eliminate use of 'restrict' keyword

### DIFF
--- a/appl/test/auditdns.c
+++ b/appl/test/auditdns.c
@@ -40,6 +40,10 @@
 #include "resolve.h"
 #include "roken.h"
 
+#if (__STDC_VERSION__ - 0) < 199901L
+# define restrict /* empty */
+#endif
+
 struct rk_dns_reply *
 rk_dns_lookup(const char *domain, const char *type_name)
 {


### PR DESCRIPTION
The 'restrict' keyword was introduced in C99 and provides a hint to the compiler that can be used to better optimized code.  The 'restrict' keyword results in build failures on some platforms.  Since auditdns.c is a test and optimization is unimportant for successful completion, elimination of the 'restrict' keyword is an acceptable change to permit successful completion of the build.

  auditdns.c:101:37: error: expected ‘;’, ‘,’ or ‘)’ before ‘hints’
     const struct addrinfo *restrict hints,
                                     ^
  auditdns.c:409:45: error: expected ‘;’, ‘,’ or ‘)’ before ‘sa’
     getnameinfo(const struct sockaddr *restrict sa, socklen_t salen,

Observed with gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44).
                                        ^