### PR TITLE
kerberos5: Add handler for NULL key

### DIFF
--- a/kdc/kerberos5.c
+++ b/kdc/kerberos5.c
@@ -366,6 +366,9 @@ _kdc_find_etype(astgs_request_t r, uint32_t flags,
 	}
     }
 
+    if (key == NULL) {
+        ret = KRB5KDC_ERR_NULL_KEY;
+    }
     if (ret == 0 && enctype == ETYPE_NULL) {
         /*
          * if the service principal is one for which there is a known 1DES


### PR DESCRIPTION
Added handler for case when key is not defined inside conditions use_strongest_session_key != 0 and if (!is_preauth && !(flags & KFE_USE_CLIENT) && princ->etypes)

We need a new handler because if ret_key is NULL and ret == 0, regardless of value ret_default_salt, ret_key will be placed 
in ckey pointer inside function _kdc_as_rep and dereferenced in call
get_pa_etype_info_both -> get_pa_etype_info2 -> make_etype_info2_entry

Pair-Programmed-With: Dmitriy Mikhalchenko <tascad@altlinux.org>
Signed-off-by: Shishkov Nikita <shishkovna@sgu.ru>