### PR TITLE
gssmask: Disable Nagle.

### DIFF
--- a/appl/gssmask/common.c
+++ b/appl/gssmask/common.c
@@ -95,3 +95,13 @@ permutate_all(struct getarg_strings *strings, size_t *size)
     free(list);
     return all;
 }
+
+void
+tcp_nodelay(rk_socket_t sock)
+{
+#ifdef HAVE_NETINET_TCP_H
+    int on = 1;
+
+    (void)setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &on, sizeof(on));
+#endif
+}

--- a/appl/gssmask/common.h
+++ b/appl/gssmask/common.h
@@ -46,6 +46,10 @@
 #include <sys/wait.h>
 #endif
 
+#ifdef HAVE_NETINET_TCP_H
+#include <netinet/tcp.h>
+#endif
+
 #include <assert.h>
 #include <krb5.h>
 #include <gssapi/gssapi.h>
@@ -112,3 +116,5 @@ krb5_error_code store_string(krb5_storage *, const char *);
     } while(0)
 
 char *** permutate_all(struct getarg_strings *, size_t *);
+
+void tcp_nodelay(rk_socket_t);

--- a/appl/gssmask/gssmaestro.c
+++ b/appl/gssmask/gssmaestro.c
@@ -303,6 +303,7 @@ wait_log(struct client *c)
     sock2 = accept(sock, (struct sockaddr *)&sast, &salen);
     if (sock2 == rk_INVALID_SOCKET)
 	err(1, "failed to accept local socket for %s", c->moniker);
+    tcp_nodelay(sock2);
     rk_closesocket(sock);
 
     return sock2;
@@ -638,6 +639,7 @@ connect_client(const char *slave)
 	sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 	if (sock == rk_INVALID_SOCKET)
 	    continue;
+	tcp_nodelay(sock);
 	if (connect(sock, res->ai_addr, res->ai_addrlen) < 0) {
 	    rk_closesocket(sock);
 	    sock = rk_INVALID_SOCKET;

--- a/appl/gssmask/gssmask.c
+++ b/appl/gssmask/gssmask.c
@@ -705,6 +705,7 @@ HandleOP(SetLoggingSocket)
     sock = socket(((struct sockaddr *)&c->sa)->sa_family, SOCK_STREAM, 0);
     if (sock == rk_INVALID_SOCKET)
 	return 0;
+    tcp_nodelay(sock);
 
     ret = connect(sock, (struct sockaddr *)&c->sa, c->salen);
     if (ret < 0) {
@@ -1294,6 +1295,7 @@ main(int argc, char **argv)
     {
 	struct client *c;
 
+	tcp_nodelay(0);
 	c = create_client(0, port, moniker_str);
 	/* close(0); */
 


### PR DESCRIPTION
This reduces the check-gssmask runtime from around 7min to 1-2sec on my laptop.

It is, perhaps, suboptimal to disable Nagle for a program that writes successive 4-byte units of a protocol message in separate syscalls rather than a single batch, and might be better to instead disable delayed acks, but:

(a) there's no portable API for disabling delayed acks, and
(b) this program appears to be used exclusively for testing anyway.

fix https://github.com/heimdal/heimdal/issues/1139