### PR TITLE
kdc: Adjust error code mapping

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -536,7 +536,7 @@ pa_pkinit_validate(astgs_request_t r, const PA_DATA *pa)
 
     ret = _kdc_pk_rd_padata(r, pa, &pkp);
     if (ret || pkp == NULL) {
-        if (ret == HX509_CERT_REVOKED) {
+        if (ret == KRB5_KDC_ERR_REVOKED_CERTIFICATE) {
             ret = KRB5_KDC_ERR_CLIENT_NOT_TRUSTED;
         } else {
             ret = KRB5KRB_AP_ERR_BAD_INTEGRITY;


### PR DESCRIPTION
Commit cbe156d9279effd6780fc36b620321e373217863 mapped error code `HX509_CERT_REVOKED` to `KRB5_KDC_ERR_REVOKED_CERTIFICATE`, so check for the latter instead.