### PR TITLE
cf: dns_search test requires resolv library

### DIFF
--- a/cf/resolv.m4
+++ b/cf/resolv.m4
@@ -73,13 +73,13 @@ AC_FIND_FUNC(res_ndestroy, resolv,
 ],
 [0])
 
-AC_FIND_FUNC_NO_LIBS(dns_search,,
+AC_FIND_FUNC(dns_search, resolv,
 [
 #ifdef HAVE_DNS_H
 #include <dns.h>
 #endif
 ],
-[0,0,0,0,0,0,0,0])
+[0])
 
 
 AC_FIND_FUNC(dn_expand, resolv,


### PR DESCRIPTION
When building for Apple operating systems rk_dns_lookup() must use dns_search() instead of res_search().  Although res_search() is available, it only issues queries using the /etc/resolv.conf configuration.  Whereas dns_search() will issue the query against alternate resolver configurations such as those created by VPN services.