### PR TITLE
appl/test: fix rk_dns_lookup symbol collision in kinit_auditdns

### DIFF
--- a/appl/test/Makefile.am
+++ b/appl/test/Makefile.am
@@ -45,6 +45,8 @@ kinit_auditdns_SOURCES = ../../kuser/kinit.c auditdns.c
 
 kinit_auditdns_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/../../lib/krb5
 
+kinit_auditdns_LDFLAGS = $(WRAP_LDFLAGS)
+
 # sync with kinit_LDADD in kuser/Makefile.am
 if !NO_AFS
 afs_lib = $(LIB_kafs)

--- a/appl/test/Makefile.am
+++ b/appl/test/Makefile.am
@@ -43,7 +43,8 @@ nt_gss_server_LDADD = $(nt_gss_client_LDADD)
 
 kinit_auditdns_SOURCES = ../../kuser/kinit.c auditdns.c
 
-kinit_auditdns_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/../../lib/krb5
+kinit_auditdns_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/../../lib/krb5 \
+	$(AUDITDNS_CPPFLAGS)
 
 kinit_auditdns_LDFLAGS = $(WRAP_LDFLAGS)
 

--- a/appl/test/auditdns.c
+++ b/appl/test/auditdns.c
@@ -40,12 +40,14 @@
 #include "resolve.h"
 #include "roken.h"
 
+struct rk_dns_reply *__wrap_rk_dns_lookup(const char *domain, const char *type_name);
+
 #if (__STDC_VERSION__ - 0) < 199901L
 # define restrict /* empty */
 #endif
 
 struct rk_dns_reply *
-rk_dns_lookup(const char *domain, const char *type_name)
+__wrap_rk_dns_lookup(const char *domain, const char *type_name)
 {
 
     fprintf(stderr, "DNS leak: %s %s (%s)\n", __func__, domain, type_name);

--- a/appl/test/auditdns.c
+++ b/appl/test/auditdns.c
@@ -37,17 +37,19 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef AUDITDNS_USE_LD_WRAP
+#define rk_dns_lookup __wrap_rk_dns_lookup
+#endif
+
 #include "resolve.h"
 #include "roken.h"
-
-struct rk_dns_reply *__wrap_rk_dns_lookup(const char *domain, const char *type_name);
 
 #if (__STDC_VERSION__ - 0) < 199901L
 # define restrict /* empty */
 #endif
 
 struct rk_dns_reply *
-__wrap_rk_dns_lookup(const char *domain, const char *type_name)
+rk_dns_lookup(const char *domain, const char *type_name)
 {
 
     fprintf(stderr, "DNS leak: %s %s (%s)\n", __func__, domain, type_name);

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,19 @@ AC_CANONICAL_HOST
 CANONICAL_HOST=$host
 AC_SUBST(CANONICAL_HOST)
 
+dnl
+dnl this is needed to not wrap calls when building on OS X Builds
+dnl
+case $host_os in
+  darwin*)
+    WRAP_LDFLAGS=""
+    ;;
+  *)
+    WRAP_LDFLAGS="-Wl,--wrap=rk_dns_lookup"
+    ;;
+esac
+AC_SUBST([WRAP_LDFLAGS])
+
 rk_SYS_LARGEFILE
 
 rk_AIX

--- a/configure.ac
+++ b/configure.ac
@@ -33,18 +33,28 @@ AC_CANONICAL_HOST
 CANONICAL_HOST=$host
 AC_SUBST(CANONICAL_HOST)
 
-dnl
-dnl this is needed to not wrap calls when building on OS X Builds
-dnl
-case $host_os in
-  darwin*)
-    WRAP_LDFLAGS=""
-    ;;
-  *)
-    WRAP_LDFLAGS="-Wl,--wrap=rk_dns_lookup"
-    ;;
-esac
+WRAP_LDFLAGS=
+AUDITDNS_CPPFLAGS=
+AS_IF([test "x$enable_shared" = xno], [
+    AC_CACHE_CHECK([whether the linker supports --wrap=rk_dns_lookup],
+        [rk_cv_ld_wrap_rk_dns_lookup],
+        [save_LDFLAGS="$LDFLAGS"
+         LDFLAGS="$LDFLAGS -Wl,--wrap=rk_dns_lookup"
+         AC_LINK_IFELSE(
+            [AC_LANG_PROGRAM([[
+void rk_dns_lookup(void);
+void __wrap_rk_dns_lookup(void) {}
+            ]], [[rk_dns_lookup();]])],
+            [rk_cv_ld_wrap_rk_dns_lookup=yes],
+            [rk_cv_ld_wrap_rk_dns_lookup=no])
+         LDFLAGS="$save_LDFLAGS"])
+
+    AS_IF([test "x$rk_cv_ld_wrap_rk_dns_lookup" = xyes],
+          [WRAP_LDFLAGS="-Wl,--wrap=rk_dns_lookup"
+           AUDITDNS_CPPFLAGS="-DAUDITDNS_USE_LD_WRAP"])
+])
 AC_SUBST([WRAP_LDFLAGS])
+AC_SUBST([AUDITDNS_CPPFLAGS])
 
 rk_SYS_LARGEFILE
 


### PR DESCRIPTION
auditdns.c defines its own rk_dns_lookup to intercept DNS lookups for auditing purposes, causing a multiple definition error at link time when libroken also provides the same symbol. Newer GNU ld treats this as a hard error rather than a warning.

Use -Wl,--wrap,rk_dns_lookup and rename the local interceptor to __wrap_rk_dns_lookup so the override works correctly against both static and shared builds of libroken.

Fixes: multiple definition of `rk_dns_lookup'

- second part of the fix to #1342
- First part is #1343