### PR TITLE
CVE-2022-37967 Implement full PAC checksum

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -892,7 +892,7 @@ _kdc_fast_check_armor_pac(astgs_request_t r, int flags)
     ret = _kdc_check_pac(r, armor_client_principal, NULL,
 			 armor_client, r->armor_server,
 			 r->armor_server, r->armor_server,
-			 &r->armor_key->key, &r->armor_key->key,
+			 &r->armor_key->key, NULL /* krbtgt_check_key */,
 			 &r->armor_ticket->ticket, &ad_kdc_issued, &mspac, NULL, NULL);
     if (ret) {
 	const char *msg = krb5_get_error_message(r->context, ret);

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1853,7 +1853,6 @@ generate_pac(astgs_request_t r, const Key *skey, const Key *tkey,
 	     krb5_boolean is_tgs)
 {
     krb5_error_code ret;
-    krb5_data data;
     uint16_t rodc_id;
     krb5_principal client;
     krb5_const_principal canon_princ = NULL;
@@ -1918,18 +1917,18 @@ generate_pac(astgs_request_t r, const Key *skey, const Key *tkey,
 	    return ret;
     }
 
-    ret = _krb5_pac_sign(r->context,
-			 r->pac,
-			 r->et.authtime,
-			 client,
-			 &skey->key, /* Server key */
-			 &tkey->key, /* TGS key */
-			 rodc_id,
-			 NULL, /* UPN */
-			 canon_princ,
-			 FALSE, /* add_full_sig */
-			 is_tgs ? &r->pac_attributes : NULL,
-			 &data);
+    ret = _krb5_kdc_pac_sign_ticket(r->context,
+                                    r->pac,
+                                    client,
+                                    &skey->key, /* Server key */
+                                    &tkey->key, /* TGS key */
+                                    rodc_id,
+                                    NULL, /* UPN */
+                                    canon_princ,
+                                    !is_tgs, /* add_ticket_sig */
+                                    !is_tgs, /* add_full_sig */
+                                    &r->et,
+                                    is_tgs ? &r->pac_attributes : NULL);
     krb5_free_principal(r->context, client);
     krb5_pac_free(r->context, r->pac);
     r->pac = NULL;
@@ -1938,9 +1937,6 @@ generate_pac(astgs_request_t r, const Key *skey, const Key *tkey,
 		   r->cname);
 	return ret;
     }
-    
-    ret = _kdc_tkt_insert_pac(r->context, &r->et, &data);
-    krb5_data_free(&data);
 
     return ret;
 }

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -2700,13 +2700,6 @@ _kdc_as_rep(astgs_request_t r)
     if (ret)
 	goto out;
 
-    /* Add the PAC */
-    if (!r->et.flags.anonymous) {
-	ret = generate_pac(r, skey, krbtgt_key, is_tgs);
-	if (ret)
-	    goto out;
-    }
-
     if (r->client->flags.synthetic) {
 	ret = add_synthetic_princ_ad(r);
 	if (ret)
@@ -2749,6 +2742,18 @@ _kdc_as_rep(astgs_request_t r)
 	    goto out;
 	}
     }
+
+    /* Add the PAC */
+    if (!r->et.flags.anonymous) {
+        ret = generate_pac(r, skey, krbtgt_key, is_tgs);
+        if (ret)
+            goto out;
+    }
+
+    /*
+     * No more changes to the ticket (r->et) from this point on, lest
+     * the checksums in the PAC be invalidated.
+     */
 
     /*
      * Last chance for plugins to update reply

--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -1927,6 +1927,7 @@ generate_pac(astgs_request_t r, const Key *skey, const Key *tkey,
 			 rodc_id,
 			 NULL, /* UPN */
 			 canon_princ,
