### PR TITLE
hx509: Use correct algorithm to create/verify signatures

### DIFF
--- a/lib/hx509/cms.c
+++ b/lib/hx509/cms.c
@@ -1434,7 +1434,7 @@ sig_process(hx509_context context, void *ctx, hx509_cert cert)
 	ret = _hx509_create_signature(context,
 				      _hx509_cert_private_key(cert),
 				      &sigalg,
-                                      &digest,
+				      NULL,
 				      &sigdata,
 				      &signer_info->signatureAlgorithm,
 				      &signer_info->signature);


### PR DESCRIPTION
Passing the digest in results in the wrong algorithm being used for signature creation/verification. ~~This is a regression introduced by commit cbe156d9279effd6780fc36b620321e373217863.~~