### PR TITLE
roken:strsep_copy: Fix out-of-bounds write in strsep_copy

### DIFF
--- a/lib/roken/strsep_copy.c
+++ b/lib/roken/strsep_copy.c
@@ -49,8 +49,8 @@ strsep_copy(const char **stringp, const char *delim, char *buf, size_t len)
     if(save == NULL)
 	return -1;
     *stringp = *stringp + strcspn(*stringp, delim);
-    l = min(len, (size_t)(*stringp - save));
     if(len > 0) {
+	l = min(len - 1, (size_t)(*stringp - save));
 	memcpy(buf, save, l);
 	buf[l] = '\0';
     }


### PR DESCRIPTION
In case len < (size_t)(*stringp - save) and len > 0
access to buf[l] leads to out-of-bounds write as
l = len and len means the length of buffer.

Change evaluation of l: only len - 1 elements of
buffer can be used for memcpy and terminator
should be written to buf[len - 1] (in case l = len - 1). 
Also, this value of l is not used when len == 0,
so we calculate it only when len > 0.

Pair-Programmed-With: Dmitry Mikhalchenko <tascad@altlinux.org>
Signed-off-by: Daniil Sarafannikov <sarafannikovda@sgu.ru>