### PR TITLE
Udp tcp fallback

### DIFF
--- a/lib/krb5/Makefile.am
+++ b/lib/krb5/Makefile.am
@@ -27,6 +27,7 @@ noinst_LTLIBRARIES =				\
 TESTS =						\
 	aes-test				\
 	derived-key-test			\
+	krbhst-test				\
 	n-fold-test				\
 	parse-name-test				\
 	pseudo-random-test			\

--- a/lib/krb5/krbhst-test.c
+++ b/lib/krb5/krbhst-test.c
@@ -86,6 +86,28 @@ main(int argc, char **argv)
     ret = krb5_init_context(&context);
     if (ret)
         krb5_err(NULL, 1, ret, "Failed to initialize context");
+    if (argc == 0) {
+	static const int protos[] = { KRB5_KRBHST_UDP, KRB5_KRBHST_TCP };
+	krb5_krbhst_handle handle;
+	krb5_krbhst_info *host;
+
+	ret = krb5_set_config(context,
+	    "[realms]\n"
+	    " TEST = {\n"
+	    "  kdc = kdc.example:1234\n"
+	    " }\n");
+	if (ret)
+	    krb5_err(context, 1, ret, "Could not set test configuration");
+	ret = krb5_krbhst_init(context, "TEST", KRB5_KRBHST_KDC, &handle);
+	if (ret)
+	    krb5_err(context, 1, ret, "Could not init krbhst iterator");
+	for (i = 0; i < sizeof(protos) / sizeof(*protos); i++) {
+	    ret = krb5_krbhst_next(context, handle, &host);
+	    if (ret || host->proto != protos[i])
+		errx(1, "Wrong protocol for host %d", i);
+	}
+	return 0;
+    }
     for(i = 0; i < argc; i++) {
 	krb5_krbhst_handle handle;
 	char host[MAXHOSTNAMELEN];

--- a/lib/krb5/krbhst.c
+++ b/lib/krb5/krbhst.c
@@ -373,6 +373,23 @@ append_host_string(krb5_context context, struct krb5_krbhst_data *kd,
 	return krb5_enomem(context);
 
     append_host_hostinfo(kd, hi);
+
+    /*
+     * If we are a bare host, and are using UDP, add TCP as well so that
+     * we still try TCP in the absence of KRB_ERR_RESPONSE_TOO_BIG.
+     */
+
+    if (strchr(host, '/') != NULL)
+        return 0;
+
+    if (krbhst_get_default_proto(context, kd) != KRB5_KRBHST_UDP)
+        return 0;
+
+    hi = parse_hostspec(context, kd, host, def_port, port);
+    if (hi == NULL)
+        return krb5_enomem(context);
+    hi->proto = KRB5_KRBHST_TCP;
+    append_host_hostinfo(kd, hi);
     return 0;
 }
 

--- a/tests/kdc/Makefile.am
+++ b/tests/kdc/Makefile.am
@@ -24,6 +24,8 @@ noinst_DATA = \
 
 check_SCRIPTS = $(SCRIPT_TESTS) 
 
+check_PROGRAMS = timed-exec udp-sink
+
 SCRIPT_TESTS = \
 	check-authz \
 	check-canon \
@@ -123,7 +125,7 @@ check-fast: check-fast.in Makefile
 	$(chmod) +x check-fast.tmp && \
 	mv check-fast.tmp check-fast
 
-check-kdc: check-kdc.in Makefile
+check-kdc: check-kdc.in Makefile timed-exec udp-sink
 	$(do_subst) < $(srcdir)/check-kdc.in > check-kdc.tmp && \
 	$(chmod) +x check-kdc.tmp && \
 	mv check-kdc.tmp check-kdc

--- a/tests/kdc/check-kdc.in
+++ b/tests/kdc/check-kdc.in
@@ -77,8 +77,11 @@ pwport=@pwport@
 
 kadmin5="${kadmin} -l -r $R5"
 kadmin="${kadmin} -l -A -r $R"
+tcpkdc="${kdc} --addresses=127.0.0.1 -P $port/tcp"
 kdc="${kdc} --addresses=localhost -P $port"
 kpasswdd="${kpasswdd} --addresses=localhost -p $pwport"
+udp_sink="${objdir}/udp-sink"
+timed_exec="${objdir}/timed-exec"
 
 server=host/datan.test.h5l.se
 server2=host/computer.example.com
@@ -313,6 +316,47 @@ fi
 
 echo foo > ${objdir}/foopassword
 echo notfoo > ${objdir}/notfoopassword
+
+sed "s/kdc = localhost:$port/kdc = 127.0.0.1:$port/" \
+    ${KRB5_CONFIG} > ${objdir}/krb5-udp-tcp.conf
+
+fallback_cleanup() {
+    test -z "${udppid}" || kill ${udppid} 2>/dev/null
+    test -z "${kdcpid}" || kill -9 ${kdcpid} 2>/dev/null
+    trap '' EXIT INT TERM
+    exit 1
+}
+trap fallback_cleanup EXIT INT TERM
+
+echo "Testing quick TCP fallback after UDP port unreachable"; > messages.log
+${tcpkdc} --no-require-preauth --detach --testing ||
+    { echo "kdc failed to start"; cat messages.log; exit 1; }
+kdcpid=`getpid kdc`
+udppid=
+
+KRB5_CONFIG=${objdir}/krb5-udp-tcp.conf \
+    ${timed_exec} 250 ${kinit} \
+    --pk-anon-fast-armor=no \
+    --password-file=${objdir}/foopassword foo@${R} || exit 1
+${klist} > /dev/null || exit 1
+${kdestroy}
+
+echo "Testing TCP fallback after a lost UDP request"
+${udp_sink} $port &
+udppid=$!
+sleep 1
+kill -0 ${udppid} 2>/dev/null || exit 1
+KRB5_CONFIG=${objdir}/krb5-udp-tcp.conf \
+    ${kinit} --pk-anon-fast-armor=no \
+    --password-file=${objdir}/foopassword foo@${R} || exit 1
+${klist} > /dev/null || exit 1
+${kdestroy}
+wait ${udppid} || exit 1
+udppid=
+
+sh ${leaks_kill} kdc ${kdcpid} || exit 1
+kdcpid=
+trap '' EXIT INT TERM
 
 echo Starting kdc ; > messages.log
 env MallocStackLogging=1 MallocStackLoggingNoCompact=1 MallocErrorAbort=1 MallocLogFile=${objdir}/malloc-log \

--- a/tests/kdc/timed-exec.c
+++ b/tests/kdc/timed-exec.c
@@ -1,0 +1,33 @@
+#include <config.h>
+
+#include <roken.h>
+
+int
+main(int argc, char **argv)
+{
+    struct timeval start, stop;
+    char *end;
+    long elapsed, limit;
+    int ret;
+
+    if (argc < 3)
+	errx(1, "usage: timed-exec milliseconds command [argument ...]");
+
+    limit = strtol(argv[1], &end, 10);
+    if (*argv[1] == '\0' || *end != '\0' || limit < 1)
+	errx(1, "invalid time limit: %s", argv[1]);
+
+    gettimeofday(&start, NULL);
+    ret = simple_execvp(argv[2], &argv[2]);
+    gettimeofday(&stop, NULL);
+    if (ret)
+	return ret;
+
+    timevalsub(&stop, &start);
+    elapsed = stop.tv_sec * 1000 + stop.tv_usec / 1000;
+    if (elapsed >= limit)
+	errx(1, "command took %ldms; expected less than %ldms",
+	     elapsed, limit);
+
+    return 0;
+}

--- a/tests/kdc/udp-sink.c
+++ b/tests/kdc/udp-sink.c
@@ -1,0 +1,36 @@
+#include <config.h>
+
+#include <roken.h>
+
+int
+main(int argc, char **argv)
+{
+    struct sockaddr_in addr;
+    char packet[1];
+    char *end;
+    long port;
+    rk_socket_t s;
+
+    if (argc != 2)
+	errx(1, "usage: udp-sink port");
+
+    port = strtol(argv[1], &end, 10);
+    if (*argv[1] == '\0' || *end != '\0' || port < 1 || port > 65535)
+	errx(1, "invalid port: %s", argv[1]);
+
+    s = socket(AF_INET, SOCK_DGRAM, 0);
+    if (rk_IS_BAD_SOCKET(s))
+	err(1, "socket");
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+    if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) == -1)
+	err(1, "bind");
+
+    if (recv(s, packet, sizeof(packet), 0) == -1)
+	err(1, "recv");
+
+    return 0;
+}


### PR DESCRIPTION
We don't fall back from UDP to TCP unless the KDC tells us to. This only hits us if we have unadorned KDC entries in `/etc/krb5.conf`, so in this case we add tcp/hostname if we are doing UDP and hostname doesn't have a slash in it.
We also recreate the situation in some tests.