### PR TITLE
treewide: fix many null dereference reports

### DIFF
--- a/lib/asn1/gen.c
+++ b/lib/asn1/gen.c
@@ -599,6 +599,8 @@ generate_constant (const Symbol *s)
 	/* header file */
 
 	gen_upper = strdup(s->gen_name);
+	if (gen_upper == NULL)
+	    errx(1, "malloc");
 	len = strlen(gen_upper);
 	for (i = 0; i < len; i++)
 	    gen_upper[i] = toupper((unsigned char)s->gen_name[i]);

--- a/lib/asn1/gen_template.c
+++ b/lib/asn1/gen_template.c
@@ -289,7 +289,11 @@ static struct tlist *
 tlist_new(const char *name)
 {
     struct tlist *tl = calloc(1, sizeof(*tl));
+    if (tl == NULL)
+	errx(1, "malloc");
     tl->name = strdup(name);
+    if (tl->name == NULL)
+	errx(1, "malloc");
     HEIM_TAILQ_INIT(&tl->template);
     return tl;
 }
@@ -421,6 +425,8 @@ add_line(struct templatehead *t, const char *fmt, ...)
 {
     struct template *q = calloc(1, sizeof(*q));
     va_list ap;
+    if (q == NULL)
+	errx(1, "malloc");
     va_start(ap, fmt);
     if (vasprintf(&q->line, fmt, ap) < 0 || q->line == NULL)
 	errx(1, "malloc");

--- a/lib/roken/resolve.c
+++ b/lib/roken/resolve.c
@@ -95,7 +95,7 @@ rk_dns_type_to_string(int type)
     for(p = stot; p->name; p++)
 	if(type == p->type)
 	    return p->name;
-    return NULL;
+    return "unknown";
 }
 
 #if ((defined(HAVE_RES_SEARCH) || defined(HAVE_RES_NSEARCH)) && defined(HAVE_DN_EXPAND)) || defined(HAVE_WINDNS)

--- a/lib/sl/sl.c
+++ b/lib/sl/sl.c
@@ -612,6 +612,12 @@ osad(const char *s1, const char *s2)
     row0 = calloc(l2 + 1, sizeof(int));
     row1 = calloc(l2 + 1, sizeof(int));
     row2 = calloc(l2 + 1, sizeof(int));
+    if (row0 == NULL || row1 == NULL || row2 == NULL) {
+	free(row0);
+	free(row1);
+	free(row2);
+	return INT_MAX;
+    }
 
     for (j = 0; j < l2 + 1; j++)
         row1[j] = j;


### PR DESCRIPTION
Add defensive handling for several NULL allocation and formatting paths reported across issues #820-#829.

Fixes #820, fixes #821, fixes #822, fixes #823, fixes #825, fixes #828