### PR TITLE
update workflows to v4 artifacts

### DIFF
--- a/.github/workflows/linux-mit-interop.yml
+++ b/.github/workflows/linux-mit-interop.yml
@@ -101,17 +101,17 @@ jobs:
                   git ls-files -o|grep -v ^build/
                 fi
             - name: Upload Install Tarball
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Install Tarball
                 path: '~/heimdal-install-linux-${{ matrix.compiler }}.tgz'
             - name: Upload Dist Tarball
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Dist Tarball
                 path: 'build/heimdal-*.tar.gz'
             - name: Upload Logs Tarball
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Test Logs
                 path: '~/logs-linux-${{ matrix.compiler }}.tgz'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -130,17 +130,17 @@ jobs:
                   git ls-files -o|grep -v ^build/
                 fi
             - name: Upload Install Tarball
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Install Tarball
                 path: '~/heimdal-install-linux-${{ matrix.compiler }}.tgz'
             - name: Upload Dist Tarball
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Dist Tarball
                 path: 'build/heimdal-*.tar.gz'
             - name: Upload Logs Tarball
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Test Logs
                 path: '~/logs-linux-${{ matrix.compiler }}.tgz'

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -113,12 +113,12 @@ jobs:
               run: |
                 find build -name \*.trs|xargs grep -lw FAIL|sed -e 's/trs$/log/'|xargs cat
             - name: Upload Install Tarball
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Install Tarball
                 path: '~/heimdal-install-osx.tgz'
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Upload Test Logs
                 path: '~/logs-osx.cpio'

--- a/.github/workflows/scanbuild.yml
+++ b/.github/workflows/scanbuild.yml
@@ -61,7 +61,7 @@ jobs:
               run: |
                 find build -name \*.trs|xargs grep -lw FAIL|sed -e 's/trs$/log/'|xargs cat
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Scan-Build Reports
                 path: '/tmp/scan-build*/'

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -127,7 +127,7 @@ jobs:
               run: |
                 find build -name \*.trs | sed -e 's/trs$/log/' | xargs cat
             - name: Upload Logs Tarball
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Test Logs
                 path: '~/logs-linux-${{ matrix.compiler }}.tgz'

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -65,7 +65,7 @@ jobs:
               run: |
                 find build -name \*.trs|xargs grep -lw FAIL | sed -e 's/trs$/log/' | xargs cat
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Test Logs
                 path: '~/logs-linux-valgrind.tgz'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,7 @@ jobs:
                 nmake /f NTMakefile APPVEYOR=1 MAKEINFO=makeinfo NO_INSTALLERS=1
                 nmake /f NTMakefile APPVEYOR=1 MAKEINFO=makeinfo NO_INSTALLERS=1 test
             - name: Upload Artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: Objects
                 path: 'D:/a/heimdal/heimdal/out/'


### PR DESCRIPTION
workflows did not work because v2 artifacts were deprecated. update to v4.