### PR TITLE
krb5: interoperate with signed KDC nonces

### DIFF
--- a/lib/asn1/krb5.asn1
+++ b/lib/asn1/krb5.asn1
@@ -572,7 +572,7 @@ KDC-REQ-BODY ::= SEQUENCE {
 	from[4]			KerberosTime OPTIONAL,
 	till[5]			KerberosTime OPTIONAL,
 	rtime[6]		KerberosTime OPTIONAL,
-	nonce[7]		Krb5UInt32,
+	nonce[7]		Krb5Int32,
 	etype[8]		SEQUENCE OF ENCTYPE, -- EncryptionType,
 					-- in preference order
 	addresses[9]		HostAddresses OPTIONAL,
@@ -651,7 +651,7 @@ TGS-REP ::= [APPLICATION 13] KDC-REP
 EncKDCRepPart ::= SEQUENCE {
 	key[0]			EncryptionKey,
 	last-req[1]		LastReq,
-	nonce[2]		Krb5UInt32,
+	nonce[2]		Krb5Int32,
 	key-expiration[3]	KerberosTime OPTIONAL,
 	flags[4]		TicketFlags,
 	authtime[5]		KerberosTime,
@@ -741,7 +741,7 @@ KrbCredInfo ::= SEQUENCE {
 
 EncKrbCredPart ::= [APPLICATION 29]   SEQUENCE {
 	ticket-info[0]		SEQUENCE OF KrbCredInfo,
-	nonce[1]		Krb5UInt32 OPTIONAL,
+	nonce[1]		Krb5Int32 OPTIONAL,
 	timestamp[2]		KerberosTime OPTIONAL,
 	usec[3]			Krb5Int32 OPTIONAL,
 	s-address[4]		HostAddress OPTIONAL,
@@ -826,8 +826,8 @@ PA-SAM-CHALLENGE-2-BODY ::= SEQUENCE {
 	sam-challenge[5]	GeneralString OPTIONAL,
 	sam-response-prompt[6]	GeneralString OPTIONAL,
 	sam-pk-for-sad[7]	EncryptionKey OPTIONAL,
-	sam-nonce[8]		Krb5UInt32,
-	sam-etype[9]		Krb5UInt32,
+	sam-nonce[8]		Krb5Int32,
+	sam-etype[9]		Krb5Int32,
 	...
 }
 
@@ -842,12 +842,12 @@ PA-SAM-RESPONSE-2 ::= SEQUENCE {
 	sam-flags[1]		SAMFlags,
 	sam-track-id[2]		GeneralString OPTIONAL,
 	sam-enc-nonce-or-sad[3]	EncryptedData, -- PA-ENC-SAM-RESPONSE-ENC
-	sam-nonce[4]		Krb5UInt32,
+	sam-nonce[4]		Krb5Int32,
 	...
 }
 
 PA-ENC-SAM-RESPONSE-ENC ::= SEQUENCE {
-	sam-nonce[0]		Krb5UInt32,
+	sam-nonce[0]		Krb5Int32,
 	sam-sad[1]		GeneralString OPTIONAL,
 	...
 }

--- a/lib/krb5/Makefile.am
+++ b/lib/krb5/Makefile.am
@@ -41,6 +41,7 @@ TESTS =						\
 	test_prf				\
 	test_store				\
 	test_crypto_wrapping			\
+	test_kdc_nonce				\
 	test_keytab				\
 	test_mem				\
 	test_pac				\

--- a/lib/krb5/get_cred.c
+++ b/lib/krb5/get_cred.c
@@ -581,7 +581,9 @@ get_cred_kdc(krb5_context context,
     padata.len = 0;
 
     krb5_generate_random_block(&nonce, sizeof(nonce));
-    nonce &= 0xffffffff;
+    /* We and MIT incorrectly encode nonces as signed, so make sure we use
+     * a non-negative value to avoid interoperability issues. */
+    nonce &= 0x7fffffff;
 
     if(flags.b.enc_tkt_in_skey && second_ticket == NULL){
 	ret = decode_Ticket(in_creds->second_ticket.data,

--- a/lib/krb5/get_in_tkt.c
+++ b/lib/krb5/get_in_tkt.c
@@ -577,7 +577,9 @@ krb5_get_in_cred(krb5_context context,
     opts = int2KDCOptions(options);
 
     krb5_generate_random_block (&nonce, sizeof(nonce));
-    nonce &= 0xffffffff;
+    /* We and MIT incorrectly encode nonces as signed, so make sure we use
+     * a non-negative value to avoid interoperability issues. */
+    nonce &= 0x7fffffff;
 
     do {
 	done = 1;

--- a/lib/krb5/init_creds_pw.c
+++ b/lib/krb5/init_creds_pw.c
@@ -2743,6 +2743,8 @@ krb5_init_creds_init(krb5_context context,
     /* Set a new nonce. */
     /* FIXME should generate a new nonce for each AS-REQ */
     krb5_generate_random_block (&ctx->nonce, sizeof(ctx->nonce));
+    /* We and MIT incorrectly encode nonces as signed, so make sure we use
+     * a non-negative value to avoid interoperability issues. */
     ctx->nonce &= 0x7fffffff;
     /* XXX these just need to be the same when using Windows PK-INIT */
     ctx->pk_nonce = ctx->nonce;

--- a/lib/krb5/test_kdc_nonce.c
+++ b/lib/krb5/test_kdc_nonce.c
@@ -1,0 +1,39 @@
+#include "krb5_locl.h"
+#include <err.h>
+
+static const unsigned char request[] = {
+    0x30, 0x1a,
+      0xa0, 0x07, 0x03, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0xa2, 0x03, 0x1b, 0x01, 0x58,
+      0xa7, 0x03, 0x02, 0x01, 0xff,
+      0xa8, 0x05, 0x30, 0x03, 0x02, 0x01, 0x12
+};
+
+int
+main(void)
+{
+    unsigned char *encoded = NULL;
+    KDC_REQ_BODY body;
+    size_t encoded_len, size;
+    int ret;
+
+    memset(&body, 0, sizeof(body));
+    ret = decode_KDC_REQ_BODY(request, sizeof(request), &body, &size);
+    if (ret)
+        errx(1, "decode_KDC_REQ_BODY: %d", ret);
+    if (size != sizeof(request) ||
+        (uint32_t)body.nonce != UINT32_MAX)
+        errx(1, "decoded nonce mismatch");
+
+    ASN1_MALLOC_ENCODE(KDC_REQ_BODY, encoded, encoded_len,
+                       &body, &size, ret);
+    if (ret)
+        errx(1, "encode_KDC_REQ_BODY: %d", ret);
+    if (size != encoded_len || encoded_len != sizeof(request) ||
+        memcmp(encoded, request, sizeof(request)) != 0)
+        errx(1, "request did not round trip");
+
+    free(encoded);
+    free_KDC_REQ_BODY(&body);
+    return 0;
+}


### PR DESCRIPTION
MIT and older Apple implementations encode Kerberos nonces as signed integers.  Restore the signed ASN.1 nonce types and constrain generated KDC nonces to the non-negative signed range.