### PR TITLE
lib:roken: allow large fragmented UDP replies from glibc resolver

### DIFF
--- a/lib/roken/resolve.c
+++ b/lib/roken/resolve.c
@@ -568,16 +568,18 @@ dns_lookup_int(const char *domain, int rr_class, int rr_type)
 	    fprintf(stderr, "dns_lookup(%s, %d, %s) --> %d\n",
 		    domain, rr_class, rk_dns_type_to_string(rr_type), size);
 	}
-	if (size > len) {
+
+	if ((size == len || size <= 0) && len < rk_DNS_MAX_PACKET_SIZE) {
+	    /* resolver may have a truncated reply or a failure occured */
+	    len *= 2;
+	    if (len > rk_DNS_MAX_PACKET_SIZE)
+		len = rk_DNS_MAX_PACKET_SIZE;
+	} else if (size > len) {
 	    /* resolver thinks it know better, go for it */
 	    len = size;
 	} else if (size > 0) {
 	    /* got a good reply */
 	    break;
-	} else if (size <= 0 && len < rk_DNS_MAX_PACKET_SIZE) {
-	    len *= 2;
-	    if (len > rk_DNS_MAX_PACKET_SIZE)
-		len = rk_DNS_MAX_PACKET_SIZE;
 	} else {
 	    /* the end, leave */
 	    resolve_free_handle(handle);


### PR DESCRIPTION
When a DNS server contains a lot of service records for Kerberos (in _kerberos._tcp for example), Heimdal client library fails to proceed with authentication as it cannot correctly receive a fragmented UDP reply. This results in an error that KDC cannot be found.

This issue is more noticeable when the reply contains additional section with resolved IP addresses for DNS names, as it almost doubles the length of the reply.

glibc resolver returns same answer length as buffer size when buffer is too small for the answer. By allowing roken to allocate a larger buffer when this happens, it can receive and parse the reply and find a KDC.

See https://github.com/krb5/krb5/commit/2cc718a86d92abef7363384d7eac48190271f676 for similar fix in dnsglue.c.