### PR TITLE
lib/asn1: fix USE_AFTER_FREE in der_print_hex_heim_integer

### DIFF
--- a/lib/asn1/der_format.c
+++ b/lib/asn1/der_format.c
@@ -97,8 +97,10 @@ der_print_hex_heim_integer (const heim_integer *data, char **p)
     if (data->negative) {
 	len = asprintf(&q, "-%s", *p);
 	free(*p);
-	if (len < 0)
+	if (len < 0) {
+	    *p = NULL;
 	    return ENOMEM;
+	}
 	*p = q;
     }
     return 0;


### PR DESCRIPTION
Set `*p` to `NULL` on `asprintf` failure to prevent a dangling pointer and subsequent `USE_AFTER_FREE` when the caller ignores `ENOMEM`.