### PR TITLE
Add KDC configuration option to always include the PAC in replies

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1837,6 +1837,9 @@ get_pac_attributes(krb5_context context, KDC_REQ *req)
 
     pac_attributes = pacreq.include_pac ? KRB5_PAC_WAS_REQUESTED : 0;
     free_PA_PAC_REQUEST(&pacreq);
+    if (pac_attributes == 0 && context->flags & KRB5_CTX_F_ALWAYS_INCLUDE_PAC) {
+        pac_attributes = KRB5_PAC_WAS_GIVEN_IMPLICITLY;
+    }
     return pac_attributes;
 }
 

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -476,6 +476,7 @@ init_context_from_config_file(krb5_context context)
     INIT_FLAG(context, flags, KRB5_CTX_F_CHECK_PAC, TRUE, "check_pac");
     INIT_FLAG(context, flags, KRB5_CTX_F_ENFORCE_OK_AS_DELEGATE, FALSE, "enforce_ok_as_delegate");
     INIT_FLAG(context, flags, KRB5_CTX_F_REPORT_CANONICAL_CLIENT_NAME, FALSE, "report_canonical_client_name");
+    INIT_FLAG(context, flags, KRB5_CTX_F_ALWAYS_INCLUDE_PAC, FALSE, "always_include_pac");
 
     /* report_canonical_client_name implies check_pac */
     if (context->flags & KRB5_CTX_F_REPORT_CANONICAL_CLIENT_NAME)

--- a/lib/krb5/krb5_locl.h
+++ b/lib/krb5/krb5_locl.h
@@ -374,6 +374,7 @@ typedef struct krb5_context_data {
 #define KRB5_CTX_F_FCACHE_STRICT_CHECKING	32
 #define KRB5_CTX_F_ENFORCE_OK_AS_DELEGATE	64
 #define KRB5_CTX_F_REPORT_CANONICAL_CLIENT_NAME	128
+#define KRB5_CTX_F_ALWAYS_INCLUDE_PAC		256
     struct send_to_kdc *send_to_kdc;
 #ifdef PKINIT
     hx509_context hx509ctx;


### PR DESCRIPTION
Add a new flag always_include_pac to the krb5_kdc_configuration

If set this over-rides the PA-PAC-REQUEST and the PAC is always included in the response