### PR TITLE
ipropd-slave: get a TGT before authenticating

### DIFF
--- a/lib/kadm5/ipropd_slave.c
+++ b/lib/kadm5/ipropd_slave.c
@@ -124,16 +124,14 @@ connect_to_master (krb5_context context, const char *master,
 }
 
 static void
-get_creds(krb5_context context, krb5_ccache *cache, const char *serverhost)
+get_creds(krb5_context context, krb5_ccache *cache)
 {
     krb5_keytab keytab;
     krb5_principal client;
     krb5_error_code ret;
     krb5_get_init_creds_opt *init_opts;
     krb5_creds creds;
-    char *server;
     char keytab_buf[256];
-    int aret;
 
     if (no_keytab_flag) {
         /* We're using an externally refreshed ccache */
@@ -176,13 +174,8 @@ get_creds(krb5_context context, krb5_ccache *cache, const char *serverhost)
     ret = krb5_get_init_creds_opt_alloc(context, &init_opts);
     if (ret) krb5_err(context, 1, ret, "krb5_get_init_creds_opt_alloc");
 
-    aret = asprintf (&server, "%s/%s", IPROP_NAME, serverhost);
-    if (aret == -1 || server == NULL)
-	krb5_errx (context, 1, "malloc: no memory");
-
     ret = krb5_get_init_creds_keytab(context, &creds, client, keytab,
-				     0, server, init_opts);
-    free (server);
+				     0, NULL, init_opts);
     krb5_get_init_creds_opt_free(context, init_opts);
     if(ret) krb5_err(context, 1, ret, "krb5_get_init_creds");
 
@@ -890,7 +883,7 @@ main(int argc, char **argv)
     if (ret)
 	krb5_err(context, 1, ret, "db->close");
 
-    get_creds(context, &ccache, master);
+    get_creds(context, &ccache);
 
     ret = krb5_sname_to_principal (context, master, IPROP_NAME,
 				   KRB5_NT_SRV_HST, &server);
@@ -956,7 +949,7 @@ main(int argc, char **argv)
 	    krb5_auth_con_free(context, auth_context);
 	    auth_context = NULL;
 	}
