### PR TITLE
gss: Fix NULL pointer dereference in _gss_copy_buffer()

### DIFF
--- a/lib/gssapi/mech/gss_utils.c
+++ b/lib/gssapi/mech/gss_utils.c
@@ -135,10 +135,14 @@ _gss_copy_buffer(OM_uint32 *minor_status,
 {
 	size_t len = from_buf->length;
 
+    if (minor_status) {
 	*minor_status = 0;
+    }
 	to_buf->value = malloc(len);
 	if (!to_buf->value) {
+    	if (minor_status) {
 		*minor_status = ENOMEM;
+    	}
 		to_buf->length = 0;
 		return GSS_S_FAILURE;
 	}


### PR DESCRIPTION
If minor_status is NULL, the if (minor_status) check is skipped and the pointer remains NULL. It is then passed to _gss_copy_buffer, where it is dereferenced without being checked.

A pointer check has been added to the _gss_copy_buffer function before each dereferencing operation.

Pair-Programmed-With: Dmitry Mikhalchenko <tascad@altlinux.org>
Signed-off-by: Shumikhina Ksenia <shumikhinaka@sgu.ru>