### PR TITLE
tests: avoid ephemeral port range

### DIFF
--- a/tests/can/Makefile.am
+++ b/tests/can/Makefile.am
@@ -9,7 +9,7 @@ check_SCRIPTS = $(SCRIPT_TESTS) test_can
 SCRIPT_TESTS = check-can
 TESTS = $(SCRIPT_TESTS)
 
-port = 49188
+port = 11088
 
 do_subst = sed -e 's,[@]srcdir[@],$(abs_srcdir),g' \
 	-e 's,[@]port[@],$(port),g' \

--- a/tests/gss/Makefile.am
+++ b/tests/gss/Makefile.am
@@ -12,7 +12,7 @@ TESTS = $(SCRIPT_TESTS)
 
 check_SCRIPTS = $(SCRIPT_TESTS)
 
-port = 49188
+port = 11088
 
 do_subst = sed \
 	-e 's,[@]srcdir[@],$(abs_srcdir),g' \

--- a/tests/java/Makefile.am
+++ b/tests/java/Makefile.am
@@ -10,7 +10,7 @@ SCRIPT_TESTS = check-kinit
 
 TESTS = $(SCRIPT_TESTS)
 
-port = 49188
+port = 11088
 
 do_subst = sed -e 's,[@]srcdir[@],$(abs_srcdir),g' \
 	-e 's,[@]env_setup[@],$(abs_top_builddir)/tests/bin/setup-env,g' \

--- a/tests/kdc/Makefile.am
+++ b/tests/kdc/Makefile.am
@@ -49,14 +49,14 @@ SCRIPT_TESTS = \
 
 TESTS = $(SCRIPT_TESTS)
 
-port = 49188
-admport = 49189
-admport2 = 49190
-pwport = 49191
-restport = 49192
-restport2 = 49193
-ipropport = 49194
-ipropport2 = 49195
+port = 11088
+admport = 11089
+admport2 = 11090
+pwport = 11091
+restport = 11092
+restport2 = 11093
+ipropport = 11094
+ipropport2 = 11095
 pkinit_ticket_max_life_from_cert = 0
 
 if HAVE_DLOPEN

--- a/tests/ldap/Makefile.am
+++ b/tests/ldap/Makefile.am
@@ -8,7 +8,7 @@ check_SCRIPTS = $(TESTS) slapd-init
 
 TESTS = check-ldap
 
-port = 49188
+port = 11088
 
 do_subst = sed \
 	-e 's,[@]env_setup[@],$(abs_top_builddir)/tests/bin/setup-env,g' \

--- a/tests/plugin/Makefile.am
+++ b/tests/plugin/Makefile.am
@@ -10,7 +10,7 @@ noinst_DATA = krb5.conf
 SCRIPT_TESTS = check-pac
 TESTS = $(SCRIPT_TESTS)
 
-port = 49188
+port = 11088
 
 do_subst = sed -e 's,[@]srcdir[@],$(abs_srcdir),g' \
 	-e 's,[@]env_setup[@],$(abs_top_builddir)/tests/bin/setup-env,g' \


### PR DESCRIPTION
On our MacOS X CI job, provjobd2 sometimes held local TCP port 49195, colliding with check-iprop.  And so we move all listening ports in the test setup out of the ephemeral port ranges on Linux and Mac.