### PR TITLE
otp: prevent implicit function declarations if HAVE_DB_NDBM

### DIFF
--- a/lib/otp/otp_db.c
+++ b/lib/otp/otp_db.c
@@ -38,9 +38,12 @@ RCSID("$Id$");
 
 #include "otp_locl.h"
 
-#if !defined(HAVE_NDBM) && !defined(HAVE_DB_NDBM)
-#include "ndbm_wrap.h"
+#if defined(HAVE_DB_NDBM)
+# include <ndbm.h>
+#elif !defined(HAVE_NDBM)
+# include "ndbm_wrap.h"
 #endif
+
 
 #define RETRIES 5
 


### PR DESCRIPTION
include ndbm.h if HAVE_DB_NDBM is defined to avoid implicit function declarations.

otp_db.c:76:9: error: call to undeclared function 'dbm_open'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  ret = dbm_open (OTP_DB, O_RDWR | O_CREAT, 0600);
        ^