### PR TITLE
dbutils: fix order of libraries for static build

### DIFF
--- a/appl/dbutils/Makefile.am
+++ b/appl/dbutils/Makefile.am
@@ -10,4 +10,4 @@ man_MANS = bsearch.1
 
 EXTRA_DIST = NTMakefile $(man_MANS)
 
-LDADD = $(LIB_roken) $(LIB_vers) $(LIB_heimbase)
+LDADD = $(LIB_vers) $(LIB_heimbase) $(LIB_roken)


### PR DESCRIPTION
- partfix of #1342 