### PR TITLE
Include db.h for nbdb compat mode

### DIFF
--- a/lib/otp/otp_db.c
+++ b/lib/otp/otp_db.c
@@ -39,7 +39,7 @@ RCSID("$Id$");
 #include "otp_locl.h"
 
 #if defined(HAVE_DB_NDBM)
-# include <ndbm.h>
+# include <db.h>
 #elif !defined(HAVE_NDBM)
 # include "ndbm_wrap.h"
 #endif


### PR DESCRIPTION
Otherwise, on nixpkgs@darwin, the build fails as follows:

```
In file included from otp_db.c:42:
/nix/store/...-libSystem-11.0.0/include/ndbm.h:89:3: error: typedef redefinition with different types ('struct datum' vs 'struct datum') } datum;
  ^
/nix/store/...-db-5.3.28-dev/include/db.h:2749:3: note: previous definition is here
} datum;
  ^
```

Spotted in https://github.com/NixOS/nixpkgs/issues/347616