### PR TITLE
kdc: Fix possible double free of ac pointer

### DIFF
--- a/kdc/fast.c
+++ b/kdc/fast.c
@@ -622,6 +622,7 @@ fast_unwrap_request(astgs_request_t r,
 
     if (ac->remote_subkey == NULL) {
 	krb5_auth_con_free(r->context, ac);
+	ac = NULL;
 	kdc_log(r->context, r->config, 2,
 		"FAST AP-REQ remote subkey missing");
 	ret = KRB5KDC_ERR_PREAUTH_FAILED;


### PR DESCRIPTION
This fixes possible double free of ac pointer. In the function 'krb5_auth_con_free' pointer ac (auth_context) is freed. In case 'ac != NULL', 'ac != tgs_ac', 'ac->remote_subkey == NULL' this function is called twice (when logging "FAST AP-REQ remote subkey missing" and at label 'out').

Pair-Programmed-With: Dmitry Mikhalchenko <tascad@altlinux.org>
Signed-off-by: Daniil Sarafannikov <sarafannikovda@sgu.ru>