### PR TITLE
Add ABI testing to our CI framework

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,6 +21,8 @@ on:
          - '**.asn1'
          - '**.opt'
          - '**.map'
+         - 'cf/check-library-abi.sh'
+         - 'lib/*/abi/**'
          - '**/COPYING'
          - '**/INSTALL'
          - '**/README*'
@@ -41,6 +43,9 @@ on:
          - '**.py'
          - '**.asn1'
          - '**.opt'
+         - '**.map'
+         - 'cf/check-library-abi.sh'
+         - 'lib/*/abi/**'
          - '**/COPYING'
          - '**/INSTALL'
          - '**/README*'
@@ -63,8 +68,9 @@ jobs:
                     - name: linux-gcc
                       os: ubuntu-22.04
                       compiler: gcc
-                      cflags: '-Wnonnull'
+                      cflags: '-g -Wnonnull'
                       configureopts: '--with-readline=yes'
+                      abi_platform: x86_64-linux-gnu
         steps:
             - name: Clone repository
               uses: actions/checkout@v4
@@ -72,7 +78,7 @@ jobs:
               if: startsWith(matrix.os, 'ubuntu')
               run: |
                 sudo apt-get update -qq
-                sudo apt-get install -y bison comerr-dev flex doxygen
+                sudo apt-get install -y abigail-tools bison comerr-dev flex doxygen
                 sudo apt-get install -y libcap-ng-dev libdb-dev libedit-dev libjson-perl
                 sudo apt-get install -y libldap2-dev libncurses5-dev libperl4-corelibs-perl
                 sudo apt-get install -y libsqlite3-dev libkeyutils-dev libreadline-dev pkg-config python3
@@ -102,6 +108,15 @@ jobs:
                 sudo sysctl kernel.core_pattern=core.%p || true
                 ulimit -c unlimited
                 make check
