### PR TITLE
lib/krb5: preserve Heimdal error-table ABI

### DIFF
--- a/lib/base/Makefile.am
+++ b/lib/base/Makefile.am
@@ -31,6 +31,8 @@ libheimbase_la_LDFLAGS += $(LDFLAGS_VERSION_SCRIPT)$(srcdir)/version-script.map
 endif
 
 libheimbase_la_LIBADD = $(PTHREAD_LIBADD) $(LIB_dlopen) $(LIB_com_err)
+libheimbase_la_CPPFLAGS = $(AM_CPPFLAGS) \
+	-Dinitialize_heim_error_table_r=_heim_initialize_heim_error_table_r
 
 include_HEADERS	= heimbase.h common_plugin.h heimbase-atomics.h heimbase-svc.h
 

--- a/lib/base/NTMakefile
+++ b/lib/base/NTMakefile
@@ -112,6 +112,12 @@ $(OBJ)\heim_err.c $(OBJ)\heim_err.h: heim_err.et
 	$(BINDIR)\compile_et.exe $(SRCDIR)\heim_err.et
 	cd $(SRCDIR)
 
+$(OBJ)\heim_err.obj: $(OBJ)\heim_err.c
+	$(C2OBJ_C) /Fd$(OBJ)\ /Fo$(OBJ)\ $(extcflags) $(MPOPT) \
+	    /Dinitialize_heim_error_table_r=_heim_initialize_heim_error_table_r @<<
+$**
+<<
+
 test:: test-binaries test-run
 
 test-run:

--- a/lib/base/context.c
+++ b/lib/base/context.c
@@ -35,6 +35,15 @@
 
 #undef __attribute__
 #define __attribute__(X)
+#undef initialize_heim_error_table_r
+
+void initialize_heim_error_table_r(struct et_list **);
+
+void
+initialize_heim_error_table_r(struct et_list **list)
+{
+    _heim_initialize_heim_error_table_r(list);
+}
 
 heim_context
 heim_context_init(void)

--- a/lib/base/heimbasepriv.h
+++ b/lib/base/heimbasepriv.h
@@ -85,6 +85,11 @@ _heim_make_permanent(heim_object_t ptr);
 heim_data_t
 _heim_db_get_value(heim_db_t, heim_string_t, heim_data_t, heim_error_t *);
 
+struct et_list;
+
+void
+_heim_initialize_heim_error_table_r(struct et_list **);
+
 
 /* tagged tid */
 extern struct heim_type_data _heim_null_object;

--- a/lib/base/version-script.map
+++ b/lib/base/version-script.map
@@ -139,6 +139,7 @@ HEIMDAL_BASE_1.0 {
 		heim_get_hash;
 		_heim_get_isa;
 		_heim_get_isaextra;
+		_heim_initialize_heim_error_table_r;
 		heim_get_log_dest;
 		heim_get_tid;
 		heim_get_warn_dest;

--- a/lib/krb5/Makefile.am
+++ b/lib/krb5/Makefile.am
@@ -264,8 +264,10 @@ dist_libkrb5_la_SOURCES =			\
 	warn.c					\
 	write_message.c
 
-nodist_libkrb5_la_SOURCES =			\
-	$(ERR_FILES)
+nodist_libkrb5_la_SOURCES = $(ERR_FILES)
+if ENABLE_SHARED
+nodist_libkrb5_la_SOURCES += obsolete-symbols.c
+endif
 
 libkrb5_la_DEPENDENCIES =			\
 	version-script.map
@@ -431,6 +433,7 @@ test_config_strings.out: test_config_strings.cfg
 
 EXTRA_DIST = \
 	NTMakefile \
+	obsolete-symbols.c \
 	dll.c \
 	libkrb5-exports.def.in \
 	verify_krb5_conf-version.rc \

--- a/lib/krb5/context.c
+++ b/lib/krb5/context.c
@@ -39,6 +39,7 @@
 #include "krb5_locl.h"
 #include <assert.h>
 #include <com_err.h>
+#include <heimbasepriv.h>
 
 static void _krb5_init_ets(krb5_context);
 
@@ -1271,7 +1272,8 @@ _krb5_init_ets(krb5_context context)
 {
     heim_add_et_list(context->hcontext, initialize_krb5_error_table_r);
     heim_add_et_list(context->hcontext, initialize_asn1_error_table_r);
-    heim_add_et_list(context->hcontext, initialize_heim_error_table_r);
+    heim_add_et_list(context->hcontext,
+		     _heim_initialize_heim_error_table_r);
 
     heim_add_et_list(context->hcontext, initialize_k524_error_table_r);
     heim_add_et_list(context->hcontext, initialize_k5e1_error_table_r);

--- a/lib/krb5/obsolete-symbols.c
+++ b/lib/krb5/obsolete-symbols.c
@@ -1,0 +1,21 @@
+#include "krb5_locl.h"
+#include <heimbasepriv.h>
+
+#if defined(PIC) && !defined(_WIN32)
+KRB5_LIB_FUNCTION void
+initialize_heim_error_table(void);
+KRB5_LIB_FUNCTION void
+initialize_heim_error_table_r(struct et_list **);
+
+KRB5_LIB_FUNCTION void
+initialize_heim_error_table(void)
+{
+    _heim_initialize_heim_error_table_r(&_et_list);
+}
+
+KRB5_LIB_FUNCTION void
+initialize_heim_error_table_r(struct et_list **list)
+{
+    _heim_initialize_heim_error_table_r(list);
+}
+#endif


### PR DESCRIPTION
Just a few symbols to pack in so that we don't have to bump the major. This and 3 more commits.