### PR TITLE
enable migration to MIT krb5 from Heimdal

### DIFF
--- a/kadmin/dump.c
+++ b/kadmin/dump.c
@@ -72,6 +72,15 @@ dump(struct dump_options *opt, int argc, char **argv)
     } else if (opt->format_string && strcmp(opt->format_string, "MIT") == 0) {
         parg.fmt = HDB_DUMP_MIT;
         fprintf(f, "kdb5_util load_dump version 5\n"); /* 5||6, either way */
+    } else if (opt->format_string) {
+	/* Open the format string as a MIT mkey file. */
+	ret = hdb_read_master_key(context, opt->format_string, &db->hdb_mit_key);
+	if (ret)
+	    krb5_errx(context, 1, "Cannot open MIT mkey file");
+	db->hdb_mit_key_set = 1;
+        parg.fmt = HDB_DUMP_MIT;
+	opt->decrypt_flag = 1;
+        fprintf(f, "kdb5_util load_dump version 5\n"); /* 5||6, either way */
     } else {
         krb5_errx(context, 1, "Supported dump formats: Heimdal and MIT");
     }

--- a/kadmin/kadmin-commands.in
+++ b/kadmin/kadmin-commands.in
@@ -80,7 +80,7 @@ command = {
 		long = "format"
 		short = "f"
 		type = "string"
-		help = "dump format, mit or heimdal (default: heimdal)"
+		help = "dump format, heimdal or mit or path to mit master key (default: heimdal)"
 	}
 	argument = "[dump-file]"
 	min_args = "0"

--- a/lib/hdb/hdb.h
+++ b/lib/hdb/hdb.h
@@ -303,6 +303,8 @@ typedef struct HDB {
      * sync and does an fsync().
      */
     krb5_error_code (*hdb_set_sync)(krb5_context, struct HDB *, int);
+    int hdb_mit_key_set;
+    hdb_master_key hdb_mit_key;
 }HDB;
 
 #define HDB_INTERFACE_VERSION	11

--- a/lib/hdb/hdb_locl.h
+++ b/lib/hdb/hdb_locl.h
@@ -70,4 +70,9 @@
 #define HDB_DEFAULT_DB HDB_DB_DIR "/heimdal"
 #define HDB_DB_FORMAT_ENTRY "hdb/db-format"
 
+/* Test for strong key etypes accepted by MIT's KDC. */
+#define        mit_strong_etype(t)                             \
+	((t) == ETYPE_AES128_CTS_HMAC_SHA1_96 ||	       \
+	 (t) == ETYPE_AES256_CTS_HMAC_SHA1_96)
+
 #endif /* __HDB_LOCL_H__ */

--- a/lib/hdb/mkey.c
+++ b/lib/hdb/mkey.c
@@ -419,80 +419,154 @@ _hdb_mkey_encrypt(krb5_context context, hdb_master_key key,
 			ptr, size, res);
 }
 
+/*
+ * Unseal and optionally reseal the key in the MIT KDC master key.
+ * If mit_key != NULL, the key is sealed using this key.
+ */
+static krb5_error_code
+_hdb_reseal_key_mkey(krb5_context context, Key *k, hdb_master_key mkey,
+    hdb_master_key mit_key)
+{
+
+    krb5_error_code ret;
+    krb5_data mitres, res;
+    size_t keysize;
+
+    hdb_master_key key, mitkey;
+
+    if(k->mkvno == NULL)
+        return 0;
+
+    key = _hdb_find_master_key(k->mkvno, mkey);
+
+    if (key == NULL)
+        return HDB_ERR_NO_MKEY;
+
+    ret = _hdb_mkey_decrypt(context, key, HDB_KU_MKEY,
+                            k->key.keyvalue.data,
+                            k->key.keyvalue.length,
+                            &res);
+    if(ret == KRB5KRB_AP_ERR_BAD_INTEGRITY) {
+        /* try to decrypt with MIT key usage */
+        ret = _hdb_mkey_decrypt(context, key, 0,
+                            k->key.keyvalue.data,
+                            k->key.keyvalue.length,
+                            &res);
+    }
+    if (ret)
+        return ret;
+
+    /* fixup keylength if the key got padded when encrypting it */
+    ret = krb5_enctype_keysize(context, k->key.keytype, &keysize);
+    if (ret) {
+        krb5_data_free(&res);
+        return ret;
+    }
+    if (keysize > res.length) {
+        krb5_data_free(&res);
+        return KRB5_BAD_KEYSIZE;
+    }
+
+    /* For mit_key != NULL, re-encrypt the key using the mitkey. */
+    if (mit_key != NULL) {
+        mitkey = _hdb_find_master_key(NULL, mit_key);
+        if (mitkey == NULL) {
+            krb5_data_free(&res);
+            return HDB_ERR_NO_MKEY;
+        }
+
+        ret = _hdb_mkey_encrypt(context, mitkey, 0,
+                            res.data,
+                            keysize,
+                            &mitres);
+        krb5_data_free(&res);
+        if (ret)
+            return ret;
+    }
+
+    krb5_data_free(&k->key.keyvalue);
+    if (mit_key == NULL) {
+        k->key.keyvalue = res;
+        k->key.keyvalue.length = keysize;
+        free(k->mkvno);
+        k->mkvno = NULL;
+    } else {
+        k->key.keyvalue = mitres;
+        *k->mkvno = mitkey->keytab.vno;
+    }
+
+    return 0;
+}
+
 krb5_error_code
 hdb_unseal_key_mkey(krb5_context context, Key *k, hdb_master_key mkey)
 {
 
     krb5_error_code ret;
-    krb5_data res;
-    size_t keysize;
 
-    hdb_master_key key;
+    ret = _hdb_reseal_key_mkey(context, k, mkey, NULL);
+    return ret;
+}
 
