### PR TITLE
Use <poll.h> insted of <sys/poll.h>

### DIFF
--- a/lib/ipc/hi_locl.h
+++ b/lib/ipc/hi_locl.h
@@ -41,7 +41,7 @@
 #include <sys/un.h>
 #endif
 
-#include <sys/poll.h>
+#include <poll.h>
 
 #include <ctype.h>
 #include <stdio.h>

--- a/lib/krb5/krb5_locl.h
+++ b/lib/krb5/krb5_locl.h
@@ -44,7 +44,7 @@
 #include <ctype.h>
 
 #ifdef HAVE_POLL_H
-#include <sys/poll.h>
+#include <poll.h>
 #endif
 
 #include <krb5-types.h>

--- a/lib/roken/getifaddrs.c
+++ b/lib/roken/getifaddrs.c
@@ -125,7 +125,7 @@ rk_freeifaddrs(struct ifaddrs *ifp);
 #include <linux/rtnetlink.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netpacket/packet.h>
 #include <net/ethernet.h>     /* the L2 protocols */
 #include <sys/uio.h>


### PR DESCRIPTION
Acording to POSIX <poll.h> should be used instead of <sys/poll.h>.

Libcs like musl libc added a redict due maintain compat with older glibcs and added the following warning:

	/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
	    1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
	      |  ^~~~~~~

Ref: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/poll.h.html