### PR TITLE
MacOS X upgrade requires small changes to pass CI

### DIFF
--- a/lib/asn1/template.c
+++ b/lib/asn1/template.c
@@ -1990,7 +1990,7 @@ _asn1_length_open_type(const struct asn1_template *tbase,
             i4 = (intptr_t)t->ptr;
             sz = _asn1_length_open_type_id(ttypeid, &i4);
             i4 = 0;
-            sz -= _asn1_length_open_type_id(ttypeid, &i8);
+            sz -= _asn1_length_open_type_id(ttypeid, &i4);
             break;
         default:
             return 0;

--- a/lib/gssapi/test_context.c
+++ b/lib/gssapi/test_context.c
@@ -653,10 +653,11 @@ wrapunwrap_iov(gss_ctx_id_t cctx, gss_ctx_id_t sctx, int flags, gss_OID mechoid)
     gss_iov_buffer_desc iov[6];
     unsigned char *p;
     int iov_len;
-    char header_data[9] = "ABCheader";
-    char trailer_data[10] = "trailerXYZ";
+    char header_data[9] = { 'A', 'B', 'C', 'h', 'e', 'a', 'd', 'e', 'r' };
+    char trailer_data[10] = { 't', 'r', 'a', 'i', 'l', 'e', 'r', 'X', 'Y', 'Z' };
 
-    char token_data[16] = "0123456789abcdef";
+    char token_data[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
+                            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
     memset(&iov, 0, sizeof(iov));
 
@@ -804,8 +805,9 @@ wrapunwrap_aead(gss_ctx_id_t cctx, gss_ctx_id_t sctx, int flags, gss_OID mechoid
     OM_uint32 min_stat, maj_stat;
     gss_qop_t qop_state;
     int conf_state, conf_state2;
-    char assoc_data[9] = "ABCheader";
-    char token_data[16] = "0123456789abcdef";
+    char assoc_data[9] = { 'A', 'B', 'C', 'h', 'e', 'a', 'd', 'e', 'r' };
+    char token_data[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
+                            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
     if (flags & USE_SIGN_ONLY) {
 	assoc.value = assoc_data;

--- a/lib/hx509/ca.c
+++ b/lib/hx509/ca.c
@@ -1204,10 +1204,8 @@ hx509_ca_tbs_add_san_permanentIdentifier_string(hx509_context context,
         free(freeme);
         return EINVAL;
     }
-    if (p) {
-        *(p++) = '\0';
-        id = p;
-    }
+    *(p++) = '\0';
+    id = p;
     if (oidstr[0] != '\0') {
         ret = der_find_heim_oid_by_name(oidstr, &found);
         if (ret) {


### PR DESCRIPTION
Our macosx image was upgraded and uses a new version of clang which cause our CI to fail.  Here are three small changes which allow the build to proceed.