### PR TITLE
krb5: avoid time-difference overflow

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -952,7 +952,7 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
 		   r->cname);
 	goto out;
     }
-    if (labs(kdc_time - p.patimestamp) > r->context->max_skew) {
+    if (krb5_time_abs(kdc_time, p.patimestamp) > r->context->max_skew) {
 	char client_time[100];
 		
 	krb5_format_time(r->context, p.patimestamp,
@@ -962,7 +962,7 @@ pa_enc_ts_validate(astgs_request_t r, const PA_DATA *pa)
 	_kdc_r_log(r, 4, "Too large time skew, "
 		   "client time %s is out by %u > %u seconds -- %s",
 		   client_time,
-		   (unsigned)labs(kdc_time - p.patimestamp),
+		   (unsigned)krb5_time_abs(kdc_time, p.patimestamp),
 		   r->context->max_skew,
 		   r->cname);
 	kdc_audit_setkv_number((kdc_request_t)r, KDC_REQUEST_KV_AUTH_EVENT,

--- a/kdc/pkinit.c
+++ b/kdc/pkinit.c
@@ -432,7 +432,7 @@ pk_check_pkauthenticator_win2k(krb5_context context,
     krb5_timeofday (context, &now);
 
     /* XXX cusec */
-    if (a->ctime == 0 || labs(a->ctime - now) > context->max_skew) {
+    if (a->ctime == 0 || krb5_time_abs(a->ctime, now) > context->max_skew) {
 	krb5_clear_error_message(context);
 	return KRB5KRB_AP_ERR_SKEW;
     }
@@ -451,7 +451,7 @@ pk_check_pkauthenticator(krb5_context context,
     krb5_timeofday (context, &now);
 
     /* XXX cusec */
-    if (a->ctime == 0 || labs(a->ctime - now) > context->max_skew) {
+    if (a->ctime == 0 || krb5_time_abs(a->ctime, now) > context->max_skew) {
 	krb5_clear_error_message(context);
 	return KRB5KRB_AP_ERR_SKEW;
     }

--- a/kuser/kinit.c
+++ b/kuser/kinit.c
@@ -1104,7 +1104,8 @@ get_new_tickets(krb5_context context,
     }
 
     if (ticket_life != 0) {
-	if (labs(cred.times.endtime - cred.times.starttime - ticket_life) > 30) {
+	if (krb5_time_abs(cred.times.endtime - cred.times.starttime,
+			  ticket_life) > 30) {
 	    char life[64];
 	    unparse_time_approx(cred.times.endtime - cred.times.starttime,
 				life, sizeof(life));
@@ -1112,7 +1113,8 @@ get_new_tickets(krb5_context context,
 	}
     }
     if (renew_life) {
-	if (labs(cred.times.renew_till - cred.times.starttime - renew) > 30) {
+	if (krb5_time_abs(cred.times.renew_till - cred.times.starttime,
+			  renew) > 30) {
 	    char life[64];
 	    unparse_time_approx(cred.times.renew_till - cred.times.starttime,
 				life, sizeof(life));

--- a/lib/krb5/test_time.c
+++ b/lib/krb5/test_time.c
@@ -57,8 +57,8 @@ check_set_time(krb5_context context)
     diff2 = krb5_time_abs(sec, tv.tv_sec);
 
     if (diff2 < 9 || diff > 11)
-	krb5_errx(context, 1, "set time error: diff: %ld",
-		  krb5_time_abs(sec, tv.tv_sec));
+	krb5_errx(context, 1, "set time error: diff: %lld",
+		  (long long)krb5_time_abs(sec, tv.tv_sec));
 }
 
 


### PR DESCRIPTION
Use krb5_time_abs() rather than subtracting time_t values before passing the result to labs().  On signed 32-bit time_t platforms, subtracting far-apart times can overflow before labs() sees the value.