### PR TITLE
cf/largefile.m4: improve compatibility with autoconf 2.72

### DIFF
--- a/cf/largefile.m4
+++ b/cf/largefile.m4
@@ -7,10 +7,16 @@ AC_DEFUN([rk_SYS_LARGEFILE],[
 AC_REQUIRE([AC_SYS_LARGEFILE])dnl
 dnl need to set this on the command line, since it might otherwise break
 dnl with generated code, such as lex
-if test "$enable_largefile" != no -a "$ac_cv_sys_large_files" != no; then
-	CPPFLAGS="$CPPFLAGS -D_LARGE_FILES=$ac_cv_sys_large_files"
-fi
-if test "$enable_largefile" != no -a "$ac_cv_sys_file_offset_bits" != no && test -n "$ac_cv_sys_file_offset_bits"; then
-	CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=$ac_cv_sys_file_offset_bits"
+if test "$enable_largefile" != no; then
+	if test -n "$ac_cv_sys_large_files" && test "$ac_cv_sys_large_files" != no; then
+		CPPFLAGS="$CPPFLAGS -D_LARGE_FILES=$ac_cv_sys_large_files"
+	fi
+	if test -n "$ac_cv_sys_file_offset_bits" && test "$ac_cv_sys_file_offset_bits" != no; then
+		CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=$ac_cv_sys_file_offset_bits"
+	fi
+	if test -n "$ac_cv_sys_largefile_opts"; then
+		AS_CASE([$ac_cv_sys_largefile_opts],[-D_FILE_OFFSET_BITS=*|-D_LARGE_FILES=*],
+			[CPPFLAGS="$CPPFLAGS $ac_cv_sys_largefile_opts"])
+	fi
 fi
 ])


### PR DESCRIPTION
as of autoconf 2.72 neither ac_cv_sys_large_files nor ac_cv_sys_file_offset_bits are populated. 1b57b62 introduced a workaround just for ac_cv_sys_file_offset_bits by checking if it's not empty.

expand fix to cover ac_cv_sys_large_files as well and check ac_cv_sys_largefile_opts which is populated in autoconf 2.72 [1]

1. https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=cf09f48841b66fe76f606dd6018bb3a93242a7c9