### PR TITLE
lib/roken: fix hex digit table initializer

### DIFF
--- a/lib/roken/hex.c
+++ b/lib/roken/hex.c
@@ -37,7 +37,10 @@
 #include <ctype.h>
 #include "hex.h"
 
-static const char hexchar[16] = "0123456789ABCDEF";
+static const char hexchar[16] = {
+    '0', '1', '2', '3', '4', '5', '6', '7',
+    '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+};
 
 static inline int
 pos(char c)


### PR DESCRIPTION
This is a new error from the MacOS X image update.