### PR TITLE
krb5: Fix a double free when running into ENOMEM

### DIFF
--- a/lib/krb5/fcache.c
+++ b/lib/krb5/fcache.c
@@ -1081,7 +1081,6 @@ cred_delete(krb5_context context,
     ret = krb5_storage_to_data(sp, &orig_cred_data);
     if (ret)
 	goto out;
-    krb5_storage_free(sp);
 
     cred_data_in_file = malloc(orig_cred_data.length);
     if (cred_data_in_file == NULL)
@@ -1103,6 +1102,7 @@ cred_delete(krb5_context context,
 	    goto out;
     }
 
+    krb5_storage_free(sp);
     sp = krb5_storage_emem();
     if (sp == NULL)
 	goto out;


### PR DESCRIPTION
From the commit message:

In cred_delete(), sp is freed after returning from krb5_storage_to_data().
Between this point and the subsequent assignment to sp via krb_storage_emem()
there are two jumps to out, both are executed in an ENOMEM scenario: malloc fail
for cred_data_in_file and krb5_principal_set_realm() fail. In out, sp is freed
again.

This patch fixes the issue by freeing sp right before the krb5_storage_emem()
call.

Signed-off-by: Linar Galimov <galimovlz@sgu.ru>
Signed-off-by: Dmitry Mikhalchenko <tascad@altlinux.org>

Alternatively, maybe can set sp to NULL after freeing, since the free function supports passing NULL. 