-    if(k->mkvno == NULL)
-	return 0;
+static krb5_error_code
+_hdb_unseal_keys_mkey(krb5_context context, hdb_entry *ent,
+		      hdb_master_key mkey, hdb_master_key mitkey)
+{
+    krb5_error_code ret;
+    size_t i;
+    int got_one = 0;
 
-    key = _hdb_find_master_key(k->mkvno, mkey);
-
-    if (key == NULL)
-	return HDB_ERR_NO_MKEY;
-
-    ret = _hdb_mkey_decrypt(context, key, HDB_KU_MKEY,
-			    k->key.keyvalue.data,
-			    k->key.keyvalue.length,
-			    &res);
-    if(ret == KRB5KRB_AP_ERR_BAD_INTEGRITY) {
-	/* try to decrypt with MIT key usage */
-	ret = _hdb_mkey_decrypt(context, key, 0,
-				k->key.keyvalue.data,
-				k->key.keyvalue.length,
-				&res);
-    }
-    if (ret)
-	return ret;
-
-    /* fixup keylength if the key got padded when encrypting it */
-    ret = krb5_enctype_keysize(context, k->key.keytype, &keysize);
-    if (ret) {
-	krb5_data_free(&res);
-	return ret;
-    }
-    if (keysize > res.length) {
-	krb5_data_free(&res);
-	return KRB5_BAD_KEYSIZE;
+    for(i = 0; i < ent->keys.len; i++){
+        if (mitkey == NULL || mit_strong_etype(ent->keys.val[i].key.keytype)) {
+            ret = _hdb_reseal_key_mkey(context, &ent->keys.val[i], mkey,
+                mitkey);
+            if (ret)
+                return ret;
+            got_one = 1;
+        }
     }
 
-    memset(k->key.keyvalue.data, 0, k->key.keyvalue.length);
-    free(k->key.keyvalue.data);
-    k->key.keyvalue = res;
-    k->key.keyvalue.length = keysize;
-    free(k->mkvno);
-    k->mkvno = NULL;
+    /*
+     * If none of the keys were string enough, create a strong key,
+     * but one that is not encrypted in the MIT master key.  As such,
+     * it will require a "change_password" once in the MIT KDC to
+     * make it work.
+     */
+    if (got_one == 0 && mitkey != NULL && ent->keys.len > 0) {
+        krb5_salt salt;
 
+        krb5_free_keyblock_contents(context, &ent->keys.val[0].key);
+        salt.salttype = KRB5_PW_SALT;
+        salt.saltvalue.data = NULL;
+        salt.saltvalue.length = 0;
+        ret = krb5_string_to_key_salt(context, ETYPE_AES256_CTS_HMAC_SHA1_96,
+            "XXXX", salt, &ent->keys.val[0].key);
+        if (ret)
+            return ret;
+    }
     return 0;
 }
 
 krb5_error_code
 hdb_unseal_keys_mkey(krb5_context context, hdb_entry *ent, hdb_master_key mkey)
 {
-    size_t i;
+    krb5_error_code ret;
 
-    for(i = 0; i < ent->keys.len; i++){
-	krb5_error_code ret;
-
-	ret = hdb_unseal_key_mkey(context, &ent->keys.val[i], mkey);
-	if (ret)
-	    return ret;
-    }
-    return 0;
+    ret = _hdb_unseal_keys_mkey(context, ent, mkey, NULL);
+    return ret;
 }
 
 krb5_error_code
 hdb_unseal_keys(krb5_context context, HDB *db, hdb_entry *ent)
 {
     if (db->hdb_master_key_set == 0)
-	return 0;
-    return hdb_unseal_keys_mkey(context, ent, db->hdb_master_key);
+        return 0;
+    if (db->hdb_mit_key_set != 0)
+        return _hdb_unseal_keys_mkey(context, ent, db->hdb_master_key,
+            db->hdb_mit_key);
+    else
+        return _hdb_unseal_keys_mkey(context, ent, db->hdb_master_key,
+            NULL);
 }
 
 /*
@@ -629,7 +703,7 @@ hdb_unseal_key(krb5_context context, HDB *db, Key *k)
 {
     if (db->hdb_master_key_set == 0)
 	return 0;
-    return hdb_unseal_key_mkey(context, k, db->hdb_master_key);
+    return _hdb_reseal_key_mkey(context, k, db->hdb_master_key, NULL);
 }
 
 krb5_error_code

--- a/lib/hdb/print.c
+++ b/lib/hdb/print.c
@@ -408,16 +408,14 @@ entry2mit_string_int(krb5_context context, krb5_storage *sp, hdb_entry *ent)
             continue;
         num_key_data++;
     }
-    if (hist_keys) {
-        for (i = 0; i < hist_keys->len; i++) {
-            /*
-             * MIT uses the highest kvno as the current kvno instead of
-             * tracking kvno separately, so we can't dump keysets with kvno
-             * higher than the entry's kvno.
-             */
-            if (hist_keys->val[i].kvno >= ent->kvno)
-                continue;
-            for (k = 0; k < hist_keys->val[i].keys.len; k++) {
+    for (i = 0; hist_keys && i < ent->kvno; i++) {
+        size_t m;
+
+        /* dump historical keys */
+        for (k = 0; k < hist_keys->len; k++) {
+	    if (hist_keys->val[k].kvno != ent->kvno - i)
+		continue;
+            for (m = 0; m < hist_keys->val[k].keys.len; m++) {
 		if (!mit_strong_etype(ent->keys.val[k].key.keytype))
 		    continue;
                 num_key_data++;

--- a/lib/hdb/print.c
+++ b/lib/hdb/print.c
@@ -418,9 +418,8 @@ entry2mit_string_int(krb5_context context, krb5_storage *sp, hdb_entry *ent)
             if (hist_keys->val[i].kvno >= ent->kvno)
                 continue;
             for (k = 0; k < hist_keys->val[i].keys.len; k++) {
-                if (ent->keys.val[k].key.keytype == ETYPE_DES_CBC_MD4 ||
-                    ent->keys.val[k].key.keytype == ETYPE_DES_CBC_MD5)
-                    continue;
+		if (!mit_strong_etype(ent->keys.val[k].key.keytype))
+		    continue;
                 num_key_data++;
             }
         }
@@ -506,8 +505,7 @@ entry2mit_string_int(krb5_context context, krb5_storage *sp, hdb_entry *ent)
      * the entry's keys -- max kvno is it)
      */
     for (i = 0; i < ent->keys.len; i++) {
-        if (ent->keys.val[i].key.keytype == ETYPE_DES_CBC_MD4 ||
-            ent->keys.val[i].key.keytype == ETYPE_DES_CBC_MD5)
+	if (!mit_strong_etype(ent->keys.val[i].key.keytype))
             continue;
         sz = append_mit_key(context, sp, ent->principal, ent->kvno,
                             &ent->keys.val[i]);
@@ -521,9 +519,8 @@ entry2mit_string_int(krb5_context context, krb5_storage *sp, hdb_entry *ent)
             if (hist_keys->val[k].kvno != ent->kvno - i)
                 continue;
             for (m = 0; m < hist_keys->val[k].keys.len; m++) {
-                if (ent->keys.val[k].key.keytype == ETYPE_DES_CBC_MD4 ||
-                    ent->keys.val[k].key.keytype == ETYPE_DES_CBC_MD5)
-                    continue;
+		if (!mit_strong_etype(ent->keys.val[k].key.keytype))
+		    continue;
                 sz = append_mit_key(context, sp, ent->principal,
                                     hist_keys->val[k].kvno,
                                     &hist_keys->val[k].keys.val[m]);

--- a/lib/hdb/print.c
+++ b/lib/hdb/print.c
@@ -89,6 +89,10 @@ append_hex(krb5_context context, krb5_storage *sp,
     size_t i;
     char *p;
 
+    /* a zero-length input stil needs to encode to something. force a -1 */
+    if (data->length == 0) {
+	return append_string(context, sp, "-1");
+    }
     p = data->data;
     if (!always_encode) {
         for (i = 0; i < data->length; i++) {

--- a/lib/hdb/print.c
+++ b/lib/hdb/print.c
@@ -400,8 +400,7 @@ entry2mit_string_int(krb5_context context, krb5_storage *sp, hdb_entry *ent)
         hist_keys = &extp->data.u.hist_keys;
 
     for (i = 0; i < ent->keys.len;i++) {
-        if (ent->keys.val[i].key.keytype == ETYPE_DES_CBC_MD4 ||
-            ent->keys.val[i].key.keytype == ETYPE_DES_CBC_MD5)
+        if (!mit_strong_etype(ent->keys.val[i].key.keytype))
             continue;
         num_key_data++;
     }
@@ -451,7 +450,7 @@ entry2mit_string_int(krb5_context context, krb5_storage *sp, hdb_entry *ent)
         krb5_data d;
         time_t val;
         unsigned char *ptr;
-        
+
         ptr = (unsigned char *)&last_pw_chg;
         val = ((unsigned long)ptr[3] << 24) | (ptr[2] << 16)
 	    | (ptr[1] << 8) | ptr[0];


### PR DESCRIPTION
This is a port of patches from Rick Macklem in FreeBSD, with several other fixes discovered while testing said patches for general issues which exist in the MIT dump writing code in Heimdal