### PR TITLE
gss/krb5: retry stale service tickets on bad kvno

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -95,6 +95,7 @@ Release Notes - Heimdal - Version Heimdal 8.0 (future)
  - ASN.1: Support circular types.
  - ASN.1: Topographically sort declarations.
  - ASN.1: Proper support for IMPLICIT tags.
+ - GSS: Retry after a KRB_AP_ERR_BADKEYVER error token
  - GSS: Add advanced credential store / load functionality.
  - GSS: Add gss_acquire_cred_from() and credential store extensions.
  - GSS: Add name attributes support, with support for many basic attributes

--- a/lib/gssapi/krb5/accept_sec_context.c
+++ b/lib/gssapi/krb5/accept_sec_context.c
@@ -310,7 +310,12 @@ send_error_token(OM_uint32 *minor_status,
     /* this e_data value encodes KERB_AP_ERR_TYPE_SKEW_RECOVERY which
        tells windows to try again with the corrected timestamp. See
        [MS-KILE] 2.2.1 KERB-ERROR-DATA */
-    krb5_data e_data = { 7, rk_UNCONST("\x30\x05\xa1\x03\x02\x01\x02") };
+    krb5_data err_skew = { 7, rk_UNCONST("\x30\x05\xa1\x03\x02\x01\x02") };
+    krb5_data err_badkeyver = {
+	sizeof(GSS_KRB5_BADKEYVER_RETRY_E_DATA) - 1,
+	rk_UNCONST(GSS_KRB5_BADKEYVER_RETRY_E_DATA)
+    };
+    krb5_data *e_data = NULL;
 
     /* build server from request if the acceptor had not selected one */
     if (server == NULL) {
@@ -333,7 +338,12 @@ send_error_token(OM_uint32 *minor_status,
 	server = ap_req_server;
     }
 
-    ret = krb5_mk_error(context, kret, NULL, &e_data, NULL,
+    if (kret == KRB5KRB_AP_ERR_SKEW || kret == KRB5KRB_AP_ERR_TKT_NYV)
+        e_data = &err_skew;
+    else if (kret == KRB5KRB_AP_ERR_BADKEYVER)
+        e_data = &err_badkeyver;
+
+    ret = krb5_mk_error(context, kret, NULL, e_data, NULL,
 			server, NULL, NULL, &outbuf);
     if (ap_req_server)
 	krb5_free_principal(context, ap_req_server);
@@ -456,12 +466,13 @@ gsskrb5_acceptor_start(OM_uint32 * minor_status,
 	krb5_rd_req_in_ctx_free(context, in);
 	if (close_kt)
 	    krb5_kt_close(context, keytab);
-	if (kret == KRB5KRB_AP_ERR_SKEW || kret == KRB5KRB_AP_ERR_TKT_NYV) {
+	if (kret == KRB5KRB_AP_ERR_SKEW ||
+	    kret == KRB5KRB_AP_ERR_TKT_NYV ||
+	    kret == KRB5KRB_AP_ERR_BADKEYVER) {
 	    /*
 	     * No reply in non-MUTUAL mode, but we don't know that its
 	     * non-MUTUAL mode yet, thats inside the 8003 checksum, so
-	     * lets only send the error token on clock skew, that
-	     * limit when send error token for non-MUTUAL.
+	     * lets only send the error token for recoverable errors.
 	     */
             krb5_auth_con_free(context, ctx->auth_context);
             krb5_auth_con_free(context, ctx->deleg_auth_context);

--- a/lib/gssapi/krb5/gsskrb5_locl.h
+++ b/lib/gssapi/krb5/gsskrb5_locl.h
@@ -52,6 +52,15 @@
  *
  */
 
+/*
+ * DER SEQUENCE { OBJECT IDENTIFIER 1.2.752.43.13.32 }
+ *
+ * Used as KRB-ERROR e-data to mark KRB_AP_ERR_BADKEYVER as a request to
+ * refresh the service ticket and retry.
+ */
+#define GSS_KRB5_BADKEYVER_RETRY_E_DATA \
+  "\x30\x08\x06\x06\x2a\x85\x70\x2b\x0d\x20"
+
 struct gss_msg_order;
 
 typedef struct gsskrb5_ctx {

--- a/lib/gssapi/krb5/init_sec_context.c
+++ b/lib/gssapi/krb5/init_sec_context.c
@@ -390,6 +390,16 @@ init_auth
 
     *minor_status = 0;
 
+    if (ctx->ccache && (ctx->more_flags & CLOSE_CCACHE)) {
+	krb5_cc_close(context, ctx->ccache);
+	ctx->ccache = NULL;
+	ctx->more_flags &= ~CLOSE_CCACHE;
+    }
+    if (ctx->source) {
+	krb5_free_principal(context, ctx->source);
+	ctx->source = NULL;
+    }
+
     if (actual_mech_type)
 	*actual_mech_type = GSS_KRB5_MECHANISM;
 
@@ -697,34 +707,62 @@ handle_error_packet(krb5_context context,
 {
     krb5_error_code kret;
     KRB_ERROR error;
+    krb5_boolean retry_badkeyver = FALSE;
 
     kret = krb5_rd_error(context, &indata, &error);
-    if (kret == 0) {
-	kret = krb5_error_from_rd_error(context, &error, NULL);
+    if (kret != 0)
+        return kret;
 
-	/* save the time skrew for this host */
-	if (kret == KRB5KRB_AP_ERR_SKEW) {
-	    krb5_data timedata;
-	    unsigned char p[4];
-	    int32_t t = error.stime - time(NULL);
+    kret = krb5_error_from_rd_error(context, &error, NULL);
+    if (kret == KRB5KRB_AP_ERR_BADKEYVER && error.e_data &&
+	error.e_data->length == sizeof(GSS_KRB5_BADKEYVER_RETRY_E_DATA) - 1 &&
+	memcmp(error.e_data->data, GSS_KRB5_BADKEYVER_RETRY_E_DATA,
+	       sizeof(GSS_KRB5_BADKEYVER_RETRY_E_DATA) - 1) == 0)
+	retry_badkeyver = TRUE;
 
-	    p[0] = (t >> 24) & 0xFF;
-	    p[1] = (t >> 16) & 0xFF;
-	    p[2] = (t >> 8)  & 0xFF;
-	    p[3] = (t >> 0)  & 0xFF;
+    if (ctx->more_flags & RETRIED)
+        goto bail;
 
-	    timedata.data = p;
-	    timedata.length = sizeof(p);
+    /* save the time skrew for this host */
+    if (kret == KRB5KRB_AP_ERR_SKEW ||
+	retry_badkeyver) {
+	krb5_data timedata;
+	unsigned char p[4];
+	int32_t t = error.stime - time(NULL);
 
-	    krb5_cc_set_config(context, ctx->ccache, ctx->target,
-			       "time-offset", &timedata);
+	p[0] = (t >> 24) & 0xFF;
+	p[1] = (t >> 16) & 0xFF;
+	p[2] = (t >> 8)  & 0xFF;
+	p[3] = (t >> 0)  & 0xFF;
 
-	    if ((ctx->more_flags & RETRIED) == 0)
-		 ctx->state = INITIATOR_RESTART;
+	timedata.data = p;
+	timedata.length = sizeof(p);
+
+	(void)krb5_cc_set_config(context, ctx->ccache, ctx->target,
+				 "time-offset", &timedata);
+    }
+
+    switch (kret) {
+    case KRB5KRB_AP_ERR_BADKEYVER:
+	if (!retry_badkeyver)
+	    break;
+	if (ctx->kcred)
+	    kret = krb5_cc_remove_cred(context, ctx->ccache, 0, ctx->kcred);
+	else
+	    kret = 0;
+	if (kret == 0) {
+	    ctx->state = INITIATOR_START;
 	    ctx->more_flags |= RETRIED;
 	}
-	free_KRB_ERROR (&error);
+        break;
+    case KRB5KRB_AP_ERR_SKEW:
+	ctx->state = INITIATOR_RESTART;
+	ctx->more_flags |= RETRIED;
+        break;
     }
+
+bail:
+    free_KRB_ERROR(&error);
     return kret;
 }
 
@@ -736,7 +774,6 @@ repl_mutual
  krb5_context context,
  const gss_OID mech_type,
  OM_uint32 req_flags,
- OM_uint32 time_req,
  const gss_channel_bindings_t input_chan_bindings,
  const gss_buffer_t input_token,
  gss_OID * actual_mech_type,
@@ -969,14 +1006,14 @@ OM_uint32 GSSAPI_CALLCONV _gsskrb5_init_sec_context
 			  context,
 			  mech_type,
 			  req_flags,
-			  time_req,
 			  input_chan_bindings,
 			  input_token,
 			  actual_mech_type,
 			  output_token,
 			  ret_flags,
 			  time_rec);
-	if (ctx->state == INITIATOR_RESTART)
+	if (ctx->state == INITIATOR_START ||
+	    ctx->state == INITIATOR_RESTART)
 	    goto again;
 	break;
     case INITIATOR_READY:

--- a/lib/krb5/rd_req.c
+++ b/lib/krb5/rd_req.c
@@ -850,10 +850,12 @@ krb5_rd_req_ctx(krb5_context context,
 		krb5_rd_req_out_ctx *outctx)
 {
     krb5_error_code ret;
+    krb5_error_code exact_keytab_ret = 0;
     krb5_ap_req ap_req;
     krb5_rd_req_out_ctx o = NULL;
     krb5_keytab id = NULL, keytab = NULL;
     krb5_principal service = NULL;
+    krb5_boolean explicit_server = (server != NULL);
 
     if (outctx)
         *outctx = NULL;
@@ -929,10 +931,8 @@ krb5_rd_req_ctx(krb5_context context,
 				  id,
 				  &o->keyblock);
 	if (ret) {
-	    /* If caller specified a server, fail. */
-	    if (service == NULL && (context->flags & KRB5_CTX_F_RD_REQ_IGNORE) == 0)
-		goto out;
-	    /* Otherwise, fall back to iterating over the keytab. This
+	    exact_keytab_ret = ret;
+	    /* Fall back to iterating over the keytab. This
 	     * have serious performace issues for larger keytab.
 	     */
 	    o->keyblock = NULL;
@@ -964,12 +964,19 @@ krb5_rd_req_ctx(krb5_context context,
 
 	krb5_keytab_entry entry;
 	krb5_kt_cursor cursor;
+	krb5_boolean newer_kvno = FALSE;
+	krb5_boolean have_kvno = FALSE;
+	krb5_boolean scan_explicit_server =
+	    explicit_server &&
+	    (context->flags & KRB5_CTX_F_RD_REQ_IGNORE) == 0;
 	int done = 0, kvno = 0;
 
 	memset(&cursor, 0, sizeof(cursor));
 
-	if (ap_req.ticket.enc_part.kvno)
+	if (ap_req.ticket.enc_part.kvno) {
 	    kvno = *ap_req.ticket.enc_part.kvno;
+	    have_kvno = TRUE;
+	}
 
 	ret = krb5_kt_start_seq_get(context, id, &cursor);
 	if (ret)
@@ -978,6 +985,7 @@ krb5_rd_req_ctx(krb5_context context,
 	done = 0;
 	while (!done) {
 	    krb5_principal p;
+	    krb5_boolean same_server;
 
 	    ret = krb5_kt_next_entry(context, id, &entry, &cursor);
 	    if (ret) {
@@ -986,6 +994,15 @@ krb5_rd_req_ctx(krb5_context context,
 					     kvno);
 		break;
 	    }
+
+	    same_server = krb5_principal_compare(context, entry.principal,
+						 server);
+	    if (scan_explicit_server && !same_server) {
+		krb5_kt_free_entry (context, &entry);
+		continue;
+	    }
+	    if (have_kvno && same_server && entry.vno > kvno)
+		newer_kvno = TRUE;
 
 	    if (entry.keyblock.keytype != ap_req.ticket.enc_part.etype) {
 		krb5_kt_free_entry (context, &entry);
@@ -1033,8 +1050,13 @@ krb5_rd_req_ctx(krb5_context context,
 	    done = 1;
 	}
 	krb5_kt_end_seq_get (context, id, &cursor);
-        if (ret)
-            goto out;
+	if ((ret == KRB5_KT_NOTFOUND || ret == KRB5_KT_END) && newer_kvno)
+	    ret = KRB5KRB_AP_ERR_BADKEYVER;
+	else if ((ret == KRB5_KT_NOTFOUND || ret == KRB5_KT_END) &&
+		 scan_explicit_server && exact_keytab_ret)
+	    ret = exact_keytab_ret;
+	if (ret)
+	    goto out;
     }
 
     if (krb5_ticket_get_authorization_data_type(context, o->ticket,

--- a/tests/gss/check-context.in
+++ b/tests/gss/check-context.in
@@ -90,6 +90,9 @@ ext -k ${keytab} host/lucid.test.h5l.se@${R}
 add -p p1 --use-defaults host/ok-delegate.test.h5l.se@${R}
 mod --attributes=+ok-as-delegate host/ok-delegate.test.h5l.se@${R}
 ext -k ${keytab} host/ok-delegate.test.h5l.se@${R}
+add -p p1 --use-defaults host/kvno-enctype.test.h5l.se@${R}
+del_enctype host/kvno-enctype.test.h5l.se@${R} aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+ext -k ${keytab} host/kvno-enctype.test.h5l.se@${R}
 add -p p1 --use-defaults host/short@${R}
 mod --alias=host/long.test.h5l.se@${R} host/short@${R}
 ext -k ${keytab} host/short@${R}
@@ -525,6 +528,108 @@ test_run ${context} \
     --server-time-offset=3600 \
     --max-loops=2 \
     --name-type=hostbased-service host@lucid.test.h5l.se
+
+test_section "Getting stale service ticket for kvno retry"
+test_run ${kdestroy}
+test_run ${kinit} --password-file=${objdir}/foopassword user1@${R}
+test_run ${kgetcred} host/lucid.test.h5l.se@${R}
+
+newkvno_keytabfile=${objdir}/server-newkvno.keytab
+newkvno_keytab="FILE:${newkvno_keytabfile}"
+rm -f ${newkvno_keytabfile}
+
+test_run ${kadmin} <<EOF
+cpw -r host/lucid.test.h5l.se@${R}
+ext -k ${newkvno_keytab} host/lucid.test.h5l.se@${R}
+ext -k ${keytab} host/lucid.test.h5l.se@${R}
+EOF
+test_run ${ktutil} -k ${newkvno_keytab} remove \
+    -p host/lucid.test.h5l.se@${R} -V 1
+
+test_section "Stale service ticket kvno"
+test_run ${context} \
+    --gsskrb5-acceptor-identity="${newkvno_keytabfile}" \
+    --mech-type=krb5 \
+    --mutual-auth \
+    --max-loops=3 \
+    --name-type=hostbased-service host@lucid.test.h5l.se
+${klist} --verbose > stale-kvno-klist.log 2>&1 || \
+    { echo "klist failed"; cat stale-kvno-klist.log; exit 1; }
+awk -v service="Server: host/lucid.test.h5l.se@${R}" '
+    $0 == service { in_service = 1; next }
+    /^Server:/ { in_service = 0 }
+    in_service && /Ticket etype: .*kvno 2/ { found = 1 }
+    END { exit found ? 0 : 1 }
+' stale-kvno-klist.log || \
+    { echo "stale KVNO retry did not refresh service ticket"; \
+      cat stale-kvno-klist.log; exit 1; }
+
+test_section "Getting stale service ticket for kvno and time offset retry"
+test_run ${kdestroy}
+test_run ${kinit} --password-file=${objdir}/foopassword user1@${R}
+test_run ${kgetcred} host/lucid.test.h5l.se@${R}
+
+rm -f ${newkvno_keytabfile}
+test_run ${kadmin} <<EOF
+cpw -r host/lucid.test.h5l.se@${R}
+ext -k ${newkvno_keytab} host/lucid.test.h5l.se@${R}
+ext -k ${keytab} host/lucid.test.h5l.se@${R}
+EOF
+test_run ${ktutil} -k ${newkvno_keytab} remove \
+    -p host/lucid.test.h5l.se@${R} -V 1
+test_run ${ktutil} -k ${newkvno_keytab} remove \
+    -p host/lucid.test.h5l.se@${R} -V 2
+
+test_section "Stale service ticket kvno with server time offset"
+test_run ${context} \
+    --gsskrb5-acceptor-identity="${newkvno_keytabfile}" \
+    --mech-type=krb5 \
+    --mutual-auth \
+    --server-time-offset=3600 \
+    --max-loops=3 \
+    --name-type=hostbased-service host@lucid.test.h5l.se
+${klist} --verbose > stale-kvno-skew-klist.log 2>&1 || \
+    { echo "klist failed"; cat stale-kvno-skew-klist.log; exit 1; }
+awk -v service="Server: host/lucid.test.h5l.se@${R}" '
+    $0 == service { in_service = 1; next }
+    /^Server:/ { in_service = 0 }
+    in_service && /Ticket etype: .*kvno 3/ { found = 1 }
+    END { exit found ? 0 : 1 }
+' stale-kvno-skew-klist.log || \
+    { echo "stale KVNO retry with skew did not refresh service ticket"; \
+      cat stale-kvno-skew-klist.log; exit 1; }
+
+test_section "Getting stale service ticket for changed enctype kvno retry"
+test_run ${kdestroy}
+test_run ${kinit} --password-file=${objdir}/foopassword user1@${R}
+test_run ${kgetcred} host/kvno-enctype.test.h5l.se@${R}
+
+rm -f ${newkvno_keytabfile}
+test_run ${kadmin} <<EOF
+cpw -r -e aes256-cts-hmac-sha1-96 host/kvno-enctype.test.h5l.se@${R}
+ext -k ${newkvno_keytab} host/kvno-enctype.test.h5l.se@${R}
+EOF
+test_run ${ktutil} -k ${newkvno_keytab} remove \
+    -p host/kvno-enctype.test.h5l.se@${R} -V 1
+
+test_section "Stale service ticket kvno with changed enctype"
+test_run ${context} \
+    --gsskrb5-acceptor-identity="${newkvno_keytabfile}" \
+    --mech-type=krb5 \
+    --mutual-auth \
+    --max-loops=3 \
+    --name-type=hostbased-service host@kvno-enctype.test.h5l.se
+${klist} --verbose > stale-kvno-enctype-klist.log 2>&1 || \
+    { echo "klist failed"; cat stale-kvno-enctype-klist.log; exit 1; }
+awk -v service="Server: host/kvno-enctype.test.h5l.se@${R}" '
+    $0 == service { in_service = 1; next }
+    /^Server:/ { in_service = 0 }
+    in_service &&
+        /Ticket etype: aes256-cts-hmac-sha1-96, kvno 2/ { found = 1 }
+    END { exit found ? 0 : 1 }
+' stale-kvno-enctype-klist.log || \
+    { echo "stale KVNO retry did not refresh service ticket with new enctype"; \
+      cat stale-kvno-enctype-klist.log; exit 1; }
 
 test_section "Getting client initial ticket for client time offset"
 test_run ${kinit} --password-file=${objdir}/foopassword user1@${R}


### PR DESCRIPTION
Teach the acceptor to return KRB_AP_ERR_BADKEYVER when the AP-REQ key version is stale and a newer service key exists, and have the initiator refresh the service credential and retry.  The message also includes the current time of day just in case we also have a clock skew problem.

NOTE: like clock skew recovery, this only works with mutual auth.