+            - name: ABI compatibility
+              if: matrix.abi_platform == 'x86_64-linux-gnu'
+              env:
+                ABI_PLATFORM: ${{ matrix.abi_platform }}
+                CC: ${{ matrix.compiler }}
+                MAKEVARS: ${{ matrix.makevars }}
+              run: |
+                cd build
+                make check-abi
             - name: Make Install
               env:
                 CC: ${{ matrix.compiler }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ asn1_*_asn1.c
 # Top-level files.
 
 /.vscode
+/abi-reports/
 /aclocal.m4
 /autom4te.cache
 /compile

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,6 +36,7 @@ EXTRA_DIST = \
 	ChangeLog.2006 \
 	Makefile.am.common \
 	autogen.sh \
+	cf/check-library-abi.sh \
 	krb5.conf \
 	cf/make-proto.pl \
 	cf/roken-h-process.pl \
@@ -61,11 +62,22 @@ EXTRA_DIST = \
 	cf/w32-list-externs-from-objs.pl \
 	cf/vararray.m4
 
+#
+# Libraries with a supported ABI opt in here and provide their own
+# check-abi target.
+#
+ABI_CHECK_DIRS =
+
+check-abi: all
+	@status=0; for dir in $(ABI_CHECK_DIRS); do \
+	    echo "Making check-abi in $$dir"; \
+	    $(MAKE) -C $$dir check-abi || status=$$?; \
+	done; exit $$status
+
 print-distdir:
 	@echo $(distdir)
 
 clean-local-gcov:
 	find . '(' -name '*.gcno' -o -name '*.gcda' -o -name '*.gcov' ')' -a -print|xargs rm -f
 
-.PHONY: clean-local-gcov
-
+.PHONY: check-abi clean-local-gcov

--- a/cf/check-library-abi.sh
+++ b/cf/check-library-abi.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+
+set -eu
+
+usage()
+{
+    echo "usage: $0 BUILD_ROOT LIBRARY ABI_VERSION_DIR [...]" >&2
+    exit 1
+}
+
+platform()
+{
+    compiler_platform=
+
+    if [ -n "${ABI_PLATFORM:-}" ]; then
+        echo "$ABI_PLATFORM"
+        return
+    fi
+
+    set -- ${CC:-cc}
+    if command -v "$1" >/dev/null 2>&1; then
+        compiler_platform=$("$@" -dumpmachine 2>/dev/null) || :
+        if [ -n "$compiler_platform" ]; then
+            echo "$compiler_platform"
+            return
+        fi
+    fi
+
+    echo "$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]')"
+}
+
+baseline_soname()
+{
+    sed -n "s/.*soname='\([^']*\)'.*/\1/p" "$1" | sed -n '1p'
+}
+
+library_soname()
+{
+    readelf -d "$1" 2>/dev/null |
+        sed -n 's/.*Library soname: \[\(.*\)\].*/\1/p' |
+        sed -n '1p'
+}
+
+built_library()
+{
+    find "$build_root/lib" \( \
+        -path "*/.libs/$1" -type f -o \
+        -path "*/.libs/$1" -type l \
+    \) |
+        sort |
+        sed -n '1p'
+}
+
+expected_soname()
+{
+    echo "$1.$(basename "$2")"
+}
+
+write_report_header()
+{
+    report=$1
+
+    {
+        echo "baseline: $baseline"
+        echo "baseline soname: $soname"
+        echo "current: $current"
+        echo "current soname: ${current_soname:-unknown}"
+        echo "build root: $build_root"
+        echo "platform: $abi_platform"
+        echo
+    } > "$report"
+}
+
+run_abidiff()
+{
+    report=$1
+    shift
+
+    write_report_header "$report"
+
+    set +e
+    abidiff \
+        --fail-no-debug-info \
+        --no-added-syms \
+        "$@" \
+        "$baseline" \
+        "$current" \
+        >> "$report" 2>&1
+    rc=$?
+    set -e
+
+    return "$rc"
+}
+
+check_abi()
+{
+    library=$1
+    abi_dir=$2
+    soname=$(expected_soname "$library" "$abi_dir")
+    baseline="$abi_dir/$abi_platform.abi"
+
+    if [ -n "${ABI_REPORT_DIR:-}" ]; then
+        report_dir="$ABI_REPORT_DIR/$soname"
+    else
+        report_dir="$build_root/abi-reports/$soname"
+    fi
+    report="$report_dir/$abi_platform.abidiff"
+
+    mkdir -p "$report_dir"
+
+    if [ ! -f "$baseline" ]; then
+        echo "$0: ABI baseline not found: $baseline" | tee "$report"
+        status=1
+        return 0
+    fi
+
+    baseline_soname=$(baseline_soname "$baseline")
+    if [ "$baseline_soname" != "$soname" ]; then
+        {
+            echo "ABI baseline SONAME mismatch for $library"
+            echo "baseline: $baseline"
+            echo "baseline soname: ${baseline_soname:-unknown}"
+            echo "expected soname: $soname"
+        } | tee "$report"
+        status=1
+        return 0
+    fi
+
+    current=$(built_library "$library")
+    if [ -z "$current" ]; then
+        echo "missing built library: $library" | tee "$report"
+        status=1
+        return 0
+    fi
+
+    current_soname=$(library_soname "$current")
+    if [ "$current_soname" != "$soname" ]; then
+        {
+            echo "ABI SONAME mismatch for $library"
+            echo "baseline: $baseline"
+            echo "baseline soname: $soname"
+            echo "current: $current"
+            echo "current soname: ${current_soname:-unknown}"
+            echo
+            echo "The ABI baseline must match the shared library version being built."
+        } | tee "$report"
+        status=1
+        return 0
+    fi
+
+    suppressions="$abi_dir/suppressions.abignore"
+
+    if [ -f "$suppressions" ] && grep -q '^\[' "$suppressions"; then
+        set -- --suppressions "$suppressions"
+    else
+        set --
+    fi
+
+    if run_abidiff "$report" "$@"; then
+        echo "ABI ok: $soname"
+    else
+        cat "$report"
+        echo "ABI differences found for $soname" >&2
+        status=1
+    fi
+
+    return 0
+}
+
+if [ "$#" -lt 3 ] || [ $((($# - 1) % 2)) -ne 0 ]; then
+    usage
+fi
+
+build_root=$1
+shift
+
+if [ ! -d "$build_root/lib" ]; then
+    echo "$0: build lib directory not found: $build_root/lib" >&2
+    exit 1
+fi
+
+abi_platform=$(platform)
+status=0
+
+while [ "$#" -gt 0 ]; do
+    library=$1
+    abi_dir=$2
+    shift 2
+
+    check_abi "$library" "$abi_dir"
+done
+
+exit "$status"


### PR DESCRIPTION
In this first pull request, we add ABI testing to our 64 bit debian build. We restrict ourselves to the libraries where nothing remotely suspicious happened. The way that the framework works is we have `lib/*/abi/SO_VER/` . In here, we store ABI's in the standard form like `x86_64-linux-gnu`. Right now that's the only one that we support. We will also store "suppressions", that is things that libabigail reports that we think are okay because, say, they are not part of what _we_ consider the public A{P,B}I.
Later pull requests will fail CI and then we can discuss what to do about it.