### PR TITLE
Fix AR warning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ if HEIMDAL_DOCUMENTATION
 SUBDIRS+= doc
 endif
 
-
+ARFLAGS = cr
 
 ## ACLOCAL = @ACLOCAL@ -I cf
 ACLOCAL_AMFLAGS = -I cf

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,9 @@ AM_PATH_PYTHON
 AC_CHECK_PROG(CLANG_FORMAT, clang-format, [clang-format], [no])
 test "$CLANG_FORMAT" = no && CLANG_FORMAT=true
 
+AR_FLAGS="cr"
+AC_SUBST(AR_FLAGS)
+
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_PREFIX_DEFAULT(/usr/heimdal)


### PR DESCRIPTION
I have noticed that `ar` utility generate a warning in error stream when building the project.
This commit solve the issue.