### PR TITLE
gsskrb5: let GSS_C_DCE_STYLE imply GSS_C_MUTUAL_FLAG as acceptor

### DIFF
--- a/lib/gssapi/krb5/8003.c
+++ b/lib/gssapi/krb5/8003.c
@@ -239,6 +239,16 @@ _gsskrb5_verify_8003_checksum(
     _gss_mg_decode_le_uint32(p, flags);
     p += 4;
 
+    /*
+     * Sometimes Windows clients forget
+     * to set GSS_C_MUTUAL_FLAG together
+     * with GSS_C_DCE_STYLE, but
+     * DCE_STYLE implies mutual authentication
+     */
+    if (*flags & GSS_C_DCE_STYLE) {
+	*flags |= GSS_C_MUTUAL_FLAG;
+    }
+
     if (cksum->checksum.length > 24 && (*flags & GSS_C_DELEG_FLAG)) {
 	if(cksum->checksum.length < 28) {
 	    *minor_status = 0;


### PR DESCRIPTION
Windows clients forget GSS_C_MUTUAL_FLAG in some situations where they use GSS_C_DCE_STYLE, in the assumption that GSS_C_MUTUAL_FLAG is implied.

Both Windows and MIT as server already imply GSS_C_MUTUAL_FLAG when GSS_C_DCE_STYLE is used.

BUG: https://bugzilla.samba.org/show_bug.cgi?id=15740