### PR TITLE
kdc: Fix memory leak of encrypted preauthentication data

### DIFF
--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -2195,6 +2195,11 @@ out:
     free(csec);
     free(cusec);
 
+    if (r->ek.encrypted_pa_data) {
+	free_METHOD_DATA(r->ek.encrypted_pa_data);
+	free(r->ek.encrypted_pa_data);
+    }
+
     free_TGS_REP(&r->rep);
     free_TransitedEncoding(&r->et.transited);
     free(r->et.starttime);


### PR DESCRIPTION
Deallocate r->ek.encrypted_pa_data after response was sent to client.