+			 FALSE, /* add_full_sig */
 			 is_tgs ? &r->pac_attributes : NULL,
 			 &data);
     krb5_free_principal(r->context, client);

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -782,7 +782,7 @@ tgs_make_reply(astgs_request_t r,
 
 	    ret = _krb5_kdc_pac_sign_ticket(r->context, r->pac, r->client_princ, serverkey,
 					    krbtgtkey, rodc_id, NULL, r->canon_client_princ,
-					    add_ticket_sig, et,
+					    add_ticket_sig, add_ticket_sig, et,
 					    is_tgs ? &r->pac_attributes : NULL);
 	    if (ret)
 		goto out;

--- a/kdc/krb5tgs.c
+++ b/kdc/krb5tgs.c
@@ -1782,7 +1782,7 @@ server_lookup:
 	    /* Verify the PAC of the TGT. */
 	    ret = _kdc_check_pac(priv, user2user_princ, NULL,
 				 user2user_client, user2user_krbtgt, user2user_krbtgt, user2user_krbtgt,
-				 &uukey->key, &priv->ticket_key->key, &adtkt,
+				 &uukey->key, NULL /* krbtgt_check_key */, &adtkt,
 				 &user2user_kdc_issued, &user2user_pac, NULL, NULL);
 	    _kdc_free_ent(context, user2user_db, user2user_client);
 	    if (ret) {
@@ -1910,7 +1910,7 @@ server_lookup:
     ret = _kdc_check_pac(priv, priv->client_princ, NULL,
 			 priv->client, priv->server,
 			 priv->krbtgt, priv->krbtgt,
-			 &priv->ticket_key->key, &priv->ticket_key->key, tgt,
+			 &priv->ticket_key->key, NULL /* krbtgt_check_key */, tgt,
 			 &kdc_issued, &priv->pac, &priv->canon_client_princ,
 			 &priv->pac_attributes);
     if (ret) {

--- a/lib/hx509/print.c
+++ b/lib/hx509/print.c
@@ -1120,7 +1120,7 @@ hx509_validate_cert(hx509_context context,
 
     if (!status.selfsigned && !status.haveCRLDP)
 	validate_print(ctx, HX509_VALIDATE_F_VALIDATE,
-		       "Not a CA nor PROXY and doesn't have"
+		       "Not a CA nor PROXY and doesn't have "
 		       "CRL Dist Point\n");
 
     if (status.selfsigned) {

--- a/lib/krb5/authdata.c
+++ b/lib/krb5/authdata.c
@@ -115,8 +115,8 @@ _kdc_tkt_insert_pac(krb5_context context,
 
     heim_assert(tkt->authorization_data->len != 0, "No authorization_data!");
     ade = tkt->authorization_data->val[tkt->authorization_data->len - 1];
-    for (i = 0; i < tkt->authorization_data->len - 1; i++) {
-	tkt->authorization_data->val[i + 1] = tkt->authorization_data->val[i];
+    for (i = tkt->authorization_data->len - 1; i > 0; i--) {
+	tkt->authorization_data->val[i] = tkt->authorization_data->val[i - 1];
     }
     tkt->authorization_data->val[0] = ade;
 

--- a/lib/krb5/pac.c
+++ b/lib/krb5/pac.c
@@ -74,6 +74,7 @@ struct krb5_pac_data {
     struct PAC_INFO_BUFFER *upn_dns_info;
     struct PAC_INFO_BUFFER *ticket_checksum;
     struct PAC_INFO_BUFFER *attributes_info;
+    struct PAC_INFO_BUFFER *full_checksum;
     krb5_data ticket_sign_data;
 
     /* PAC_UPN_DNS_INFO */
@@ -101,6 +102,7 @@ struct krb5_pac_data {
 #define PAC_TICKET_CHECKSUM		16
 #define PAC_ATTRIBUTES_INFO		17
 #define PAC_REQUESTOR_SID		18
+#define PAC_FULL_CHECKSUM		19
 
 /* Flag in PAC_UPN_DNS_INFO */
 #define PAC_EXTRA_LOGON_INFO_FLAGS_UPN_DEFAULTED	0x1
@@ -398,6 +400,13 @@ krb5_pac_parse(krb5_context context, const void *ptr, size_t len,
             else
                 p->attributes_info = &p->pac->buffers[i];
             break;
+        case PAC_FULL_CHECKSUM:
+                if (p->full_checksum)
+                krb5_set_error_message(context, ret = EINVAL,
+                                       N_("PAC has multiple full checksums", ""));
+            else
+                p->full_checksum = &p->pac->buffers[i];
+            break;
         default: break;
         }
     }
@@ -669,7 +678,8 @@ verify_checksum(krb5_context context,
 		const struct PAC_INFO_BUFFER *sig,
 		const krb5_data *data,
 		void *ptr, size_t len,
-		const krb5_keyblock *key)
+		const krb5_keyblock *key,
+		krb5_boolean strict_cksumtype_match)
 {
     krb5_storage *sp = NULL;
     uint32_t type;
@@ -727,7 +737,7 @@ verify_checksum(krb5_context context,
      * http://blogs.msdn.com/b/openspecification/archive/2010/01/01/verifying-the-server-signature-in-kerberos-privilege-account-certificate.aspx
      * for Microsoft's explanation */
 
-    if (cksum.cksumtype == CKSUMTYPE_HMAC_MD5) {
+    if (cksum.cksumtype == CKSUMTYPE_HMAC_MD5 && !strict_cksumtype_match) {
 	Checksum local_checksum;
 
 	memset(&local_checksum, 0, sizeof(local_checksum));
@@ -1330,7 +1340,7 @@ build_attributes_info(krb5_context context,
  * @param pac the pac structure returned by krb5_pac_parse().
  * @param authtime The time of the ticket the PAC belongs to.
  * @param principal the principal to verify.
- * @param server The service key, most always be given.
+ * @param server The service key, may be given.
  * @param privsvr The KDC key, may be given.
 
  * @return Returns 0 to indicate success. Otherwise an kerberos et
@@ -1348,6 +1358,21 @@ krb5_pac_verify(krb5_context context,
 		const krb5_keyblock *privsvr)
 {
     krb5_error_code ret;
+    /*
+     * If we are in the KDC, we expect back a full signature in the PAC
+     *
+     * This is set up as a separate variable to make it easier if a
+     * subsequent patch is added to make this configurable in the
+     * krb5.conf (or forced into the krb5_context via Samba)
+     */
+    krb5_boolean expect_full_sig = privsvr != NULL;
+
+    /*
+     * If we are on the KDC, then we trust we are not in a realm with
+     * buggy Windows 2008 or similar era DCs that give out HMAC-MD5
+     * signatures over AES keys.  DES is also already gone.
+     */
+    krb5_boolean strict_cksumtype_match = expect_full_sig;
 
     if (pac->server_checksum == NULL) {
 	krb5_set_error_message(context, EINVAL, "PAC missing server checksum");
@@ -1361,6 +1386,10 @@ krb5_pac_verify(krb5_context context,
 	krb5_set_error_message(context, EINVAL, "PAC missing logon name");
 	return EINVAL;
     }
+    if (expect_full_sig && pac->full_checksum == NULL) {
+        krb5_set_error_message(context, EINVAL, "PAC missing full checksum");
+        return EINVAL;
+    }
 
     if (principal != NULL) {
 	ret = verify_logonname(context, pac->logon_name, &pac->data, authtime,
@@ -1373,13 +1402,14 @@ krb5_pac_verify(krb5_context context,
         pac->privsvr_checksum->buffersize < 4)
 	return EINVAL;
 
-    /*
-     * in the service case, clean out data option of the privsvr and
-     * server checksum before checking the checksum.
-     */
-    if (server != NULL)
+    if (server != NULL || privsvr != NULL)
     {
 	krb5_data *copy;
+
+        /*
+         * in the service case, clean out data option of the privsvr and
+         * server checksum before checking the checksum.
+         */
 
 	ret = krb5_copy_data(context, &pac->data, &copy);
 	if (ret)
@@ -1393,15 +1423,43 @@ krb5_pac_verify(krb5_context context,
 	       0,
 	       pac->privsvr_checksum->buffersize - 4);
 
-	ret = verify_checksum(context,
-			      pac->server_checksum,
-			      &pac->data,
-			      copy->data,
-			      copy->length,
-			      server);
+        if (server != NULL) {
+            ret = verify_checksum(context,
+                                  pac->server_checksum,
+                                  &pac->data,
+                                  copy->data,
+                                  copy->length,
+                                  server,
+                                  strict_cksumtype_match);
+            if (ret) {
+                krb5_free_data(context, copy);
+                return ret;
+            }
+        }
+
+        if (privsvr != NULL && pac->full_checksum != NULL) {
+            /*
+             * in the full checksum case, also clean out the full
+             * checksum before verifying it.
+             */
+            memset((char *)copy->data + pac->full_checksum->offset + 4,
+                   0,
+                   pac->full_checksum->buffersize - 4);
+
+            ret = verify_checksum(context,
+                                  pac->full_checksum,
+                                  &pac->data,
+                                  copy->data,
+                                  copy->length,
+                                  privsvr,
+                                  strict_cksumtype_match);
+            if (ret) {
+                krb5_free_data(context, copy);
+                return ret;
+            }
+        }
+
 	krb5_free_data(context, copy);
-	if (ret)
-	    return ret;
     }
     if (privsvr) {
 	/* The priv checksum covers the server checksum */
@@ -1411,7 +1469,8 @@ krb5_pac_verify(krb5_context context,
 			      (char *)pac->data.data
 			      + pac->server_checksum->offset + 4,
 			      pac->server_checksum->buffersize - 4,
-			      privsvr);
+			      privsvr,
+			      strict_cksumtype_match);
 	if (ret)
 	    return ret;
 
@@ -1424,7 +1483,8 @@ krb5_pac_verify(krb5_context context,
 
 	    ret = verify_checksum(context, pac->ticket_checksum, &pac->data,
 				 pac->ticket_sign_data.data,
-				 pac->ticket_sign_data.length, privsvr);
+				 pac->ticket_sign_data.length, privsvr,
+				 strict_cksumtype_match);
 	    if (ret)
 		return ret;
 	}
@@ -1520,6 +1580,7 @@ _krb5_pac_sign(krb5_context context,
 	       uint16_t rodc_id,
 	       krb5_const_principal upn_princ,
 	       krb5_const_principal canon_princ,
+	       krb5_boolean add_full_sig,
 	       uint64_t *pac_attributes, /* optional */
 	       krb5_data *data)
 {
@@ -1527,7 +1588,7 @@ _krb5_pac_sign(krb5_context context,
     krb5_storage *sp = NULL, *spdata = NULL;
     uint32_t end;
     size_t server_size, priv_size;
-    uint32_t server_offset = 0, priv_offset = 0, ticket_offset = 0;
+    uint32_t server_offset = 0, priv_offset = 0, ticket_offset = 0, full_offset = 0;
     uint32_t server_cksumtype = 0, priv_cksumtype = 0;
     uint32_t num = 0;
     uint32_t i, sz;
@@ -1608,6 +1669,16 @@ _krb5_pac_sign(krb5_context context,
 				       N_("PAC has multiple attributes info buffers", ""));
 		goto out;
 	    }
+        } else if (p->pac->buffers[i].type == PAC_FULL_CHECKSUM) {
+            if (p->full_checksum == NULL) {
+                p->full_checksum = &p->pac->buffers[i];
+            }
+            if (p->full_checksum != &p->pac->buffers[i]) {
+                ret = KRB5KDC_ERR_BADOPTION;
+                krb5_set_error_message(context, ret,
+                                       N_("PAC has multiple full checksums", ""));
+                goto out;
+            }
 	}
     }
 
@@ -1624,6 +1695,8 @@ _krb5_pac_sign(krb5_context context,
 	num++;
     if (pac_attributes && p->attributes_info == NULL)
 	num++;
+    if (add_full_sig && p->full_checksum == NULL)
+        num++;
 
     /* Allocate any missing-but-necessary buffers */
     if (num) {
@@ -1674,6 +1747,11 @@ _krb5_pac_sign(krb5_context context,
 	    p->attributes_info = &p->pac->buffers[p->pac->numbuffers++];
 	    p->attributes_info->type = PAC_ATTRIBUTES_INFO;
 	}
+        if (add_full_sig && p->full_checksum == NULL) {
+            p->full_checksum = &p->pac->buffers[p->pac->numbuffers++];
+            memset(p->full_checksum, 0, sizeof(*p->full_checksum));
+            p->full_checksum->type = PAC_FULL_CHECKSUM;
+        }
     }
 
     /* Calculate LOGON NAME */
@@ -1817,6 +1895,31 @@ _krb5_pac_sign(krb5_context context,
 		len += sizeof(rodc_id);
 		CHECK(ret, krb5_store_uint16(spdata, rodc_id), out);
 	    }
+        } else if (add_full_sig &&
+                   p->pac->buffers[i].type == PAC_FULL_CHECKSUM) {
+            if (priv_size > UINT32_MAX - 4) {
+                ret = EINVAL;
+                krb5_set_error_message(context, ret, "integer overrun");
+                goto out;
+            }
+            len = priv_size + 4;
+            if (end > UINT32_MAX - 4) {
+                ret = EINVAL;
+                krb5_set_error_message(context, ret, "integer overrun");
+                goto out;
+            }
+            full_offset = end + 4;
+            CHECK(ret, krb5_store_uint32(spdata, priv_cksumtype), out);
+            CHECK(ret, fill_zeros(context, spdata, priv_size), out);
+            if (rodc_id != 0) {
+                if (len > UINT32_MAX - sizeof(rodc_id)) {
+                    ret = EINVAL;
+                    krb5_set_error_message(context, ret, "integer overrun");
+                    goto out;
+                }
+                len += sizeof(rodc_id);
+                CHECK(ret, fill_zeros(context, spdata, sizeof(rodc_id)), out);
+            }
 	} else if (p->pac->buffers[i].type == PAC_LOGON_NAME) {
 	    len = krb5_storage_write(spdata, logon.data, logon.length);
 	    if (logon.length != len) {
@@ -1892,6 +1995,21 @@ _krb5_pac_sign(krb5_context context,
 			      p->ticket_sign_data.data,
 			      p->ticket_sign_data.length,
 			      (char *)d.data + ticket_offset, priv_size);
+    if (ret == 0 && add_full_sig)
+        ret = create_checksum(context, priv_key, priv_cksumtype,
+                              d.data, d.length,
+                              (char *)d.data + full_offset, priv_size);
+    if (ret == 0 && add_full_sig && rodc_id != 0) {
+        void *buf = (char *)d.data + full_offset + priv_size;
+        krb5_storage *rs = krb5_storage_from_mem(buf, sizeof(rodc_id));
+        if (rs == NULL)
+            ret = krb5_enomem(context);
+        else
+            krb5_storage_set_flags(rs, KRB5_STORAGE_BYTEORDER_LE);
+        if (ret == 0)
+            ret = krb5_store_uint16(rs, rodc_id);
+        krb5_storage_free(rs);
+    }
     if (ret == 0)
         ret = create_checksum(context, server_key, server_cksumtype,
                               d.data, d.length,
@@ -1901,22 +2019,15 @@ _krb5_pac_sign(krb5_context context,
                               (char *)d.data + server_offset, server_size,
                               (char *)d.data + priv_offset, priv_size);
     if (ret == 0 && rodc_id != 0) {
-	krb5_data rd;
-	krb5_storage *rs = krb5_storage_emem();
+        void *buf = (char *)d.data + priv_offset + priv_size;
+        krb5_storage *rs = krb5_storage_from_mem(buf, sizeof(rodc_id));
 	if (rs == NULL)
 	    ret = krb5_enomem(context);
         else
             krb5_storage_set_flags(rs, KRB5_STORAGE_BYTEORDER_LE);
         if (ret == 0)
             ret = krb5_store_uint16(rs, rodc_id);
-        if (ret == 0)
-            ret = krb5_storage_to_data(rs, &rd);
 	krb5_storage_free(rs);
-	if (ret)
-	    goto out;
-	heim_assert(rd.length == sizeof(rodc_id), "invalid length");
-	memcpy((char *)d.data + priv_offset + priv_size, rd.data, rd.length);
-	krb5_data_free(&rd);
     }
 
     if (ret)
@@ -2163,6 +2274,7 @@ _krb5_kdc_pac_sign_ticket(krb5_context context,
 			  krb5_const_principal upn,
 			  krb5_const_principal canon_name,
 			  krb5_boolean add_ticket_sig,
+			  krb5_boolean add_full_sig,
 			  EncTicketPart *tkt,
 			  uint64_t *pac_attributes) /* optional */
 {
@@ -2200,6 +2312,7 @@ _krb5_kdc_pac_sign_ticket(krb5_context context,
 
     ret = _krb5_pac_sign(context, pac, tkt->authtime, client, server_key,
 			 kdc_key, rodc_id, upn, canon_name,
+			 add_full_sig,
 			 pac_attributes, &rspac);
     if (ret == 0)
         ret = _kdc_tkt_insert_pac(context, tkt, &rspac);

--- a/lib/krb5/test_pac.c
+++ b/lib/krb5/test_pac.c
@@ -884,8 +884,12 @@ check_ticket_signature(krb5_context context,
 
     heim_assert(!is_krbtgt(&ticket.sname) == !!signedticket, "ticket-signature");
 
+    /*
+     * We have to not verify the KDC checksum as the saved PAC has no
+     * full checksum, and krb5_pac_verify requires this now
+     */
     ret = krb5_pac_verify(context, pac, et.authtime, client,
-			  tkt->key, tkt->kdc_key);
+			  tkt->key, NULL);
     if (ret)
 	t_err(context, tkt->name, "krb5_pac_verify ticket-sig", ret);
 
@@ -906,9 +910,13 @@ check_ticket_signature(krb5_context context,
     if (ret)
 	t_err(context, tkt->name, "remove_AuthorizationData", ret);
 
+    /*
+     * While we should do a full PAC signature in the same case as
+     * signedticket, the saved examples do not have one
+     */
     ret = _krb5_kdc_pac_sign_ticket(context, pac, client, tkt->key,
 				    tkt->kdc_key, tkt->rodc_id,
-				    NULL, NULL, signedticket, &et, NULL);
+				    NULL, NULL, signedticket, FALSE, &et, NULL);
     if (ret)
 	t_err(context, tkt->name, "_krb5_kdc_pac_sign_ticket", ret);
 
@@ -927,9 +935,14 @@ check_ticket_signature(krb5_context context,
     if (ret)
 	t_err(context, tkt->name, "remove_AuthorizationData 2", ret);
 
+    /*
+     * This time we will not be doing a krb5_data_cmp() so we add the
+     * full signature so that we can run that check in
+     * krb5_pac_verify()
+     */
     ret = _krb5_kdc_pac_sign_ticket(context, pac, client, tkt->key,
 				    tkt->kdc_key, tkt->rodc_id,
-				    NULL, NULL, signedticket, &et, NULL);
+				    NULL, NULL, signedticket, TRUE, &et, NULL);
     if (ret)
 	t_err(context, tkt->name, "_krb5_kdcsignedticketsign_ticket 2", ret);
 
@@ -1025,13 +1038,18 @@ main(int argc, char **argv)
     if (ret)
 	krb5_err(context, 1, ret, "krb5_pac_parse");
 
+    /*
+     * We have to not verify the KDC checksum as the saved PAC has no
+     * full checksum, and krb5_pac_verify requires this now
+     */
     ret = krb5_pac_verify(context, pac, authtime, p,
-			   &member_keyblock, &kdc_keyblock);
+			  &member_keyblock, NULL);
     if (ret)
 	krb5_err(context, 1, ret, "krb5_pac_verify");
 
     ret = _krb5_pac_sign(context, pac, authtime, p,
 			 &member_keyblock, &kdc_keyblock, 0, NULL, NULL,
+			 TRUE,
 			 NULL, &data);
     if (ret)
 	krb5_err(context, 1, ret, "_krb5_pac_sign");
@@ -1058,14 +1076,14 @@ main(int argc, char **argv)
 	if (ret)
 	    krb5_err(context, 1, ret, "krb5_pac_init");
 
-	/* our two user buffer plus the three "system" buffers */
+	/* our two user buffer plus the four "system" buffers */
 	ret = krb5_pac_get_types(context, pac, &len, &list);
 	if (ret)
 	    krb5_err(context, 1, ret, "krb5_pac_get_types");
 
 	for (i = 0; i < len; i++) {
 	    /* skip server_cksum, privsvr_cksum, and logon_name */
-	    if (list[i] == 6 || list[i] == 7 || list[i] == 10)
+	    if (list[i] == 6 || list[i] == 7 || list[i] == 10 || list[i] == 19)
 		continue;
 
 	    ret = krb5_pac_get_buffer(context, pac, list[i], &data);
@@ -1089,7 +1107,7 @@ main(int argc, char **argv)
 
 	ret = _krb5_pac_sign(context, pac2, authtime, p,
 			     &member_keyblock, &kdc_keyblock, 0,
-			     NULL, NULL, NULL, &data);
+			     NULL, NULL, TRUE, NULL, &data);
 	if (ret)
 	    krb5_err(context, 1, ret, "_krb5_pac_sign 4");
 
@@ -1189,7 +1207,7 @@ main(int argc, char **argv)
 
     ret = _krb5_pac_sign(context, pac, authtime, p,
 			 &member_keyblock, &kdc_keyblock, 0,
-			 NULL, NULL, NULL, &data);
+			 NULL, NULL, TRUE, NULL, &data);
     if (ret)
 	krb5_err(context, 1, ret, "_krb5_pac_sign");
 
@@ -1209,11 +1227,11 @@ main(int argc, char **argv)
 	uint32_t *list;
 	size_t len;
 
-	/* our two user buffer plus the three "system" buffers */
+	/* our two user buffer plus the four "system" buffers */
 	ret = krb5_pac_get_types(context, pac, &len, &list);
 	if (ret)
 	    krb5_err(context, 1, ret, "krb5_pac_get_types");
-	if (len != 5)
+	if (len != 6)
 	    krb5_errx(context, 1, "list wrong length");
 	free(list);
     }

--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -947,11 +947,11 @@ ${kgetcred} --out-cache=${o2cache} --delegation-credential-cache=${ocache} ${ser
 	{ ec=1 ; eval "${testfailed}"; }
 
 echo "test constrained delegation evidence (evidence from AS)"; > messages.log
-# This fails because we don't add PAC ticket-signature in AS-REP (as Windows).
+# This succeeds because we add PAC ticket-signature in AS-REP (as Windows).
 ${kinit} --cache=${ocache} --password-file=${objdir}/barpassword \
 	--forwardable --server=${ps} bar@${R} || \
         { ec=1 ; eval "${testfailed}"; }
-${kgetcred} --delegation-credential-cache=${ocache} ${server}@${R} && \
+${kgetcred} --delegation-credential-cache=${ocache} ${server}@${R} || \
 	{ ec=1 ; eval "${testfailed}"; }
 
 echo "test constrained delegation impersonation (missing PAC)"; > messages.log

--- a/tests/plugin/kdc_test_plugin.c
+++ b/tests/plugin/kdc_test_plugin.c
@@ -96,7 +96,7 @@ pac_verify(void *ctx,
     if (ret)
 	return ret;
 
-    return krb5_pac_verify(context, *pac, 0, NULL, NULL, &key->key);
+    return krb5_pac_verify(context, *pac, 0, NULL, &key->key, NULL);
 }
 
 static void logit(const char *what, astgs_request_t r)


### PR DESCRIPTION
Add a new PAC checksum type to ensure the integrity of the PAC.

https://bugzilla.samba.org/show_bug.cgi?id=15231 has details about the vulnerability.

https://i.blackhat.com/EU-22/Thursday-Briefings/EU-22-Tervoort-Breaking-Kerberos-RC4-Cipher-and-Spoofing-Windows-PACs-wp.pdf is the paper.