-        get_creds(context, &ccache, master);
+        get_creds(context, &ccache);
         if (verbose)
             krb5_warnx(context, "authenticating to master");
 	ret = krb5_sendauth (context, &auth_context, &master_fd,

--- a/tests/kdc/check-iprop.in
+++ b/tests/kdc/check-iprop.in
@@ -55,6 +55,7 @@ ipropport2=@ipropport2@
 cache="FILE:${objdir}/cache.krb5"
 keytabfile=${objdir}/iprop.keytab
 keytab="FILE:${keytabfile}"
+slave_config="${objdir}/krb5-slave-as-is.conf"
 
 kdc="${kdc} --addresses=localhost -P $port"
 kadmin="${kadmin} -r $R"
@@ -216,6 +217,10 @@ wait_for_slave_down () {
 KRB5_CONFIG="${objdir}/krb5.conf"
 export KRB5_CONFIG
 
+# Exercise ipropd-slave with name canonicalization that does not add a realm.
+sed "s/name_canon_rules = as-is:realm=${R}/name_canon_rules = as-is:/" \
+    "${objdir}/krb5-slave.conf" > "${slave_config}" || exit 1
+
 rm -f ${keytabfile}
 rm -f current-db*
 rm -f current*.log
@@ -323,7 +328,7 @@ ipdm=`getpid ipropd-master`
 
 echo "starting slave" ; > messages.log
 env ${HEIM_MALLOC_DEBUG} \
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${ipropd_slave} || { echo "ipropd-slave failed to start"; exit 1; }
 ipds=`getpid ipropd-slave`
 sh ${wait_kdc} ipropd-slave messages.log 'slave status change: up-to-date' || exit 1
@@ -351,7 +356,7 @@ wait_for "Slave sees new host" get_iprop_ver2 0 || exit 1
 
 # ----------------- checking: pushing lives changes
 
-slave_get() { KRB5_CONFIG="${objdir}/krb5-slave.conf" ${kadmin} -l get "$@"; }
+slave_get() { KRB5_CONFIG="${slave_config}" ${kadmin} -l get "$@"; }
 slave_check_exists() {
     # Creation with a random key is not atomic, there are at present
     # 3 log entries to create a random key principal, the entry is
@@ -383,27 +388,27 @@ wait_for_slave2 4
 echo "Delete 3DES keys"
 ${kadmin} -l del_enctype host/foo@${R} aes256-cts-hmac-sha1-96
 wait_for_slave
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${kadmin} -l get host/foo@${R} | \
     ${EGREP} Keytypes: | cut -d: -f2 | tr ' ' '
 ' | sed 's/^.*[[]\(.*\)[]].*$/\1/' | grep '[0-9]' | sort -nu | tr -d '
 ' | ${EGREP} 1234 > /dev/null || exit 1
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${kadmin} -l get host/foo@${R} | \
     ${EGREP} 'Keytypes:.*aes256-cts-hmac-sha1-96' > /dev/null && exit 1
 
 echo "Change policy host"
 ${kadmin} -l modify --policy=default host/foo@${R} || exit 1
 wait_for_slave
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${kadmin} -l get host/foo@${R} > /dev/null 2>/dev/null || exit 1
 
 echo "Rename host"
 ${kadmin} -l rename host/foo@${R} host/bar@${R} || exit 1
 wait_for_slave
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${kadmin} -l get host/foo@${R} > /dev/null 2>/dev/null && exit 1
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${kadmin} -l get host/bar@${R} > /dev/null || exit 1
 
 wait_for_slave2 3
@@ -411,7 +416,7 @@ wait_for_slave2 3
 echo "Delete host"
 ${kadmin} -l delete host/bar@${R} || exit 1
 wait_for_slave
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${kadmin} -l get host/bar@${R} > /dev/null 2>/dev/null && exit 1
 
 # See note below in LMDB sanity checking
@@ -447,7 +452,7 @@ cp ${objdir}/current.log ${objdir}/current.log.tmp
 echo "starting slave again" ; > messages.log
 > iprop-stats
 env ${HEIM_MALLOC_DEBUG} \
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${ipropd_slave} || { echo "ipropd-slave failed to start"; exit 1; }
 ipds=`getpid ipropd-slave`
 
@@ -461,7 +466,7 @@ echo "checking for replay problems"
 ${EGREP} 'Entry already exists in database' messages.log && exit 1
 
 echo "compare versions on master and slave logs (no lock)"
-KRB5_CONFIG=${objdir}/krb5-slave.conf \
+KRB5_CONFIG=${slave_config} \
 ${iprop_log} last-version -n > slave-last.tmp
 ${iprop_log} last-version -n > master-last.tmp
 cmp master-last.tmp slave-last.tmp || exit 1
@@ -475,7 +480,7 @@ rm current.slave.log current-db.slave* || exit 1
 rm -f iprop-slave-status
 echo "starting slave" ; > messages.log
 env ${HEIM_MALLOC_DEBUG} \
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${ipropd_slave} || { echo "ipropd-slave failed to start"; exit 1; }
 ipds=`getpid ipropd-slave`
 wait_for_slave 0
@@ -507,7 +512,7 @@ wait_for_slave_down
 wait_for_master_down
 
 echo "compare versions on master and slave logs"
-KRB5_CONFIG=${objdir}/krb5-slave.conf \
+KRB5_CONFIG=${slave_config} \
 ${iprop_log} last-version > slave-last.tmp
 ${iprop_log} last-version > master-last.tmp
 cmp master-last.tmp slave-last.tmp || exit 1
@@ -526,7 +531,7 @@ ipdm=`getpid ipropd-master`
 
 echo "starting slave" ; > messages.log
 env ${HEIM_MALLOC_DEBUG} \
-KRB5_CONFIG="${objdir}/krb5-slave.conf" \
+KRB5_CONFIG="${slave_config}" \
 ${ipropd_slave} || { echo "ipropd-slave failed to start"; exit 1; }
 ipds=`getpid ipropd-slave`
 wait_for_slave -1
@@ -588,7 +593,7 @@ trap "" EXIT
 $leaked && exit 1
 
 echo "compare versions on master and slave logs"
-KRB5_CONFIG=${objdir}/krb5-slave.conf \
+KRB5_CONFIG=${slave_config} \
 ${iprop_log} last-version > slave-last.tmp
 ${iprop_log} last-version > master-last.tmp
 cmp master-last.tmp slave-last.tmp || exit 1


### PR DESCRIPTION
Do not request an iprop/<master> initial ticket directly. With name_canon_rules = as-is: this can leave the acquired credential mismatched with what krb5_sendauth() later asks for. Get a normal TGT and let sendauth acquire the service ticket.

Fixes #1332.